### PR TITLE
feat(skills): add skill organization infrastructure

### DIFF
--- a/.ai/plans/skill-organization-strategy.md
+++ b/.ai/plans/skill-organization-strategy.md
@@ -1,0 +1,386 @@
+# Skill Organization Strategy
+
+**Created:** 2025-12-25
+**Status:** Draft
+**Purpose:** Define naming conventions, taxonomy, and merge strategy for external skills
+
+---
+
+## Naming Convention
+
+### Pattern
+```
+<category>-[<subcategory>-]<tool>-<focus>
+```
+
+### Examples
+| Full Name | Category | Subcategory | Tool | Focus |
+|-----------|----------|-------------|------|-------|
+| `cicd-github-actions-dev` | cicd | - | github-actions | dev |
+| `cicd-github-actions-ops` | cicd | - | github-actions | ops |
+| `data-ingest-weaviate-ops` | data | ingest | weaviate | ops |
+| `cloud-aws-terraform-eng` | cloud | aws | terraform | eng |
+| `lang-rust-cargo-dev` | lang | rust | cargo | dev |
+| `llm-rag-langchain-dev` | llm | rag | langchain | dev |
+| `observability-metrics-prometheus-ops` | observability | metrics | prometheus | ops |
+
+---
+
+## Focus Taxonomy
+
+| Focus | Code | Description | Target Audience |
+|-------|------|-------------|-----------------|
+| Operations | `ops` | Day-to-day operations, troubleshooting, maintenance | SRE, Platform Engineers, Admins |
+| Development | `dev` | Building, coding, implementing features | Developers, Contributors |
+| Engineering | `eng` | Architecture, design patterns, optimization | Senior Engineers, Architects |
+| Newcomer | `nub` | Learning-focused, tutorials, onboarding | New users, Beginners |
+| Executive | `xec` | Strategy, cost analysis, high-level overview | Managers, CTOs, Decision-makers |
+
+### Focus Overlap Rules
+- A skill can only have ONE focus
+- If content serves multiple focuses, split into separate skills
+- Reference files can be shared across focus variants
+
+---
+
+## Category Taxonomy
+
+### Primary Categories (16)
+
+| Category | Code | Description | Subcategories |
+|----------|------|-------------|---------------|
+| AI/ML | `ai` | Machine learning, models, training | train, infer, eval, finetune |
+| Backend | `backend` | Server-side development | api, graphql, grpc, websocket |
+| CI/CD | `cicd` | Continuous integration/deployment | github, gitlab, jenkins, argocd |
+| Cloud | `cloud` | Cloud infrastructure | aws, gcp, azure, cloudflare |
+| Data | `data` | Data engineering & processing | ingest, transform, quality, stream |
+| Database | `db` | Database operations | postgres, mongodb, redis, vector |
+| Frontend | `frontend` | Client-side development | react, vue, svelte, css |
+| Kubernetes | `k8s` | Container orchestration | helm, gitops, security, networking |
+| Language | `lang` | Language-specific patterns | rust, python, go, typescript, elixir |
+| LLM | `llm` | LLM applications | rag, prompts, agents, eval |
+| Meta | `meta` | Skill/agent development | skills, plugins, mcp, hooks |
+| Methodology | `method` | Development methodologies | debugging, tdd, planning, review |
+| Observability | `observability` | Monitoring & logging | metrics, tracing, logging, alerts |
+| Scientific | `sci` | Scientific computing | stats, bio, quantum, viz |
+| Security | `security` | Security practices | scan, pentest, compliance, secrets |
+| Workflow | `workflow` | Automation tools | n8n, temporal, airflow, make |
+
+### Subcategory Examples
+
+```yaml
+ai:
+  - train      # Training models
+  - infer      # Inference/serving
+  - eval       # Evaluation & benchmarks
+  - finetune   # Fine-tuning
+  - safety     # AI safety & alignment
+
+cicd:
+  - github     # GitHub Actions
+  - gitlab     # GitLab CI
+  - jenkins    # Jenkins
+  - argocd     # ArgoCD
+  - tekton     # Tekton
+
+cloud:
+  - aws        # Amazon Web Services
+  - gcp        # Google Cloud Platform
+  - azure      # Microsoft Azure
+  - cloudflare # Cloudflare
+  - terraform  # Multi-cloud IaC
+
+data:
+  - ingest     # Data ingestion
+  - transform  # Transformations (dbt, spark)
+  - quality    # Data quality
+  - stream     # Streaming (kafka, flink)
+  - lake       # Data lakehouse
+
+db:
+  - postgres   # PostgreSQL
+  - mongodb    # MongoDB
+  - redis      # Redis
+  - vector     # Vector databases
+  - graph      # Graph databases
+
+k8s:
+  - helm       # Helm charts
+  - gitops     # GitOps (flux, argocd)
+  - security   # Pod security, policies
+  - networking # Service mesh, ingress
+  - operators  # Operator development
+
+lang:
+  - rust       # Rust
+  - python     # Python
+  - go         # Go
+  - typescript # TypeScript
+  - elixir     # Elixir
+  - lean       # Lean4
+
+llm:
+  - rag        # Retrieval-augmented generation
+  - prompts    # Prompt engineering
+  - agents     # Agent development
+  - eval       # LLM evaluation
+  - embeddings # Embeddings & vectors
+
+observability:
+  - metrics    # Prometheus, metrics
+  - tracing    # Distributed tracing
+  - logging    # Log aggregation
+  - alerts     # Alerting rules
+
+security:
+  - scan       # SAST, DAST scanning
+  - pentest    # Penetration testing
+  - compliance # GDPR, SOC2, ISO
+  - secrets    # Secrets management
+  - forensics  # Digital forensics
+```
+
+---
+
+## Skill Structure Standard
+
+### Directory Layout
+```
+<skill-name>/
+├── SKILL.md              # Required: Main skill file
+└── references/           # Optional: Reference materials
+    ├── <topic>.md        # Topic-specific references
+    └── <subtopic>/       # Nested for complex domains
+        └── *.md
+```
+
+### SKILL.md Template
+```markdown
+---
+name: <category>-[<subcategory>-]<tool>-<focus>
+description: <Clear description of what this skill does and when to use it>
+created: YYYY-MM-DDTHH:MM
+updated: YYYY-MM-DDTHH:MM
+tags: [<category>, <subcategory>, <tool>, <focus>]
+source: <original-repo> # If imported/merged
+---
+
+# <Title>
+
+<One-line description>
+
+## Overview
+
+<What this skill covers and does NOT cover>
+
+**This skill covers:**
+- ...
+
+**This skill does NOT cover:**
+- ...
+
+## Quick Reference
+
+<Tables, diagrams for fast lookup>
+
+## Workflow: <Primary Use Case>
+
+### Step 1: ...
+### Step 2: ...
+...
+
+## Common Patterns
+
+<Code examples for frequent tasks>
+
+## Troubleshooting
+
+<Common issues and solutions>
+
+## See Also
+
+- [references/<topic>.md](references/<topic>.md) - <description>
+- `<related-skill>` skill - <relationship>
+```
+
+---
+
+## Skill Analysis & Selection Criteria
+
+### Evaluation Matrix
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Uniqueness | 30% | Does it fill a gap? Avoid duplicates |
+| Quality | 25% | Well-structured, accurate, comprehensive |
+| Maintainability | 20% | Active source? Clear ownership? |
+| Focus Fit | 15% | Matches a defined focus level |
+| Token Efficiency | 10% | Concise, uses references effectively |
+
+### Selection Decision Tree
+
+```
+1. Does skill fill an identified gap?
+   └─ NO → Skip (unless significantly higher quality than existing)
+   └─ YES → Continue
+
+2. Is there overlap with existing skill?
+   └─ YES → Evaluate merge vs replace
+      ├─ If external is clearly better → Replace
+      ├─ If internal is better → Skip external
+      └─ If complementary → Merge (combine best parts)
+   └─ NO → Continue
+
+3. Does skill fit naming convention?
+   └─ NO → Rename to convention before import
+   └─ YES → Continue
+
+4. Is skill well-structured?
+   └─ NO → Restructure during import
+   └─ YES → Import as-is (with naming adjustment)
+```
+
+---
+
+## Merge Strategy
+
+### Merge Types
+
+| Type | When | Process |
+|------|------|---------|
+| **Direct Import** | No overlap, fits convention | Rename, import, version track |
+| **Replace** | External significantly better | Archive old, import new |
+| **Enhance** | External has valuable additions | Add new sections/references |
+| **Combine** | Multiple sources cover different aspects | Create new unified skill |
+| **Split** | External covers multiple focuses | Create focus-specific variants |
+
+### Merge Process
+
+1. **Identify candidates** from external manifest
+2. **Map to naming convention** (category, subcategory, tool, focus)
+3. **Check for overlaps** with existing skills
+4. **Evaluate quality** using criteria matrix
+5. **Determine merge type** based on overlap and quality
+6. **Execute merge** with version tracking
+7. **Update manifest** with source attribution
+
+---
+
+## Priority Import List
+
+Based on gap analysis and quality assessment:
+
+### Tier 1: Critical (Import immediately)
+
+| External Skill | Target Name | Source | Reason |
+|----------------|-------------|--------|--------|
+| mcp-builder | meta-mcp-builder-dev | anthropics/skills | MCP development |
+| systematic-debugging | method-debugging-systematic-eng | obra/superpowers | Unique methodology |
+| rag-implementation | llm-rag-patterns-dev | wshobson/agents | LLM patterns |
+| terraform-module-library | cloud-terraform-modules-eng | wshobson/agents | IaC patterns |
+| prometheus-configuration | observability-metrics-prometheus-ops | wshobson/agents | Monitoring |
+| context-fundamentals | meta-context-engineering-dev | muratcankoylan | Meta-skill |
+
+### Tier 2: High Priority
+
+| External Skill | Target Name | Source | Reason |
+|----------------|-------------|--------|--------|
+| helm-chart-scaffolding | k8s-helm-charts-dev | wshobson/agents | K8s deployment |
+| polars | data-analysis-polars-dev | K-Dense-AI | Modern dataframes |
+| handling-rust-errors | lang-rust-errors-dev | hashintel/hash | Rust patterns |
+| playwright-skill | frontend-testing-playwright-dev | lackeyjb | E2E testing |
+| elixir-architect | lang-elixir-patterns-eng | maxim-ist | Fills language gap |
+
+### Tier 3: As Needed
+
+| Category | Skills to Import |
+|----------|------------------|
+| Scientific | qiskit, pymc, literature-review |
+| AI Research | mechanistic-interpretability, safety-alignment |
+| Lean4 | lean4-theorem-proving |
+| Security | ffuf-web-fuzzing, sigma-threat-hunting |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Foundation
+1. Create skill template in `components/skills/.templates/`
+2. Add justfile recipe: `create-skill <name>`
+3. Add validation script for naming/structure
+
+### Phase 2: Priority Imports
+1. Import Tier 1 skills (6 skills)
+2. Rename to convention
+3. Restructure if needed
+4. Track versions in `.versions/`
+
+### Phase 3: Bulk Processing
+1. Create import automation for categories
+2. Process Tier 2 skills
+3. Create merged skills where needed
+
+### Phase 4: Maintenance
+1. Weekly check for updates (`just check-external-updates`)
+2. Monthly quality review
+3. Prune unused skills
+
+---
+
+## Justfile Recipes (Proposed)
+
+```just
+# Create new skill from template
+[group('skills')]
+create-skill name:
+    @scripts/create-skill.py "{{ name }}"
+
+# Validate skill naming and structure
+[group('skills')]
+validate-skill path:
+    @scripts/validate-skill.py "{{ path }}"
+
+# Bulk rename skills to convention
+[group('skills')]
+normalize-skill-names:
+    @scripts/normalize-skills.py
+
+# Import and restructure external skill
+[group('skills')]
+import-and-normalize repo skill target:
+    just import-skill "{{ repo }}" "{{ skill }}" "{{ target }}"
+    just validate-skill "components/skills/{{ target }}"
+```
+
+---
+
+## Appendix: Full Category Mapping from External Manifest
+
+| External Category | Maps To | Subcategory |
+|-------------------|---------|-------------|
+| anthropic-official | meta | skills |
+| claude-code-plugin-dev | meta | plugins |
+| methodology | method | - |
+| context-engineering | meta | context |
+| scientific | sci | - |
+| backend-patterns | backend | - |
+| data-engineering | data | - |
+| cloud-infrastructure | cloud | - |
+| kubernetes | k8s | - |
+| cicd | cicd | - |
+| llm-development | llm | - |
+| observability | observability | - |
+| security | security | - |
+| python | lang | python |
+| javascript-typescript | lang | typescript |
+| rust | lang | rust |
+| n8n | workflow | n8n |
+| causal-analysis | sci | causal |
+| crash-analysis | security | forensics |
+| development-roles | meta | personas |
+| business-marketing | meta | business |
+| compliance | security | compliance |
+| creative-design | frontend | design |
+| ai-research | ai | research |
+| elixir | lang | elixir |
+| lean4 | lang | lean |

--- a/components/skills/.templates/README.md
+++ b/components/skills/.templates/README.md
@@ -1,0 +1,82 @@
+# Skill Templates
+
+Templates for creating new Claude Code skills following the naming convention and structure standards.
+
+## Naming Convention
+
+```
+<category>-[<subcategory>-]<tool>-<focus>
+```
+
+### Focus Codes
+
+| Focus | Code | Description | Audience |
+|-------|------|-------------|----------|
+| Operations | `ops` | Day-to-day operations, troubleshooting | SRE, Platform Engineers |
+| Development | `dev` | Building, coding, implementing | Developers |
+| Engineering | `eng` | Architecture, design patterns | Senior Engineers, Architects |
+| Newcomer | `nub` | Learning-focused, onboarding | Beginners |
+| Executive | `xec` | Strategy, high-level overview | Managers, CTOs |
+
+### Categories
+
+| Code | Category | Subcategories |
+|------|----------|---------------|
+| `ai` | AI/ML | train, infer, eval, finetune |
+| `backend` | Backend | api, graphql, grpc, websocket |
+| `cicd` | CI/CD | github, gitlab, jenkins, argocd |
+| `cloud` | Cloud | aws, gcp, azure, cloudflare |
+| `data` | Data | ingest, transform, quality, stream |
+| `db` | Database | postgres, mongodb, redis, vector |
+| `frontend` | Frontend | react, vue, svelte, css |
+| `k8s` | Kubernetes | helm, gitops, security, networking |
+| `lang` | Language | rust, python, go, typescript |
+| `llm` | LLM | rag, prompts, agents, eval |
+| `meta` | Meta | skills, plugins, mcp, hooks |
+| `method` | Methodology | debugging, tdd, planning, review |
+| `observability` | Observability | metrics, tracing, logging, alerts |
+| `sci` | Scientific | stats, bio, quantum, viz |
+| `security` | Security | scan, pentest, compliance, secrets |
+| `workflow` | Workflow | n8n, temporal, airflow, make |
+
+## Usage
+
+```bash
+# Create new skill from template
+just create-skill <category>-<tool>-<focus>
+
+# Examples
+just create-skill lang-rust-cargo-dev
+just create-skill cloud-aws-terraform-eng
+just create-skill observability-metrics-prometheus-ops
+```
+
+## Template Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{SKILL_NAME}}` | Full skill name | `lang-rust-cargo-dev` |
+| `{{CATEGORY}}` | Primary category | `lang` |
+| `{{SUBCATEGORY}}` | Optional subcategory | `rust` |
+| `{{TOOL}}` | Tool/technology | `cargo` |
+| `{{FOCUS}}` | Focus level | `dev` |
+| `{{TITLE}}` | Human-readable title | `Rust Cargo Development` |
+| `{{SOURCE_REPO}}` | If imported, source repo | `hashintel/hash` |
+
+## Directory Structure
+
+```
+<skill-name>/
+├── SKILL.md              # Required: Main skill file
+└── references/           # Optional: Reference materials
+    ├── <topic>.md        # Topic-specific references
+    └── <subtopic>/       # Nested for complex domains
+        └── *.md
+```
+
+## Validation
+
+```bash
+# Validate skill structure and naming
+just validate-skill components/skills/<skill-name>
+```

--- a/components/skills/.templates/SKILL.md
+++ b/components/skills/.templates/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: {{SKILL_NAME}}
+description: {{DESCRIPTION}}
+created: {{CREATED_DATE}}
+updated: {{UPDATED_DATE}}
+tags: [{{CATEGORY}}, {{SUBCATEGORY}}, {{TOOL}}, {{FOCUS}}]
+source: {{SOURCE_REPO}}
+---
+
+# {{TITLE}}
+
+{{ONE_LINE_DESCRIPTION}}
+
+## Overview
+
+{{OVERVIEW_TEXT}}
+
+**This skill covers:**
+- {{COVERAGE_ITEM_1}}
+- {{COVERAGE_ITEM_2}}
+- {{COVERAGE_ITEM_3}}
+
+**This skill does NOT cover:**
+- {{EXCLUSION_ITEM_1}}
+- {{EXCLUSION_ITEM_2}}
+
+## Quick Reference
+
+### Key Commands
+
+| Command | Description |
+|---------|-------------|
+| `{{CMD_1}}` | {{CMD_1_DESC}} |
+| `{{CMD_2}}` | {{CMD_2_DESC}} |
+
+### Common Patterns
+
+| Pattern | When to Use |
+|---------|-------------|
+| {{PATTERN_1}} | {{PATTERN_1_USE}} |
+| {{PATTERN_2}} | {{PATTERN_2_USE}} |
+
+## Workflow: {{PRIMARY_WORKFLOW}}
+
+### Step 1: {{STEP_1_TITLE}}
+
+{{STEP_1_CONTENT}}
+
+### Step 2: {{STEP_2_TITLE}}
+
+{{STEP_2_CONTENT}}
+
+### Step 3: {{STEP_3_TITLE}}
+
+{{STEP_3_CONTENT}}
+
+## Common Patterns
+
+### {{PATTERN_SECTION_1}}
+
+```{{LANG}}
+{{CODE_EXAMPLE_1}}
+```
+
+### {{PATTERN_SECTION_2}}
+
+```{{LANG}}
+{{CODE_EXAMPLE_2}}
+```
+
+## Troubleshooting
+
+### {{ISSUE_1}}
+
+**Symptoms:** {{SYMPTOMS_1}}
+
+**Solution:** {{SOLUTION_1}}
+
+### {{ISSUE_2}}
+
+**Symptoms:** {{SYMPTOMS_2}}
+
+**Solution:** {{SOLUTION_2}}
+
+## See Also
+
+- [references/{{REF_1}}.md](references/{{REF_1}}.md) - {{REF_1_DESC}}
+- [references/{{REF_2}}.md](references/{{REF_2}}.md) - {{REF_2_DESC}}
+- `{{RELATED_SKILL}}` skill - {{RELATED_SKILL_DESC}}

--- a/components/skills/.templates/references/example.md
+++ b/components/skills/.templates/references/example.md
@@ -1,0 +1,28 @@
+# {{REFERENCE_TITLE}}
+
+Reference documentation for {{TOPIC}}.
+
+## Overview
+
+{{REFERENCE_OVERVIEW}}
+
+## Details
+
+### {{SECTION_1}}
+
+{{SECTION_1_CONTENT}}
+
+### {{SECTION_2}}
+
+{{SECTION_2_CONTENT}}
+
+## Examples
+
+```{{LANG}}
+{{EXAMPLE_CODE}}
+```
+
+## Related
+
+- [../SKILL.md](../SKILL.md) - Main skill file
+- [{{RELATED_REF}}.md]({{RELATED_REF}}.md) - Related reference

--- a/justfile
+++ b/justfile
@@ -1,6 +1,542 @@
+# Claude Code configuration directory
 
-claude:
-    echo "TODO: Setup repo for claude code integration, using .ai/* contents"
+CLAUDE_DIR := env("HOME") / ".claude"
+
+# Install Claude Code components to ~/.claude/
+[group('install')]
+install target='all':
+    @just _install-{{ target }}
+
+[private]
+_install-all: _install-claude
+
+ls-tags:
+    yq --output-format=json '.' "{{ justfile_directory() }}/components/skills/external.yaml" | jq '[ .manifest[] | add | .tags[] ] | unique'
+
+[private]
+_install-claude: _install-claude-commands _install-claude-rules _install-claude-skills _install-claude-hooks
+    @echo "✓ Claude Code components installed to {{ CLAUDE_DIR }}"
+
+[private]
+_install-claude-commands:
+    @echo "Installing commands..."
+    @mkdir -p "{{ CLAUDE_DIR }}/commands"
+    @for f in components/commands/*.md; do \
+        [ -f "$f" ] && ln -sf "$(pwd)/$f" "{{ CLAUDE_DIR }}/commands/$(basename $f)" && echo "  → $(basename $f)"; \
+    done || true
+
+[private]
+_install-claude-rules:
+    @echo "Installing rules..."
+    @mkdir -p "{{ CLAUDE_DIR }}/rules"
+    @for f in components/rules/*.md; do \
+        [ -f "$f" ] && ln -sf "$(pwd)/$f" "{{ CLAUDE_DIR }}/rules/$(basename $f)" && echo "  → $(basename $f)"; \
+    done || true
+
+[private]
+_install-claude-skills:
+    @echo "Installing skills..."
+    @mkdir -p "{{ CLAUDE_DIR }}/skills"
+    @for d in components/skills/*/; do \
+        name=$(basename "$d"); \
+        target="{{ CLAUDE_DIR }}/skills/$name"; \
+        if [ -d "$d" ]; then \
+            if [ -L "$target" ]; then \
+                rm -f "$target"; \
+            elif [ -d "$target" ]; then \
+                rm -rf "$target"; \
+            fi; \
+            ln -sfn "$(pwd)/$d" "$target" && echo "  → $name/"; \
+        fi; \
+    done || true
+
+[private]
+_install-claude-hooks:
+    @echo "Installing hooks..."
+    @mkdir -p "{{ CLAUDE_DIR }}/hooks"
+    @for f in components/hooks/*; do \
+        [ -f "$f" ] && [ "$(basename $f)" != ".gitkeep" ] && ln -sf "$(pwd)/$f" "{{ CLAUDE_DIR }}/hooks/$(basename $f)" && echo "  → $(basename $f)"; \
+    done || true
+
+# Uninstall Claude Code components from ~/.claude/
+[group('install')]
+uninstall target='all':
+    @just _uninstall-{{ target }}
+
+[private]
+_uninstall-all: _uninstall-claude
+
+[private]
+_uninstall-claude:
+    @echo "Uninstalling Claude Code components..."
+    @for f in components/commands/*.md; do \
+        [ -f "$f" ] && rm -f "{{ CLAUDE_DIR }}/commands/$(basename $f)"; \
+    done || true
+    @for f in components/rules/*.md; do \
+        [ -f "$f" ] && rm -f "{{ CLAUDE_DIR }}/rules/$(basename $f)"; \
+    done || true
+    @for d in components/skills/*/; do \
+        [ -d "$d" ] && rm -f "{{ CLAUDE_DIR }}/skills/$(basename $d)"; \
+    done || true
+    @for f in components/hooks/*; do \
+        [ -f "$f" ] && [ "$(basename $f)" != ".gitkeep" ] && rm -f "{{ CLAUDE_DIR }}/hooks/$(basename $f)"; \
+    done || true
+    @echo "✓ Claude Code components uninstalled"
+
+# List installed Claude Code components
+[group('install')]
+list-claude:
+    @echo "Commands:"
+    @ls -la "{{ CLAUDE_DIR }}/commands/" 2>/dev/null | grep -E "\.md$" || echo "  (none)"
+    @echo "\nRules:"
+    @ls -la "{{ CLAUDE_DIR }}/rules/" 2>/dev/null | grep -E "\.md$" || echo "  (none)"
+    @echo "\nSkills:"
+    @ls -la "{{ CLAUDE_DIR }}/skills/" 2>/dev/null | grep -v "^total" | grep -v "^\." || echo "  (none)"
+    @echo "\nHooks:"
+    @ls -la "{{ CLAUDE_DIR }}/hooks/" 2>/dev/null | grep -v "^total" | grep -v "^\." || echo "  (none)"
+
+# Anthropic skills registry
+
+ANTHROPIC_SKILLS_REPO := "https://github.com/anthropics/skills.git"
+ANTHROPIC_VERSION_FILE := "components/skills/.anthropic-version"
+
+# Mapping: local-name -> upstream-path
+
+ANTHROPIC_SKILL_MAP := "claude-skill-dev:skills/skill-creator"
+
+# Fetch/update skills from Anthropic's skills repository
+[group('upstream')]
+sync-anthropic-skills:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Fetching latest from anthropics/skills..."
+
+    # Get current commit SHA
+    NEW_SHA=$(curl -sL https://api.github.com/repos/anthropics/skills/commits/main | jq -r '.sha[:7]')
+    OLD_SHA=$(cat "{{ ANTHROPIC_VERSION_FILE }}" 2>/dev/null || echo "none")
+
+    if [ "$NEW_SHA" = "$OLD_SHA" ]; then
+        echo "✓ Already up to date ($OLD_SHA)"
+        exit 0
+    fi
+
+    echo "Updating: $OLD_SHA → $NEW_SHA"
+
+    # Clone with sparse checkout
+    TMPDIR=$(mktemp -d)
+    trap "rm -rf $TMPDIR" EXIT
+
+    git clone --depth 1 --filter=blob:none --sparse "{{ ANTHROPIC_SKILLS_REPO }}" "$TMPDIR/skills" 2>/dev/null
+    cd "$TMPDIR/skills"
+
+    # Parse skill map and checkout each
+    IFS=' ' read -ra MAPPINGS <<< "{{ ANTHROPIC_SKILL_MAP }}"
+    PATHS=""
+    for mapping in "${MAPPINGS[@]}"; do
+        upstream_path="${mapping#*:}"
+        PATHS="$PATHS $upstream_path"
+    done
+    git sparse-checkout set $PATHS
+
+    cd - > /dev/null
+
+    # Copy each skill to local name
+    for mapping in "${MAPPINGS[@]}"; do
+        local_name="${mapping%%:*}"
+        upstream_path="${mapping#*:}"
+
+        rm -rf "components/skills/$local_name"
+        cp -r "$TMPDIR/skills/$upstream_path" "components/skills/$local_name"
+        echo "  → $local_name (from $upstream_path)"
+    done
+
+    # Save version
+    echo "$NEW_SHA" > "{{ ANTHROPIC_VERSION_FILE }}"
+    echo "✓ Updated to $NEW_SHA"
+
+# Check if Anthropic skills have updates available
+[group('upstream')]
+check-anthropic-updates:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    NEW_SHA=$(curl -sL https://api.github.com/repos/anthropics/skills/commits/main | jq -r '.sha[:7]')
+    OLD_SHA=$(cat "{{ ANTHROPIC_VERSION_FILE }}" 2>/dev/null || echo "not installed")
+
+    if [ "$OLD_SHA" = "not installed" ]; then
+        echo "Anthropic skills not installed. Run: just sync-anthropic-skills"
+    elif [ "$NEW_SHA" = "$OLD_SHA" ]; then
+        echo "✓ Up to date ($OLD_SHA)"
+    else
+        echo "Update available: $OLD_SHA → $NEW_SHA"
+        echo "Run: just sync-anthropic-skills"
+    fi
+
+# Show current Anthropic skills version
+[group('upstream')]
+anthropic-version:
+    @cat "{{ ANTHROPIC_VERSION_FILE }}" 2>/dev/null || echo "not installed"
+
+# External skills manifest
+EXTERNAL_MANIFEST := justfile_directory() / "components/skills/external.yaml"
+EXTERNAL_VERSION_DIR := justfile_directory() / "components/skills/.versions"
+
+# List available external skills (optionally filter by category)
+[group('external')]
+list-external-skills category='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z "{{ category }}" ]; then
+        echo "Categories:"
+        yq -r '.manifest | keys[]' "{{ EXTERNAL_MANIFEST }}" | while read cat; do
+            count=$(yq -r ".manifest[\"$cat\"] | length" "{{ EXTERNAL_MANIFEST }}")
+            printf "  %-30s (%d skills)\n" "$cat" "$count"
+        done
+    else
+        echo "Skills in {{ category }}:"
+        yq -r ".manifest[\"{{ category }}\"][] | \"  \" + .name + \" - \" + (.notes // \"(no description)\")" "{{ EXTERNAL_MANIFEST }}" 2>/dev/null || echo "  Category not found"
+    fi
+
+# Search external skills by name or tag
+[group('external')]
+search-skills query:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Searching for '{{ query }}'..."
+    yq -o=json '.manifest' "{{ EXTERNAL_MANIFEST }}" | \
+        jq -r --arg q "{{ query }}" '
+            to_entries[] |
+            .key as $cat |
+            .value[] |
+            select(
+                (.name | test($q; "i")) or
+                (.tags[]? | test($q; "i")) or
+                (.notes? // "" | test($q; "i"))
+            ) |
+            "[\($cat)] \(.name) - \(.notes // "(no description)")"
+        '
+
+# Import a skill from an external repository
+[group('external')]
+import-skill repo skill local_name='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    SKILL_NAME="{{ if local_name != '' { local_name } else { skill } }}"
+    TARGET_DIR="{{ justfile_directory() }}/components/skills/$SKILL_NAME"
+
+    echo "Importing $SKILL_NAME from {{ repo }}..."
+
+    # Create version tracking directory
+    mkdir -p "{{ EXTERNAL_VERSION_DIR }}"
+
+    # Get current commit SHA
+    NEW_SHA=$(curl -sL "https://api.github.com/repos/{{ repo }}/commits/main" 2>/dev/null | jq -r '.sha[:7]' || \
+              curl -sL "https://api.github.com/repos/{{ repo }}/commits/master" | jq -r '.sha[:7]')
+
+    VERSION_FILE="{{ EXTERNAL_VERSION_DIR }}/$SKILL_NAME"
+    OLD_SHA=$(cat "$VERSION_FILE" 2>/dev/null || echo "none")
+
+    if [ "$NEW_SHA" = "$OLD_SHA" ] && [ -d "$TARGET_DIR" ]; then
+        echo "✓ Already up to date ($OLD_SHA)"
+        exit 0
+    fi
+
+    echo "Fetching: $OLD_SHA → $NEW_SHA"
+
+    # Clone with sparse checkout
+    TMPDIR=$(mktemp -d)
+    trap "rm -rf $TMPDIR" EXIT
+
+    git clone --depth 1 --filter=blob:none --sparse "https://github.com/{{ repo }}.git" "$TMPDIR/repo" 2>/dev/null
+    cd "$TMPDIR/repo"
+
+    # Try to find the skill path (check if git ls-tree returns non-empty output)
+    SKILL_PATH=""
+    for path in "{{ skill }}" "skills/{{ skill }}" ".claude/skills/{{ skill }}"; do
+        if [ -n "$(git ls-tree --name-only HEAD "$path" 2>/dev/null)" ]; then
+            SKILL_PATH="$path"
+            break
+        fi
+    done
+
+    if [ -z "$SKILL_PATH" ]; then
+        echo "Error: Could not find skill '{{ skill }}' in repository"
+        echo "Tried: {{ skill }}, skills/{{ skill }}, .claude/skills/{{ skill }}"
+        exit 1
+    fi
+
+    git sparse-checkout set "$SKILL_PATH"
+    cd - > /dev/null
+
+    # Copy to local
+    rm -rf "$TARGET_DIR"
+    cp -r "$TMPDIR/repo/$SKILL_PATH" "$TARGET_DIR"
+
+    # Save version
+    echo "$NEW_SHA" > "$VERSION_FILE"
+    echo "✓ Imported $SKILL_NAME from {{ repo }} ($NEW_SHA)"
+
+# Import skill by name from manifest
+[group('external')]
+import-skill-by-name name local_name='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Find skill in manifest
+    SKILL_DATA=$(yq -o=json '.manifest' "{{ EXTERNAL_MANIFEST }}" | \
+        jq -r --arg name "{{ name }}" '
+            to_entries[] |
+            .value[] |
+            select(.name == $name) |
+            "\(.repo)|\(.path // .name)"
+        ' | head -1)
+
+    if [ -z "$SKILL_DATA" ]; then
+        echo "Error: Skill '{{ name }}' not found in manifest"
+        echo "Try: just search-skills {{ name }}"
+        exit 1
+    fi
+
+    REPO=$(echo "$SKILL_DATA" | cut -d'|' -f1)
+    SKILL_PATH=$(echo "$SKILL_DATA" | cut -d'|' -f2)
+    SKILL_NAME=$(basename "$SKILL_PATH")
+
+    LOCAL_NAME="{{ if local_name != '' { local_name } else { '' } }}"
+    if [ -z "$LOCAL_NAME" ]; then
+        LOCAL_NAME="$SKILL_NAME"
+    fi
+
+    echo "Found: $REPO / $SKILL_PATH"
+    just import-skill "$REPO" "$SKILL_PATH" "$LOCAL_NAME"
+
+# List external registries
+[group('external')]
+list-registries:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Registries:"
+    yq -r '.registries[] | "  [" + .type + "] " + .name + " - " + (.notes // "")' "{{ EXTERNAL_MANIFEST }}"
+
+# Show version of imported external skill
+[group('external')]
+external-version skill:
+    @cat "{{ EXTERNAL_VERSION_DIR }}/{{ skill }}" 2>/dev/null || echo "not imported"
+
+# Check for updates to imported external skills
+[group('external')]
+check-external-updates:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ ! -d "{{ EXTERNAL_VERSION_DIR }}" ]; then
+        echo "No external skills imported yet."
+        exit 0
+    fi
+
+    echo "Checking for updates..."
+    for version_file in "{{ EXTERNAL_VERSION_DIR }}"/*; do
+        [ -f "$version_file" ] || continue
+        skill=$(basename "$version_file")
+        old_sha=$(cat "$version_file")
+
+        # Find repo in manifest
+        repo=$(yq -o=json '.manifest' "{{ EXTERNAL_MANIFEST }}" | \
+            jq -r --arg name "$skill" '
+                to_entries[] |
+                .value[] |
+                select(.name == $name) |
+                .repo
+            ' | head -1)
+
+        if [ -n "$repo" ]; then
+            new_sha=$(curl -sL "https://api.github.com/repos/$repo/commits/main" 2>/dev/null | jq -r '.sha[:7]' || echo "$old_sha")
+            if [ "$new_sha" != "$old_sha" ]; then
+                echo "  ⬆ $skill: $old_sha → $new_sha"
+            else
+                echo "  ✓ $skill: up to date ($old_sha)"
+            fi
+        fi
+    done
+
+# Skill management
+SKILL_TEMPLATE_DIR := justfile_directory() / "components/skills/.templates"
+
+# Create new skill from template
+[group('skills')]
+create-skill name:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    SKILL_NAME="{{ name }}"
+    TARGET_DIR="{{ justfile_directory() }}/components/skills/$SKILL_NAME"
+
+    # Validate naming convention (allows lowercase letters and numbers like k8s)
+    if ! echo "$SKILL_NAME" | grep -qE '^[a-z0-9]+-([a-z0-9]+-)?[a-z0-9]+-[a-z]+$'; then
+        echo "Error: Invalid skill name format"
+        echo "Expected: <category>-[<subcategory>-]<tool>-<focus>"
+        echo "Focus must be one of: ops, dev, eng, nub, xec"
+        echo "Examples: lang-rust-cargo-dev, cloud-aws-terraform-eng"
+        exit 1
+    fi
+
+    # Extract components
+    FOCUS=$(echo "$SKILL_NAME" | rev | cut -d'-' -f1 | rev)
+    if ! echo "$FOCUS" | grep -qE '^(ops|dev|eng|nub|xec)$'; then
+        echo "Error: Invalid focus '$FOCUS'"
+        echo "Must be one of: ops, dev, eng, nub, xec"
+        exit 1
+    fi
+
+    if [ -d "$TARGET_DIR" ]; then
+        echo "Error: Skill '$SKILL_NAME' already exists"
+        exit 1
+    fi
+
+    echo "Creating skill: $SKILL_NAME"
+
+    # Create directory structure
+    mkdir -p "$TARGET_DIR/references"
+
+    # Copy template
+    cp "{{ SKILL_TEMPLATE_DIR }}/SKILL.md" "$TARGET_DIR/SKILL.md"
+
+    # Replace basic placeholders
+    CREATED_DATE=$(date -u +"%Y-%m-%dT%H:%M")
+    sed -i '' "s/\{\{SKILL_NAME\}\}/$SKILL_NAME/g" "$TARGET_DIR/SKILL.md"
+    sed -i '' "s/\{\{CREATED_DATE\}\}/$CREATED_DATE/g" "$TARGET_DIR/SKILL.md"
+    sed -i '' "s/\{\{UPDATED_DATE\}\}/$CREATED_DATE/g" "$TARGET_DIR/SKILL.md"
+
+    echo "✓ Created skill at: $TARGET_DIR"
+    echo "  Edit SKILL.md to complete the skill definition"
+
+# Validate skill naming and structure
+[group('skills')]
+validate-skill path:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    SKILL_PATH="{{ path }}"
+    SKILL_NAME=$(basename "$SKILL_PATH")
+    ERRORS=0
+
+    echo "Validating: $SKILL_NAME"
+
+    # Check naming convention (allows lowercase letters and numbers like k8s)
+    if ! echo "$SKILL_NAME" | grep -qE '^[a-z0-9]+-([a-z0-9]+-)?[a-z0-9]+-[a-z]+$'; then
+        echo "  ✗ Name doesn't match pattern: <category>-[<subcategory>-]<tool>-<focus>"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  ✓ Name follows convention"
+    fi
+
+    # Check focus
+    FOCUS=$(echo "$SKILL_NAME" | rev | cut -d'-' -f1 | rev)
+    if ! echo "$FOCUS" | grep -qE '^(ops|dev|eng|nub|xec)$'; then
+        echo "  ✗ Invalid focus: $FOCUS (expected: ops, dev, eng, nub, xec)"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  ✓ Valid focus: $FOCUS"
+    fi
+
+    # Check SKILL.md exists
+    if [ ! -f "$SKILL_PATH/SKILL.md" ]; then
+        echo "  ✗ Missing SKILL.md"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "  ✓ SKILL.md exists"
+
+        # Check for required frontmatter
+        if ! head -1 "$SKILL_PATH/SKILL.md" | grep -q '^---$'; then
+            echo "  ✗ Missing YAML frontmatter"
+            ERRORS=$((ERRORS + 1))
+        else
+            echo "  ✓ Has YAML frontmatter"
+        fi
+
+        # Check for required sections
+        for section in "Overview" "Quick Reference" "Troubleshooting"; do
+            if grep -q "^## $section" "$SKILL_PATH/SKILL.md"; then
+                echo "  ✓ Has $section section"
+            else
+                echo "  ⚠ Missing $section section (recommended)"
+            fi
+        done
+    fi
+
+    if [ $ERRORS -gt 0 ]; then
+        echo "Validation failed with $ERRORS error(s)"
+        exit 1
+    else
+        echo "✓ Validation passed"
+    fi
+
+# List local skills with their focus levels
+[group('skills')]
+list-skills:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Local skills:"
+    for d in "{{ justfile_directory() }}"/components/skills/*/; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        # Skip hidden directories and templates
+        [[ "$name" == .* ]] && continue
+
+        # Extract focus if follows convention (allows lowercase letters and numbers like k8s)
+        if echo "$name" | grep -qE '^[a-z0-9]+-([a-z0-9]+-)?[a-z0-9]+-[a-z]+$'; then
+            focus=$(echo "$name" | rev | cut -d'-' -f1 | rev)
+            printf "  %-40s [%s]\n" "$name" "$focus"
+        else
+            printf "  %-40s [non-standard]\n" "$name"
+        fi
+    done
+
+# Validate all local skills
+[group('skills')]
+validate-all-skills:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    TOTAL=0
+    PASSED=0
+    FAILED=0
+
+    for d in "{{ justfile_directory() }}"/components/skills/*/; do
+        [ -d "$d" ] || continue
+        name=$(basename "$d")
+        [[ "$name" == .* ]] && continue
+
+        TOTAL=$((TOTAL + 1))
+        if just validate-skill "$d" >/dev/null 2>&1; then
+            PASSED=$((PASSED + 1))
+        else
+            FAILED=$((FAILED + 1))
+            echo "Failed: $name"
+        fi
+    done
+
+    echo ""
+    echo "Results: $PASSED/$TOTAL passed, $FAILED failed"
+
+# Import external skill and normalize to naming convention
+[group('skills')]
+import-and-normalize repo skill target:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Importing and normalizing: {{ skill }} → {{ target }}"
+
+    # Import the skill
+    just import-skill "{{ repo }}" "{{ skill }}" "{{ target }}"
+
+    # Validate the result
+    just validate-skill "{{ justfile_directory() }}/components/skills/{{ target }}"
 
 opencode:
     echo "TODO: Setup repo for OpenCode integration, using .ai/* contents"


### PR DESCRIPTION
## Summary

- Add skill template directory with SKILL.md template
- Add justfile recipes for skill management (create, validate, list, import)
- Add skill organization strategy plan with naming convention and categories

Closes #35

## Test plan

- [ ] Run `just list-skills` to verify recipe works
- [ ] Run `just validate-all-skills` to verify validation
- [ ] Review strategy plan for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)