### PR TITLE
feat(skills): add Rust language skills collection

### DIFF
--- a/components/skills/lang-rust-benchmarking-eng/SKILL.md
+++ b/components/skills/lang-rust-benchmarking-eng/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: benchmarking
+description: Run and manage performance benchmarks with cargo xtask bench for facet-json, analyzing results with Markdown reports and comparing against serde_json baseline
+---
+
+# Benchmarking with cargo xtask bench
+
+The facet project uses a sophisticated benchmarking system that generates Markdown reports comparing performance across multiple targets.
+
+## Quick Reference - Running Specific Benchmarks
+
+```bash
+# Run specific benchmark by name
+cargo bench --bench unified_benchmarks_divan -- flatten_2enums
+
+# Run with Tier-2 diagnostics
+FACET_TIER2_DIAG=1 cargo bench --bench unified_benchmarks_divan -- flatten_2enums 2>&1 | grep TIER_DIAG
+
+# Check tier2 statistics (attempts/successes/fallbacks)
+cargo bench --bench unified_benchmarks_divan -- flatten_2enums 2>&1 | grep TIER_STATS
+
+# Run all benchmarks matching a pattern
+cargo bench --bench unified_benchmarks_divan -- flatten
+
+# Run Tier-2 JIT benchmarks only
+cargo bench --bench unified_benchmarks_divan -- "tier2"
+
+# List available benchmarks
+cargo bench --bench unified_benchmarks_divan -- --list | grep -v "    " | head -20
+```
+
+**⚠️  IMPORTANT:** Benchmark `.rs` files are GENERATED from `facet-json/benches/benchmarks.kdl`.
+**DO NOT** edit `unified_benchmarks_*.rs` directly - edit `benchmarks.kdl` instead.
+
+## Quick Usage
+
+```bash
+# Run all benchmarks and generate HTML + Markdown report
+cargo xtask bench --index --serve
+
+# Run benchmarks without the full perf index (faster)
+cargo xtask bench
+
+# Re-analyze existing benchmark data without re-running
+cargo xtask bench --no-run
+
+# Run only specific benchmarks (filter passed to cargo bench)
+cargo xtask bench --index booleans
+
+# Just generate reports from latest data
+cargo xtask bench --no-run --index --serve
+```
+
+## How It Works
+
+The benchmarking system has three main components:
+
+### 1. Benchmark Definition (`benchmarks.kdl`)
+
+Benchmarks are defined in `facet-json/benches/benchmarks.kdl` using KDL syntax:
+
+```kdl
+benchmark name="simple_struct" type="SimpleRecord" category="micro" {
+    json "{\"id\": 42, \"name\": \"test\", \"active\": true}"
+}
+
+benchmark name="booleans" type="Vec<bool>" category="synthetic" {
+    generated "booleans"
+}
+
+type_def name="SimpleRecord" {
+    code """
+#[derive(Debug, PartialEq, Facet, serde::Serialize, serde::Deserialize, Clone)]
+struct SimpleRecord {
+    id: u64,
+    name: String,
+    active: bool,
+}
+"""
+}
+```
+
+**Categories**: `micro`, `synthetic`, `realistic`, `other`
+**Data sources**: `json` (inline), `json_file`, `json_brotli`, `generated`
+
+### 2. Benchmark Generation (`cargo xtask gen-benchmarks`)
+
+Run this after editing `benchmarks.kdl`:
+
+```bash
+cargo xtask gen-benchmarks
+```
+
+This generates three files in `facet-json/`:
+- `benches/unified_benchmarks_divan.rs` - Wall-clock timing benchmarks
+- `benches/unified_benchmarks_gungraun.rs` - Instruction count benchmarks
+- `tests/generated_benchmark_tests.rs` - Test versions for valgrind debugging
+
+**Every benchmark gets all 4 targets automatically:**
+- `serde_json` - Baseline (serde_json crate)
+- `facet_format_json` - facet-format-json without JIT (reflection only)
+- `facet_format_jit_t1` - Tier-1 JIT (shape-based, ParseEvent stream)
+- `facet_format_jit_t2` - Tier-2 JIT (format-specific, direct byte parsing)
+
+### 3. Benchmark Execution and Analysis
+
+`cargo xtask bench` does:
+1. Runs `unified_benchmarks_divan` (wall-clock times via divan)
+2. Runs `unified_benchmarks_gungraun` (instruction counts via gungraun + valgrind)
+3. Parses output and combines results
+4. Generates multiple report formats:
+   - `bench-reports/run.json` - Full structured data (schema: run-v1)
+   - `bench-reports/perf/RESULTS.md` - **Markdown report for LLMs and humans**
+   - `bench-reports/perf-data.json` - Legacy format for perf tracking
+
+## The Markdown Report (`perf/RESULTS.md`)
+
+Located at `bench-reports/perf/RESULTS.md`, this is the **authoritative source** for performance analysis:
+
+**Structure:**
+- **Targets table** - Definitions of all benchmark targets
+- **Benchmark sections** - Grouped by category (Micro, Synthetic, Realistic)
+- **Per-benchmark tables** - Deserialize and Serialize results
+  - Columns: Target, Time (median), Instructions, vs serde_json ratio
+  - Ratios: `**0.84×** ✓` (wins), `1.03×` (close), `3.12× ⚠` (needs work)
+- **Summary** - Auto-categorized by performance:
+  - Wins: ≤1.0× vs serde_json
+  - Close: ≤1.5× vs serde_json
+  - Needs Work: >1.5× vs serde_json
+
+**Example:**
+```markdown
+### booleans
+
+**Deserialize:**
+
+| Target | Time (median) | Instructions | vs serde_json |
+|--------|---------------|--------------|---------------|
+| serde_json | 56.21µs | 1,157,922 | 1.00× |
+| format+jit2 | 53.46µs | 972,221 | **0.84×** ✓ |
+| format+jit1 | 809.30µs | 7,031,459 | 6.07× ⚠ |
+| format | 2.94ms | 23,169,951 | 20.01× ⚠ |
+```
+
+## Adding New Benchmarks
+
+1. **Edit `facet-json/benches/benchmarks.kdl`**
+   ```kdl
+   benchmark name="my_bench" type="MyType" category="synthetic" {
+       generated "my_generator"
+   }
+
+   type_def name="MyType" {
+       code """
+   #[derive(Debug, Facet, serde::Serialize, serde::Deserialize, Clone)]
+   struct MyType {
+       field: String,
+   }
+   """
+   }
+   ```
+
+2. **If using `generated`, add generator to `tools/benchmark-generator/src/main.rs`**
+   - Edit `generate_json_data()` function
+   - Add case for your generator name
+
+3. **Regenerate benchmarks**
+   ```bash
+   cargo xtask gen-benchmarks
+   ```
+
+4. **Run benchmarks**
+   ```bash
+   cargo xtask bench --index --serve
+   ```
+
+## Important Flags
+
+### `--no-run`
+Skips running benchmarks, uses latest data. Useful for:
+- Regenerating reports after fixing parser bugs
+- Testing report generation changes
+- Quick iterations on report formatting
+
+### `--index`
+Generates the full perf.facet.rs index:
+- Clones the `facet-rs/perf.facet.rs` repo (gh-pages branch)
+- Copies benchmark reports to `bench-reports/perf/`
+- Generates index.html and supporting files
+- **Required for viewing the interactive SPA**
+
+### `--serve`
+Starts a local server at `http://localhost:1999` to view reports.
+Requires `--index`.
+
+### `--push`
+Pushes generated reports to the perf.facet.rs repo.
+**Use with caution** - only for publishing official results.
+
+## Debugging Benchmarks with Valgrind
+
+The generated tests in `tests/generated_benchmark_tests.rs` mirror the benchmarks and can be run under valgrind:
+
+```bash
+# Run specific benchmark as test under valgrind
+cargo nextest run --profile valgrind -p facet-json generated_benchmark_tests::test_booleans --features jit
+
+# Or use the generated test filters
+cargo nextest run --profile valgrind -p facet-json test_simple_struct --features jit
+```
+
+This is essential for debugging crashes or memory issues in benchmarks.
+
+## Files and Directories
+
+```
+bench-reports/
+├── divan-{timestamp}.txt          # Raw divan output
+├── gungraun-{timestamp}.txt       # Raw gungraun output
+├── run.json                       # Structured results (run-v1 schema)
+├── perf-data.json                 # Legacy perf tracking format
+└── perf/
+    ├── RESULTS.md                 # **MAIN REPORT - READ THIS**
+    ├── index.html                 # SPA (generated with --index)
+    ├── app.js                     # SPA logic (copied from scripts/)
+    └── shared-styles.css          # SPA styles (copied from scripts/)
+
+facet-json/benches/
+├── benchmarks.kdl                 # **EDIT THIS to add benchmarks**
+├── unified_benchmarks_divan.rs    # Generated (divan)
+└── unified_benchmarks_gungraun.rs # Generated (gungraun)
+
+facet-json/tests/
+└── generated_benchmark_tests.rs   # Generated (for valgrind)
+
+tools/
+├── benchmark-generator/           # KDL → Rust codegen
+└── benchmark-analyzer/            # Output parsing + report generation
+```
+
+## Don't Edit Generated Files
+
+❌ **NEVER edit these files** (they're regenerated):
+- `unified_benchmarks_divan.rs`
+- `unified_benchmarks_gungraun.rs`
+- `generated_benchmark_tests.rs`
+- `bench-reports/perf/index.html`, `app.js`, `shared-styles.css`
+
+✅ **Edit these instead**:
+- `facet-json/benches/benchmarks.kdl` - Benchmark definitions
+- `tools/benchmark-generator/src/main.rs` - Generator logic (for `generated` benchmarks)
+- `scripts/app.js`, `scripts/shared-styles.css` - SPA source (not the copies in perf/)
+
+## Common Workflows
+
+### Quick local benchmark run
+```bash
+cargo xtask bench
+# Check bench-reports/perf/RESULTS.md
+```
+
+### Full interactive report
+```bash
+cargo xtask bench --index --serve
+# Opens http://localhost:1999
+```
+
+### After editing benchmarks.kdl
+```bash
+cargo xtask gen-benchmarks
+cargo xtask bench
+```
+
+### Re-analyze existing data
+```bash
+cargo xtask bench --no-run --index
+```
+
+### Benchmark a specific test
+```bash
+cargo xtask bench integers
+# Only runs benchmarks matching "integers"
+```
+
+## Performance Analysis Tips
+
+1. **Focus on the Markdown report first** (`perf/RESULTS.md`)
+   - Easy to grep, parse, and read
+   - Shows all critical metrics in one place
+   - Auto-categorized by performance tier
+
+2. **Use instruction counts, not just time**
+   - More stable than wall-clock time
+   - Architecture-independent
+   - Appears in "vs serde_json" column when available
+
+3. **Look for patterns in the Summary section**
+   - "Needs Work" items are optimization targets
+   - "Wins" validate current approach
+   - "Close" items are low-hanging fruit
+
+4. **Compare Tier-1 vs Tier-2 JIT**
+   - Large gaps = Tier-2 not implemented or buggy
+   - Similar performance = Tier-2 working but not optimized
+   - Tier-2 wins = format-specific optimizations paying off
+
+## Troubleshooting
+
+### Benchmarks fail to compile
+```bash
+# Regenerate from KDL
+cargo xtask gen-benchmarks
+```
+
+### Parser errors in output
+- Check `bench-reports/divan-*.txt` or `gungraun-*.txt` for malformed output
+- Fix the benchmark code, not the parser (usually)
+
+### Missing benchmarks in report
+- Ensure benchmark has `category` in `benchmarks.kdl`
+- Check that `cargo xtask gen-benchmarks` ran successfully
+- Verify benchmark functions are generated (check `unified_benchmarks_*.rs`)
+
+### `--index` fails
+- Ensure `gh` CLI is installed and authenticated
+- Check network connection (clones from GitHub)
+- Try `--index` without `--push` first
+
+## See Also
+
+- divan docs: https://docs.rs/divan/
+- gungraun: Custom fork with valgrind integration
+- Nextest valgrind profile: `.config/nextest.toml`
+- Benchmark generator: `tools/benchmark-generator/`
+- Report analyzer: `tools/benchmark-analyzer/`

--- a/components/skills/lang-rust-cargo-dev/SKILL.md
+++ b/components/skills/lang-rust-cargo-dev/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: managing-cargo-dependencies
+description: Cargo.toml dependency management patterns for HASH workspace. Use when adding, updating, or removing dependencies, organizing Cargo.toml sections, configuring version pinning and default features, or managing public dependencies.
+license: AGPL-3.0
+metadata:
+  triggers:
+    type: domain
+    enforcement: suggest
+    priority: high
+    keywords:
+      - cargo
+      - dependency
+      - Cargo.toml
+      - crate
+      - workspace.dependencies
+      - default-features
+    intent-patterns:
+      - "\\b(add|update|remove|manage)\\b.*?\\b(dependency|dependencies|crate|crates)\\b"
+      - "\\bCargo\\.toml\\b"
+      - "\\b(public|private)\\s+dependency\\b"
+---
+
+# Cargo Dependencies Management
+
+Guidance for adding and managing dependencies in Cargo.toml files within the HASH repository's workspace structure.
+
+## Core Principles
+
+**HASH uses a strict workspace dependency pattern:**
+
+✅ **DO:**
+
+- Add external dependencies to workspace root `[workspace.dependencies]`
+- Use caret version specifiers (e.g., `version = "1.0.0"` = `^1.0.0`)
+- Set `default-features = false` for all dependencies unless specifically needed
+- Use `workspace = true` in package Cargo.toml
+- Organize dependencies into 4 sections with comment headers
+- Use `public = true` for dependencies exposed in public API
+- Align dependency names using spaces for readability
+
+❌ **DON'T:**
+
+- Add version numbers directly in package Cargo.toml
+- Use exact versions with `=` prefix (e.g., `=1.0.0`) in workspace root
+- Enable `default-features` without considering impact
+- Mix different dependency types without section comments
+- Forget `public = true` for dependencies exposed in public API
+
+## Quick Reference
+
+### The 4-Section Pattern
+
+Every package `Cargo.toml` must organize dependencies into these sections:
+
+```toml
+[dependencies]
+# Public workspace dependencies
+hash-graph-types = { workspace = true, public = true }
+hashql-core      = { workspace = true, public = true }
+
+# Public third-party dependencies
+serde     = { workspace = true, public = true, features = ["derive"] }
+tokio     = { workspace = true, public = true }
+
+# Private workspace dependencies
+error-stack = { workspace = true }
+hash-codec  = { workspace = true }
+
+# Private third-party dependencies
+tracing     = { workspace = true }
+regex       = { workspace = true }
+```
+
+**Keep all 4 section comments even if a section is empty.**
+
+### Quick Add Process
+
+1. **Check workspace root** - Is dependency already there?
+2. **Add to workspace if needed** - With caret version `1.2.3`
+3. **Determine section** - Public workspace/third-party or private?
+4. **Add to package** - Use `workspace = true` (+ `public = true` if needed)
+
+## Detailed Guides
+
+Choose the guide that matches the task:
+
+### [workspace-setup.md](references/workspace-setup.md)
+
+**Use when:** Adding new dependencies to workspace root
+
+- How to add external crates to workspace
+- Version pinning with exact versions
+- Default features configuration
+- Workspace member paths
+
+### [package-dependencies.md](references/package-dependencies.md)
+
+**Use when:** Adding dependencies to a package Cargo.toml
+
+- The 4-section organizational structure
+- Public vs private dependencies
+- When to use `public = true`
+- Alignment and formatting rules
+- Feature configuration
+
+### [examples-reference.md](references/examples-reference.md)
+
+**Use when:** Looking for real examples from HASH codebase
+
+- Complete examples from `@local/codec`
+- Complete examples from `@local/hashql/core`
+- Optional dependencies pattern
+- dev-dependencies structure
+
+## Common Patterns
+
+### Adding a New External Dependency
+
+```toml
+# 1. Add to workspace root Cargo.toml
+[workspace.dependencies]
+my-crate = { version = "1.2.3", default-features = false }
+
+# 2. Add to package Cargo.toml (appropriate section)
+[dependencies]
+# Private third-party dependencies
+my-crate = { workspace = true }
+```
+
+### Making a Dependency Public
+
+```toml
+# Use when the dependency appears in your public API
+serde = { workspace = true, public = true, features = ["derive"] }
+tokio = { workspace = true, public = true }
+```
+
+### Optional Dependencies
+
+```toml
+[dependencies]
+serde = { workspace = true, optional = true, features = ["derive"] }
+
+[features]
+serde = ["dep:serde", "other-dep/serde"]
+```
+
+## References
+
+- [workspace-setup.md](references/workspace-setup.md) - Workspace root configuration
+- [package-dependencies.md](references/package-dependencies.md) - Package dependency structure
+- [examples-reference.md](references/examples-reference.md) - Real codebase examples
+- [Workspace Cargo.toml](../../../Cargo.toml) - Root workspace configuration
+- [hash-codec/Cargo.toml](../../../libs/@local/codec/Cargo.toml) - Reference example
+- [hashql-core/Cargo.toml](../../../libs/@local/hashql/core/Cargo.toml) - Reference example

--- a/components/skills/lang-rust-cargo-dev/references/examples-reference.md
+++ b/components/skills/lang-rust-cargo-dev/references/examples-reference.md
@@ -1,0 +1,262 @@
+# Examples Reference
+
+Real examples from the HASH codebase demonstrating dependency patterns.
+
+---
+
+## Example 1: @local/codec
+
+Complete example from [hash-codec/Cargo.toml](../../../../libs/@local/codec/Cargo.toml)
+
+### Full Dependencies Section
+
+```toml
+[dependencies]
+# Public workspace dependencies
+error-stack         = { workspace = true, public = true, optional = true }
+harpc-wire-protocol = { workspace = true, public = true, optional = true }
+
+# Public third-party dependencies
+bytes      = { workspace = true, public = true }
+serde_core = { workspace = true, public = true, optional = true }
+uuid       = { workspace = true, public = true, optional = true, features = ["serde"] }
+
+# Private workspace dependencies
+
+# Private third-party dependencies
+dashu-base     = { workspace = true, optional = true, features = ["std"] }
+derive_more    = { workspace = true, optional = true, features = ["display", "error"] }
+simple-mermaid = { workspace = true }
+```
+
+### Key Points
+
+- ✅ All 4 section comments present (even when empty - line "Private workspace dependencies")
+- ✅ `public = true` for dependencies exposed in public API (`bytes`, `uuid`)
+- ✅ No `public = true` for internal dependencies (`simple-mermaid`)
+- ✅ Alignment within each section
+- ✅ Many `optional = true` dependencies activated via `[features]`
+
+### Features Configuration
+
+```toml
+[features]
+bytes = ["dep:bytes"]
+serde = ["dep:serde_core", "dep:uuid", "uuid/serde"]
+json = ["serde", "serde_json"]
+```
+
+---
+
+## Example 2: @local/hashql/core
+
+Complete example from [hashql-core/Cargo.toml](../../../../libs/@local/hashql/core/Cargo.toml)
+
+### Full Dependencies Section
+
+```toml
+[dependencies]
+# Public workspace dependencies
+hash-graph-types      = { workspace = true, public = true }
+hashql-diagnostics    = { workspace = true, public = true }
+
+# Public third-party dependencies
+anstyle   = { workspace = true, public = true }
+foldhash  = { workspace = true, public = true }
+hashbrown = { workspace = true, public = true }
+
+# Private workspace dependencies
+
+# Private third-party dependencies
+bitvec               = { workspace = true, features = ["alloc"] }
+derive_more          = { workspace = true, features = ["debug", "from"] }
+unicode-segmentation = { workspace = true }
+```
+
+### Key Points
+
+- ✅ Empty "Private workspace dependencies" section kept
+- ✅ Public workspace crates (`hash-graph-types`, `hashql-diagnostics`)
+- ✅ Public third-party crates (`anstyle`, `foldhash`, `hashbrown`)
+- ✅ Features specified at package level (`bitvec`, `derive_more`)
+- ✅ Perfect alignment
+
+---
+
+## Example 3: Typical Backend Service
+
+Pattern for a backend service package:
+
+```toml
+[dependencies]
+# Public workspace dependencies
+hash-graph-types = { workspace = true, public = true }
+error-stack      = { workspace = true, public = true }
+
+# Public third-party dependencies
+serde = { workspace = true, public = true, features = ["derive"] }
+tokio = { workspace = true, public = true }
+
+# Private workspace dependencies
+hash-codec = { workspace = true }
+
+# Private third-party dependencies
+tracing       = { workspace = true }
+regex         = { workspace = true }
+serde_json    = { workspace = true }
+tokio-util    = { workspace = true, features = ["codec"] }
+derive_more   = { workspace = true, features = ["debug", "display", "from"] }
+```
+
+---
+
+## Example 4: dev-dependencies
+
+Dev dependencies don't need 4-section structure:
+
+```toml
+[dev-dependencies]
+insta              = { workspace = true }
+proptest           = { workspace = true }
+rstest             = { workspace = true }
+test-strategy      = { workspace = true }
+tokio              = { workspace = true, features = ["test-util"] }
+```
+
+**Note:** Can add features to dev-dependencies for testing.
+
+---
+
+## Example 5: Optional Dependencies Pattern
+
+Full pattern with optional dependencies:
+
+```toml
+[dependencies]
+# Public workspace dependencies
+error-stack = { workspace = true, public = true, optional = true }
+
+# Public third-party dependencies
+serde = { workspace = true, public = true, optional = true, features = ["derive"] }
+
+# Private workspace dependencies
+
+# Private third-party dependencies
+tracing = { workspace = true }
+
+[features]
+default = []
+serde = ["dep:serde", "error-stack/serde"]
+std = ["error-stack/std"]
+```
+
+---
+
+## Example 6: Feature-Rich Dependency
+
+When a dependency needs many features:
+
+```toml
+[dependencies]
+# Private third-party dependencies
+tokio = {
+    workspace = true,
+    features = [
+        "rt-multi-thread",
+        "macros",
+        "signal",
+        "sync",
+        "time",
+        "fs",
+        "io-util",
+    ],
+}
+```
+
+**Note:** Multi-line format when feature list is long.
+
+---
+
+## Example 7: Workspace Member Reference
+
+Adding a new workspace member:
+
+```toml
+# In workspace root Cargo.toml
+[workspace.dependencies]
+my-new-crate.path = "libs/@local/my-new-crate"
+
+# In package Cargo.toml
+[dependencies]
+# Public workspace dependencies
+my-new-crate = { workspace = true, public = true }
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+### ❌ Version in Package
+
+```toml
+# WRONG - version should be in workspace root only
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+```
+
+### ❌ Exact Pinning in Workspace
+
+```toml
+# WRONG - use caret versions, let Cargo.lock handle exact pinning
+[workspace.dependencies]
+serde = { version = "=1.0.228", default-features = false }
+```
+
+### ❌ Missing Section Comments
+
+```toml
+# WRONG - missing section structure
+[dependencies]
+serde = { workspace = true, public = true }
+tokio = { workspace = true, public = true }
+tracing = { workspace = true }
+```
+
+### ❌ Wrong Section
+
+```toml
+# WRONG - serde should be in "Public third-party"
+[dependencies]
+# Private third-party dependencies
+serde = { workspace = true, public = true }
+```
+
+### ❌ No Alignment
+
+```toml
+# WRONG - inconsistent spacing
+hash-graph-types = { workspace = true, public = true }
+hashql-core = { workspace = true, public = true }
+```
+
+---
+
+## Quick Checklist
+
+When reviewing Cargo.toml:
+
+- [ ] All 4 section comments present (even if empty)
+- [ ] Dependencies in correct section (public/private, workspace/third-party)
+- [ ] `public = true` for all public API dependencies
+- [ ] `workspace = true` for all dependencies
+- [ ] Alignment within each section
+- [ ] No version numbers in package Cargo.toml
+- [ ] Features specified at package level (not workspace)
+
+---
+
+## Related
+
+- [workspace-setup.md](workspace-setup.md) - Managing workspace root
+- [package-dependencies.md](package-dependencies.md) - Section structure details
+- [SKILL.md](../SKILL.md) - Overview and quick reference

--- a/components/skills/lang-rust-cargo-dev/references/package-dependencies.md
+++ b/components/skills/lang-rust-cargo-dev/references/package-dependencies.md
@@ -1,0 +1,297 @@
+# Package Dependencies Guide
+
+Complete guide for managing dependencies in package Cargo.toml files.
+
+---
+
+## The 4-Section Structure
+
+**Every** package Cargo.toml must organize dependencies into exactly 4 sections:
+
+```toml
+[dependencies]
+# Public workspace dependencies
+hash-graph-types = { workspace = true, public = true }
+hashql-core      = { workspace = true, public = true }
+
+# Public third-party dependencies
+serde     = { workspace = true, public = true, features = ["derive"] }
+tokio     = { workspace = true, public = true }
+smallvec  = { workspace = true, public = true }
+
+# Private workspace dependencies
+error-stack = { workspace = true }
+hash-codec  = { workspace = true }
+
+# Private third-party dependencies
+tracing       = { workspace = true }
+regex         = { workspace = true }
+derive_more   = { workspace = true, features = ["debug", "from"] }
+```
+
+### Section Order (Always)
+
+1. **Public workspace dependencies** - Workspace crates in public API
+2. **Public third-party dependencies** - External crates in public API
+3. **Private workspace dependencies** - Workspace crates used internally
+4. **Private third-party dependencies** - External crates used internally
+
+### Empty Sections
+
+**Keep section comments even when empty:**
+
+```toml
+[dependencies]
+# Public workspace dependencies
+
+# Public third-party dependencies
+serde = { workspace = true, public = true }
+
+# Private workspace dependencies
+
+# Private third-party dependencies
+tracing = { workspace = true }
+```
+
+See [hashql-core/Cargo.toml](../../../../libs/@local/hashql/core/Cargo.toml) for example.
+
+---
+
+## Public vs Private Dependencies
+
+### What is `public = true`?
+
+Use `public = true` when a dependency appears in your **public API**:
+
+- Return types in public functions
+- Public struct fields
+- Re-exported types
+- Generic trait bounds on public items
+
+### When to Use `public = true`
+
+✅ **Use public = true:**
+
+```rust
+// Dependency appears in public signature
+pub fn get_entity() -> EntityType { ... }  // EntityType = public
+
+// Dependency in public struct field
+pub struct Store {
+    pub entities: Vec<EntityType>,  // EntityType = public
+}
+
+// Re-exported
+pub use serde::Serialize;  // serde = public
+```
+
+❌ **Don't use public = true:**
+
+```rust
+// Only used internally
+fn internal_helper() -> EntityType { ... }  // EntityType can be private
+
+// Private field
+pub struct Store {
+    entities: Vec<EntityType>,  // EntityType can be private (private field)
+}
+
+// Only used in function bodies
+pub fn process() {
+    let data = serde_json::to_string(&x);  // serde_json can be private
+}
+```
+
+### Public Dependency Examples
+
+```toml
+[dependencies]
+# Public - these appear in public API
+serde      = { workspace = true, public = true }
+tokio      = { workspace = true, public = true }
+hash-codec = { workspace = true, public = true }
+
+# Private - only used internally
+tracing = { workspace = true }
+regex   = { workspace = true }
+```
+
+---
+
+## Adding Dependencies
+
+### Step 1: Determine Section
+
+Ask yourself:
+
+1. **Is it a workspace member or external crate?**
+2. **Does it appear in my public API?**
+
+This gives you one of 4 sections:
+
+- Public + workspace → Section 1
+- Public + external → Section 2
+- Private + workspace → Section 3
+- Private + external → Section 4
+
+### Step 2: Add to Appropriate Section
+
+```toml
+[dependencies]
+# Public workspace dependencies
+my-workspace-crate = { workspace = true, public = true }
+
+# Public third-party dependencies
+serde = { workspace = true, public = true, features = ["derive"] }
+
+# Private workspace dependencies
+error-stack = { workspace = true }
+
+# Private third-party dependencies
+tracing = { workspace = true }
+```
+
+### Step 3: Add Features (if needed)
+
+```toml
+# Enable specific features
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
+serde = { workspace = true, public = true, features = ["derive"] }
+```
+
+---
+
+## Alignment and Formatting
+
+Align `=` signs within each section for readability:
+
+### Good Alignment
+
+```toml
+# Public workspace dependencies
+hash-graph-types      = { workspace = true, public = true }
+hashql-core           = { workspace = true, public = true }
+hashql-diagnostics    = { workspace = true, public = true }
+
+# Public third-party dependencies
+anstyle   = { workspace = true, public = true }
+foldhash  = { workspace = true, public = true }
+hashbrown = { workspace = true, public = true }
+```
+
+### Bad Alignment
+
+```toml
+# Don't do this
+hash-graph-types = { workspace = true, public = true }
+hashql-core = { workspace = true, public = true }
+hashql-diagnostics = { workspace = true, public = true }
+```
+
+Use spaces (not tabs) to align the `=` within each section.
+
+---
+
+## Features Configuration
+
+### Enabling Features
+
+```toml
+[dependencies]
+# Enable specific features needed by this package
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+serde = { workspace = true, features = ["derive"] }
+```
+
+### Feature Dependencies
+
+Features can depend on other features:
+
+```toml
+[features]
+default = ["std"]
+std = ["serde/std", "dep:tokio"]
+```
+
+---
+
+## Optional Dependencies
+
+For conditional compilation:
+
+```toml
+[dependencies]
+# Optional dependencies
+serde = { workspace = true, optional = true, features = ["derive"] }
+tokio = { workspace = true, optional = true }
+
+[features]
+# Activate optional dependencies via features
+serde = ["dep:serde"]
+async = ["dep:tokio", "tokio/rt"]
+```
+
+**Note:** Optional dependencies still follow the 4-section structure.
+
+---
+
+## dev-dependencies
+
+Dev dependencies don't need the 4-section structure:
+
+```toml
+[dev-dependencies]
+insta         = { workspace = true }
+proptest      = { workspace = true }
+rstest        = { workspace = true }
+test-strategy = { workspace = true }
+```
+
+Just list them alphabetically, all with `workspace = true`.
+
+---
+
+## Common Patterns
+
+### Adding a Workspace Member (Public)
+
+```toml
+[dependencies]
+# Public workspace dependencies
+my-crate = { workspace = true, public = true }
+```
+
+### Adding External Crate (Private)
+
+```toml
+[dependencies]
+# Private third-party dependencies
+regex = { workspace = true }
+```
+
+### Adding with Features
+
+```toml
+[dependencies]
+# Private third-party dependencies
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+```
+
+### Optional + Public
+
+```toml
+[dependencies]
+# Public third-party dependencies
+serde = { workspace = true, public = true, optional = true, features = ["derive"] }
+
+[features]
+serde = ["dep:serde"]
+```
+
+---
+
+## Related
+
+- [workspace-setup.md](workspace-setup.md) - Adding to workspace root
+- [examples-reference.md](examples-reference.md) - Real examples from HASH
+- [SKILL.md](../SKILL.md) - Overview and quick reference

--- a/components/skills/lang-rust-cargo-dev/references/workspace-setup.md
+++ b/components/skills/lang-rust-cargo-dev/references/workspace-setup.md
@@ -1,0 +1,186 @@
+# Workspace Setup Guide
+
+Complete guide for managing dependencies in the workspace root Cargo.toml.
+
+---
+
+## Checking Existing Dependencies
+
+Before adding a new dependency, check if it already exists:
+
+```bash
+grep "^my-crate" Cargo.toml
+```
+
+Or search within the workspace.dependencies section:
+
+```bash
+grep -A 1 "^\[workspace.dependencies\]" Cargo.toml | grep "my-crate"
+```
+
+---
+
+## Adding External Crates
+
+All external crates must be defined in workspace root `[workspace.dependencies]`:
+
+### Basic External Dependency
+
+```toml
+[workspace.dependencies]
+# External dependencies
+serde = { version = "1.0.228", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
+regex = { version = "1.11.1", default-features = false }
+```
+
+### With Features (at workspace level)
+
+```toml
+[workspace.dependencies]
+# When you need features enabled everywhere
+derive_more = { version = "1.0.0", default-features = false, features = ["debug", "from"] }
+```
+
+**Note:** Usually better to enable features at package level for granular control.
+
+---
+
+## Version Specifiers
+
+HASH uses **caret version specifiers** (e.g., `1.0.228` = `^1.0.228`) for reproducible builds with `Cargo.lock`:
+
+✅ **Correct:**
+
+```toml
+serde = { version = "1.0.228", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
+```
+
+❌ **Wrong:**
+
+```toml
+serde = { version = "=1.0.228", default-features = false } # Exact pinning (not needed)
+tokio = "1.47"                                              # No shorthand
+serde = { version = "1.0", default-features = false }      # Too vague
+```
+
+---
+
+## Default Features
+
+Always disable default features at workspace level:
+
+```toml
+[workspace.dependencies]
+# Disable defaults - enable features where needed
+tokio = { version = "=1.47.1", default-features = false }
+serde = { version = "=1.0.228", default-features = false }
+regex = { version = "=1.11.1", default-features = false }
+```
+
+Then enable specific features in package Cargo.toml:
+
+```toml
+# In package Cargo.toml
+[dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+serde = { workspace = true, features = ["derive"] }
+```
+
+**Note:** Workspace root should have `default-features = false`, but package level can override with specific features.
+
+### Why Disable Defaults?
+
+- **Smaller binaries** - Only include what you need
+- **Faster compile times** - Less code to compile
+- **Explicit dependencies** - Clear what features each package uses
+- **Avoid bloat** - Default features often include unnecessary functionality
+
+---
+
+## Workspace Members
+
+For internal crates (workspace members), use path references:
+
+```toml
+[workspace.dependencies]
+# Workspace members
+error-stack.path = "libs/error-stack"
+hash-codec.path = "libs/@local/codec"
+hash-graph-types.path = "libs/@local/hash-graph-types"
+hashql-core.path = "libs/@local/hashql/core"
+```
+
+**Note:** Use relative paths from workspace root.
+
+---
+
+## Organizing Workspace Dependencies
+
+Group related dependencies with comments:
+
+```toml
+[workspace.dependencies]
+# Core error handling
+error-stack = { path = "libs/error-stack" }
+
+# Async runtime
+tokio = { version = "1.47.1", default-features = false }
+tokio-util = { version = "0.7.13", default-features = false }
+
+# Serialization
+serde = { version = "1.0.228", default-features = false }
+serde_json = { version = "1.0.138", default-features = false }
+
+# Database
+postgres = { version = "0.19.9", default-features = false }
+postgres-types = { version = "0.2.8", default-features = false }
+```
+
+---
+
+## Finding Latest Versions
+
+```bash
+# Check crates.io for latest version
+cargo search my-crate --limit 1
+
+# Or use cargo-edit (if installed)
+cargo add my-crate --dry-run
+```
+
+---
+
+## Common Patterns
+
+### Adding a Popular Crate
+
+```toml
+[workspace.dependencies]
+# Add to appropriate section
+tracing = { version = "0.1.41", default-features = false }
+```
+
+### Adding with Specific Features (workspace-wide)
+
+```toml
+[workspace.dependencies]
+# When all packages need the same features
+uuid = { version = "1.11.0", default-features = false, features = ["v4", "serde"] }
+```
+
+### Adding Workspace Member
+
+```toml
+[workspace.dependencies]
+my-new-crate.path = "libs/@local/my-new-crate"
+```
+
+---
+
+## Related
+
+- [package-dependencies.md](package-dependencies.md) - Adding to package Cargo.toml
+- [examples-reference.md](examples-reference.md) - Real examples from HASH
+- [Workspace Cargo.toml](../../../../Cargo.toml) - Root configuration

--- a/components/skills/lang-rust-crates-dev/SKILL.md
+++ b/components/skills/lang-rust-crates-dev/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: exploring-rust-crates
+description: Generate Rust documentation to understand crate APIs, structure, and usage. Use when exploring Rust code, understanding crate organization, finding functions/types/traits, or needing context about a Rust package in the HASH workspace.
+license: AGPL-3.0
+metadata:
+  triggers:
+    type: domain
+    enforcement: suggest
+    priority: medium
+    keywords:
+      - cargo doc
+      - rust documentation
+      - crate api
+      - rust crate
+      - module hierarchy
+    intent-patterns:
+      - "\\b(explore|understand|learn)\\b.*?\\b(rust|crate|package)\\b"
+      - "\\b(what|how)\\b.*?\\b(functions|types|traits|api)\\b.*?\\bcrate\\b"
+      - "\\bdocument(ation)?\\b.*?\\brust\\b"
+---
+
+# Exploring Rust Crates
+
+Generate and use Rust documentation to understand crate APIs, structure, and code organization in the HASH workspace.
+
+## Generating Documentation
+
+### For a Specific Package
+
+```bash
+cargo doc --no-deps --all-features --package <package-name>
+```
+
+### For the Entire Workspace
+
+```bash
+cargo doc --no-deps --all-features --workspace
+```
+
+### Key Flags
+
+- `--no-deps`: Document local code only (faster, less noise)
+- `--all-features`: Include all feature-gated APIs
+- `--package <name>`: Target a specific crate
+- `--workspace`: Document all crates in the workspace
+- `--document-private-items`: Include internal implementation details
+
+## What Generated Docs Provide
+
+1. **Crate organization** - Module hierarchy and component relationships
+2. **Public API surface** - All public functions, types, traits, and constants
+3. **Usage examples** - Code examples from doctest blocks
+4. **Error documentation** - Documented error conditions and handling
+5. **Type relationships** - Trait implementations, type aliases, associated types
+
+## Viewing Documentation
+
+Docs are generated at:
+
+```txt
+target/doc/<crate_name>/index.html
+```
+
+## Tips
+
+- Generate docs before diving into unfamiliar Rust code
+- Cross-reference `# Errors` sections for error handling patterns
+- Look for `# Examples` sections for idiomatic usage patterns

--- a/components/skills/lang-rust-docs-dev/SKILL.md
+++ b/components/skills/lang-rust-docs-dev/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: documenting-rust-code
+description: Rust documentation practices for HASH codebase. Use when writing doc comments, documenting functions/types/traits/modules, creating error sections, using intra-doc links, or following rustdoc conventions.
+license: AGPL-3.0
+metadata:
+  triggers:
+    type: domain
+    enforcement: suggest
+    priority: high
+    keywords:
+      - rustdoc
+      - doc comment
+      - documentation
+      - intra-doc link
+    intent-patterns:
+      - "\\bdocument(ing|ation)?\\b.*?\\b(rust|function|type|struct|enum|trait|module)\\b"
+      - "\\b(write|add|create)\\b.*?\\bdoc\\s*comment\\b"
+      - "\\b#\\s*(Errors|Panics|Examples|Arguments)\\b"
+---
+
+# Rust Documentation Practices
+
+Comprehensive guidance on documenting Rust code in the HASH repository following rustdoc conventions.
+
+## Core Principles
+
+**Follow high-quality standards like `time`, `jiff`, and `serde`:**
+
+✅ **DO:**
+
+- Begin every doc comment with single-line summary
+- Use intra-doc links for all type references
+- Document all error conditions with `# Errors`
+- Include practical examples for public APIs
+- Link standard library types: [`Vec`], [`HashMap`], etc.
+- Use inline parameter descriptions for simple functions (0-2 params)
+- Describe return values in main text, not separate sections
+
+❌ **DON'T:**
+
+- Document standard trait implementations (`Debug`, `Display`, `From`)
+- Add separate `# Returns` sections (inline instead)
+- Mention variable types already in signatures
+- Use comments on same line as code
+- Skip error documentation for fallible functions
+
+## Quick Reference
+
+### Basic Doc Comment
+
+```rust
+/// Retrieves an entity by its UUID.
+///
+/// Loads the entity from the store and verifies access permissions.
+/// Returns the [`Entity`] if found and accessible.
+///
+/// # Errors
+///
+/// - [`NotFound`] if the entity doesn't exist
+/// - [`AuthorizationError`] if access is denied
+///
+/// [`NotFound`]: EntityError::NotFound
+/// [`AuthorizationError`]: EntityError::Authorization
+pub fn get_entity(&self, id: EntityId) -> Result<Entity, Report<EntityError>> {
+```
+
+### Intra-Doc Links
+
+```rust
+/// Updates the [`User`] using [`UserUpdateStrategy`].
+///
+/// See [`validation::user`] for validation rules.
+///
+/// [`validation::user`]: crate::validation::user
+```
+
+## Documentation Patterns
+
+### Simple Functions (0-2 params)
+
+Describe parameters inline:
+
+```rust
+/// Processes the `input` elements and returns filtered results.
+///
+/// Takes a collection of `input` elements, applies the `filter_fn`,
+/// and returns a [`Vec`] containing only matching elements.
+```
+
+### Complex Functions (3+ params)
+
+Use explicit `# Arguments` section:
+
+```rust
+/// Merges multiple data sources with transformation rules.
+///
+/// # Arguments
+///
+/// * `sources` - Collection of data sources to merge
+/// * `rules` - Transformation rules to apply
+/// * `options` - Configuration controlling merge behavior
+/// * `callback` - Optional function for each merged item
+```
+
+### Error Documentation
+
+```rust
+/// # Errors
+///
+/// - [`WebAlreadyExists`] if web ID is taken
+/// - [`AuthorizationError`] if permission denied
+///
+/// [`WebAlreadyExists`]: WebError::WebAlreadyExists
+/// [`AuthorizationError`]: WebError::Authorization
+```
+
+### Module Documentation
+
+```rust
+//! Entity management functionality.
+//!
+//! Main types:
+//! - [`Entity`] - Core entity type
+//! - [`EntityStore`] - Storage trait
+//!
+//! # Examples
+//!
+//! ```
+//! use hash_graph::entity::Entity;
+//! ```
+```
+
+### Examples with Error Handling
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// let entities = get_entities_by_type(type_id)?;
+/// assert_eq!(entities.len(), 2);
+/// # Ok::<(), Box<dyn core::error::Error>>(())
+/// ```
+```
+
+## Verification
+
+```bash
+cargo doc --no-deps --all-features
+```
+
+## References
+
+- **[references/function-documentation.md](references/function-documentation.md)**: Functions and methods documentation patterns
+- **[references/type-documentation.md](references/type-documentation.md)**: Types, structs, enums, and traits documentation
+- **[references/error-documentation.md](references/error-documentation.md)**: Error conditions and panics documentation
+- **[references/examples-and-links.md](references/examples-and-links.md)**: Examples and intra-doc links usage

--- a/components/skills/lang-rust-docs-dev/references/error-documentation.md
+++ b/components/skills/lang-rust-docs-dev/references/error-documentation.md
@@ -1,0 +1,218 @@
+# Error Documentation Guide
+
+Complete guide for documenting error conditions in Rust functions.
+
+---
+
+## The `# Errors` Section
+
+**Every fallible function** (returning `Result`) must document error conditions:
+
+```rust
+/// Creates a new web in the system.
+///
+/// Registers the web with the given parameters and ensures uniqueness.
+///
+/// # Errors
+///
+/// - [`WebAlreadyExists`] if a web with the same ID exists
+/// - [`AuthorizationError`] if the account lacks permission
+/// - [`DatabaseError`] if the database operation fails
+///
+/// [`WebAlreadyExists`]: WebError::WebAlreadyExists
+/// [`AuthorizationError`]: WebError::Authorization
+/// [`DatabaseError`]: WebError::Database
+pub fn create_web(&mut self) -> Result<WebId, Report<WebError>> {
+```
+
+---
+
+## Linking Error Variants
+
+Use intra-doc links for error enum variants:
+
+### Format
+
+```rust
+/// # Errors
+///
+/// - [`VariantName`] - when this happens
+///
+/// [`VariantName`]: ErrorType::VariantName
+```
+
+### Example
+
+```rust
+pub enum EntityError {
+    NotFound,
+    Validation,
+    Database,
+}
+
+/// # Errors
+///
+/// - [`NotFound`] if entity doesn't exist
+/// - [`Validation`] if data is invalid
+///
+/// [`NotFound`]: EntityError::NotFound
+/// [`Validation`]: EntityError::Validation
+```
+
+---
+
+## Runtime Errors
+
+For errors created at runtime (not enum variants), use plain text:
+
+```rust
+/// Validates input values are unique.
+///
+/// # Errors
+///
+/// Returns a validation error if the input contains duplicates
+pub fn validate_unique(values: &[String]) -> Result<(), Report<ValidationError>> {
+```
+
+---
+
+## External Crate Errors
+
+For errors from external crates, describe without links:
+
+```rust
+/// Parses JSON configuration from file.
+///
+/// # Errors
+///
+/// - Returns IO error if file cannot be read
+/// - Returns parse error if JSON is malformed
+pub fn load_config(path: &Path) -> Result<Config, Box<dyn Error>> {
+```
+
+---
+
+## Panic Documentation
+
+Use `# Panics` for functions that can panic:
+
+```rust
+/// Converts the entity ID to a UUID.
+///
+/// # Panics
+///
+/// Panics if the entity ID contains an invalid UUID format.
+pub fn to_uuid(&self) -> Uuid {
+    Uuid::parse_str(&self.id).expect("should be valid UUID")
+}
+```
+
+**Note:** Prefer returning `Result` over panicking in library code.
+
+---
+
+## Complete Example
+
+```rust
+/// Updates entity properties with validation.
+///
+/// Applies the given `changes` to the entity after validating them
+/// against the entity's type schema. Returns the updated entity.
+///
+/// # Errors
+///
+/// - [`NotFound`] if entity doesn't exist
+/// - [`ValidationError`] if changes violate schema
+/// - [`AuthorizationError`] if caller lacks write permission
+/// - [`ConcurrencyError`] if entity was modified concurrently
+/// - [`DatabaseError`] if the update operation fails
+///
+/// # Panics
+///
+/// Panics if `changes` is empty (use `has_changes()` to check first).
+///
+/// [`NotFound`]: EntityError::NotFound
+/// [`ValidationError`]: EntityError::Validation
+/// [`AuthorizationError`]: EntityError::Authorization
+/// [`ConcurrencyError`]: EntityError::Concurrency
+/// [`DatabaseError`]: EntityError::Database
+pub fn update_entity(
+    &mut self,
+    id: EntityId,
+    changes: PropertyChanges,
+) -> Result<Entity, Report<EntityError>> {
+    assert!(!changes.is_empty(), "changes must not be empty");
+    // implementation
+}
+```
+
+---
+
+## Error Documentation Checklist
+
+- [ ] `# Errors` section for all `Result`-returning functions
+- [ ] Each error variant listed with bullet point
+- [ ] Intra-doc links for enum variants
+- [ ] Plain descriptions for runtime/external errors
+- [ ] Link definitions at end of doc comment
+- [ ] `# Panics` section if function can panic
+
+---
+
+## Common Patterns
+
+### Multiple Error Types
+
+```rust
+/// # Errors
+///
+/// - [`IoError`] if file operations fail
+/// - [`ParseError`] if data format is invalid
+/// - [`ValidationError`] if data doesn't meet requirements
+///
+/// [`IoError`]: Error::Io
+/// [`ParseError`]: Error::Parse
+/// [`ValidationError`]: Error::Validation
+```
+
+### Optional Operations
+
+```rust
+/// Tries to load cached data, returns `None` if not cached.
+///
+/// # Errors
+///
+/// - [`CacheError`] if cache is corrupted
+/// - [`IoError`] if cache file cannot be read
+///
+/// Returns `Ok(None)` if data is not in cache (not an error).
+///
+/// [`CacheError`]: Error::Cache
+/// [`IoError`]: Error::Io
+pub fn try_load_cached(&self) -> Result<Option<Data>, Report<Error>> {
+```
+
+### Async Functions
+
+```rust
+/// Fetches entity from remote store.
+///
+/// # Errors
+///
+/// - [`NetworkError`] if connection fails
+/// - [`TimeoutError`] if request exceeds deadline
+/// - [`NotFound`] if entity doesn't exist remotely
+///
+/// [`NetworkError`]: RemoteError::Network
+/// [`TimeoutError`]: RemoteError::Timeout
+/// [`NotFound`]: RemoteError::NotFound
+pub async fn fetch_remote(&self, id: EntityId) -> Result<Entity, Report<RemoteError>> {
+```
+
+---
+
+## Related
+
+- [function-documentation.md](function-documentation.md) - Function docs
+- [../rust-error-stack/SKILL.md](../../rust-error-stack/SKILL.md) - Error handling patterns
+- [SKILL.md](../SKILL.md) - Overview

--- a/components/skills/lang-rust-docs-dev/references/examples-and-links.md
+++ b/components/skills/lang-rust-docs-dev/references/examples-and-links.md
@@ -1,0 +1,323 @@
+# Examples and Intra-Doc Links Guide
+
+Complete guide for writing examples and using intra-doc links in Rust documentation.
+
+---
+
+## Intra-Doc Links
+
+### Why Use Them
+
+Intra-doc links make documentation navigable and catch broken references at compile time.
+
+**Link everything:**
+
+- Types you mention
+- Related functions
+- Standard library types
+- Error variants
+
+### Basic Syntax
+
+```rust
+/// Updates the [`Entity`] using [`UserUpdateStrategy`].
+///
+/// Returns the updated [`Entity`] or [`EntityError`].
+pub fn update(entity: Entity) -> Result<Entity, EntityError> {
+```
+
+### Linking Patterns
+
+**Current module items:**
+
+```rust
+/// Uses the [`LocalType`] for processing.
+```
+
+**Other modules:**
+
+```rust
+/// See [`crate::validation::user`] for validation rules.
+```
+
+With link definition:
+
+```rust
+/// See [`validation::user`] for validation rules.
+///
+/// [`validation::user`]: crate::validation::user
+```
+
+**Standard library:**
+
+```rust
+/// Returns a [`Vec`] of [`HashMap`] entries.
+/// Uses [`swap_remove`] for efficient removal.
+///
+/// [`swap_remove`]: Vec::swap_remove
+```
+
+**Trait methods:**
+
+```rust
+/// Implements [`Iterator::next`] for sequential access.
+```
+
+**Error variants:**
+
+```rust
+/// # Errors
+///
+/// - [`NotFound`] if entity doesn't exist
+///
+/// [`NotFound`]: EntityError::NotFound
+```
+
+---
+
+## Writing Examples
+
+### Basic Example Structure
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// use hash_graph::entity::Entity;
+///
+/// let entity = Entity::new(id, properties)?;
+/// assert_eq!(entity.id(), id);
+/// # Ok::<(), Box<dyn core::error::Error>>(())
+/// ```
+```
+
+### Example Checklist
+
+- [ ] Imports shown (unless obvious)
+- [ ] Error handling included
+- [ ] Assertions demonstrate behavior
+- [ ] Example compiles
+- [ ] Example is minimal but complete
+
+---
+
+## Hiding Setup Code
+
+Use `#` to hide necessary setup from docs display:
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// # use hash_graph::entity::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let store = create_test_store();
+/// # let type_id = EntityTypeId::new();
+/// let entity = store.get_entity(type_id)?;
+/// println!("Found: {}", entity.name);
+/// # Ok(())
+/// # }
+/// ```
+```
+
+**What renders:**
+
+```rust
+let entity = store.get_entity(type_id)?;
+println!("Found: {}", entity.name);
+```
+
+---
+
+## Error Handling in Examples
+
+### Using `?` Operator
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// let result = fallible_operation()?;
+/// assert!(result.is_valid());
+/// # Ok::<(), Box<dyn core::error::Error>>(())
+/// ```
+```
+
+### Using `expect` for Infallible Cases
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// let config = Config::default();
+/// let value = config.get("key").expect("should have default key");
+/// ```
+```
+
+---
+
+## Multi-Step Examples
+
+Show realistic usage patterns:
+
+```rust
+/// # Examples
+///
+/// ```rust
+/// # use hash_graph::entity::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// // Create entity
+/// let mut entity = Entity::new(id, properties)?;
+///
+/// // Update properties
+/// entity.set_property("name", "Updated")?;
+/// entity.set_property("status", "active")?;
+///
+/// // Validate and save
+/// entity.validate()?;
+/// store.save(&entity)?;
+/// # Ok(())
+/// # }
+/// ```
+```
+
+---
+
+## Module Documentation
+
+Use `//!` for module-level docs:
+
+```rust
+//! Entity management functionality.
+//!
+//! This module provides types and functions for creating, updating,
+//! and querying entities in the system.
+//!
+//! # Main Types
+//!
+//! - [`Entity`] - Core entity type
+//! - [`EntityId`] - Unique identifier
+//! - [`EntityStore`] - Storage trait
+//!
+//! # Examples
+//!
+//! ```rust
+//! use hash_graph::entity::{Entity, EntityStore};
+//!
+//! let entity = Entity::new(id, properties)?;
+//! store.save(&entity)?;
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+```
+
+---
+
+## Performance Notes
+
+Document performance characteristics when relevant:
+
+```rust
+/// Retrieves all entities matching the filter.
+///
+/// # Performance
+///
+/// This operation has O(n) complexity where n is the total number of
+/// entities. Uses pagination internally with 100-item pages.
+///
+/// For large result sets, consider using [`get_entities_stream`] which
+/// provides incremental results with O(1) memory usage.
+///
+/// [`get_entities_stream`]: Self::get_entities_stream
+```
+
+---
+
+## Async Documentation
+
+```rust
+/// Processes entity asynchronously.
+///
+/// # Concurrency
+///
+/// Spawns background tasks for parallel processing. Requires multi-threaded
+/// runtime. Returns when all spawned tasks complete.
+///
+/// # Examples
+///
+/// ```rust
+/// # use hash_graph::entity::*;
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let result = processor.process_async(entity).await?;
+/// assert!(result.is_processed());
+/// # Ok(())
+/// # }
+/// ```
+pub async fn process_async(&self, entity: Entity) -> Result<ProcessResult, Error> {
+```
+
+---
+
+## Complete Example
+
+```rust
+/// Validates and creates entity with type checking.
+///
+/// Takes `properties` and validates them against the entity's type schema.
+/// If validation succeeds, creates a new [`Entity`] with generated UUID.
+///
+/// # Arguments
+///
+/// * `type_id` - Entity type defining the schema
+/// * `properties` - Key-value pairs for entity properties
+/// * `web_id` - Web this entity belongs to
+///
+/// # Errors
+///
+/// - [`ValidationError`] if properties don't match schema
+/// - [`TypeNotFound`] if entity type doesn't exist
+/// - [`DatabaseError`] if storage operation fails
+///
+/// # Examples
+///
+/// ```rust
+/// # use hash_graph::entity::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let store = create_test_store();
+/// # let type_id = EntityTypeId::new();
+/// # let web_id = WebId::new();
+/// let properties = vec![
+///     ("name".to_string(), "Example".into()),
+///     ("status".to_string(), "active".into()),
+/// ];
+///
+/// let entity_id = store.create_entity(
+///     type_id,
+///     properties,
+///     web_id,
+/// )?;
+///
+/// let entity = store.get_entity(entity_id)?;
+/// assert_eq!(entity.get_property("name"), Some(&"Example".into()));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`ValidationError`]: EntityError::Validation
+/// [`TypeNotFound`]: EntityError::TypeNotFound
+/// [`DatabaseError`]: EntityError::Database
+pub fn create_entity(
+    &mut self,
+    type_id: EntityTypeId,
+    properties: Vec<(String, Value)>,
+    web_id: WebId,
+) -> Result<EntityId, Report<EntityError>> {
+```
+
+---
+
+## Related
+
+- [function-documentation.md](function-documentation.md) - Function docs
+- [error-documentation.md](error-documentation.md) - Error docs
+- [type-documentation.md](type-documentation.md) - Type docs
+- [SKILL.md](../SKILL.md) - Overview

--- a/components/skills/lang-rust-docs-dev/references/function-documentation.md
+++ b/components/skills/lang-rust-docs-dev/references/function-documentation.md
@@ -1,0 +1,277 @@
+# Function Documentation Guide
+
+Complete guide for documenting functions and methods in Rust.
+
+---
+
+## Documentation Structure
+
+Every public function must have a doc comment with:
+
+1. **Single-line summary** - What the function does
+2. **Detailed description** - How it behaves
+3. **Parameter descriptions** - Inline (simple) or explicit (complex)
+4. **Return value** - Described in main text
+5. **Error conditions** - `# Errors` section if fallible
+6. **Examples** - `# Examples` section for public APIs
+
+---
+
+## Single-Line Summary
+
+Begin every doc comment with a clear, action-oriented summary:
+
+✅ **Good summaries:**
+
+```rust
+/// Retrieves an entity by its UUID.
+/// Creates a new web in the system.
+/// Processes the input elements and returns filtered results.
+```
+
+❌ **Bad summaries:**
+
+```rust
+/// This function gets an entity  // "This function" is redundant
+/// Entity getter                  // Too vague
+/// Gets entity                    // Missing "the" or article
+```
+
+---
+
+## Parameter Documentation
+
+### Simple Functions (0-2 parameters)
+
+Describe parameters **inline** in the main description:
+
+```rust
+/// Processes the `input` elements and returns a filtered collection.
+///
+/// Takes a collection of `input` elements, applies the `filter_fn` predicate
+/// to each, and returns a [`Vec`] containing only the elements that passed
+/// the filter condition.
+pub fn process<T, F>(input: &[T], filter_fn: F) -> Vec<T>
+where
+    F: Fn(&T) -> bool,
+{
+```
+
+### Complex Functions (3+ parameters)
+
+Use explicit `# Arguments` section with bullet points:
+
+```rust
+/// Merges multiple data sources and applies transformation rules.
+///
+/// This function combines data from various sources, applies the specified
+/// transformation rules, and returns a unified data structure.
+///
+/// # Arguments
+///
+/// * `sources` - Collection of data sources to merge
+/// * `rules` - Transformation rules to apply during merging
+/// * `options` - Configuration options controlling the merge behavior
+/// * `callback` - Optional function called for each merged item
+/// * `context` - Additional context passed to transformation rules
+```
+
+---
+
+## Return Value Documentation
+
+**Always** describe return values in the main description, **not** in a separate section:
+
+✅ **Good:**
+
+```rust
+/// Retrieves an entity by its UUID.
+///
+/// Loads the entity from the store and verifies access permissions.
+/// Returns the [`Entity`] object if found and accessible.
+pub fn get_entity(&self, id: EntityId) -> Result<Entity, Report<EntityError>> {
+```
+
+❌ **Bad:**
+
+```rust
+/// Retrieves an entity by its UUID.
+///
+/// # Returns
+///
+/// The entity if found  // Don't use separate Returns section
+```
+
+---
+
+## Async Function Documentation
+
+Document concurrency considerations when relevant:
+
+```rust
+/// Processes the entity asynchronously.
+///
+/// Fetches entity data, validates it, and stores the result. The operation
+/// runs concurrently with other async tasks but maintains consistency
+/// guarantees through database transactions.
+///
+/// # Concurrency
+///
+/// This function spawns multiple tasks to process entity attributes in
+/// parallel. It should be called from a multi-threaded runtime context.
+///
+/// # Errors
+///
+/// - [`ValidationError`] if entity data is invalid
+/// - [`DatabaseError`] if storage operation fails
+pub async fn process_entity(&self, id: EntityId) -> Result<(), Report<ProcessError>> {
+```
+
+---
+
+## When to Skip Documentation
+
+**Skip documentation for:**
+
+- Standard trait implementations (`Debug`, `Display`, `From`, `Into`)
+- Trait-derived methods (unless special behavior)
+- Private helper functions (optional)
+- Obvious getters/setters
+
+```rust
+// Good: No docs needed
+impl Debug for MyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // implementation
+    }
+}
+
+// Good: No docs needed
+impl From<MyType> for String {
+    fn from(value: MyType) -> Self {
+        value.to_string()
+    }
+}
+```
+
+**Document trait implementations only when:**
+
+- Special behavior beyond trait definition
+- Performance considerations
+- Different failure modes
+- Additional functionality
+
+```rust
+// Good: Documentation needed for special behavior
+/// Custom serialization supporting legacy v1 format.
+///
+/// This implementation handles both current schema and deprecated v1
+/// for backward compatibility with older data.
+impl Serialize for ComplexType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // special implementation
+    }
+}
+```
+
+---
+
+## Performance Documentation
+
+Add `# Performance` sections for performance-critical functions:
+
+```rust
+/// Retrieves all entities matching the filter.
+///
+/// # Performance
+///
+/// This operation has O(n) complexity where n is the number of entities
+/// matching the filter. For large result sets, consider using the streaming
+/// version [`get_entities_stream`] instead.
+///
+/// [`get_entities_stream`]: Self::get_entities_stream
+```
+
+**When to document performance:**
+
+- Processing variable-sized inputs
+- Hot path functions
+- Complex algorithms (non-obvious complexity)
+- Public APIs with performance guarantees
+- Resource-intensive operations
+- Operations with tradeoffs
+
+**When to skip:**
+
+- Obvious characteristics (simple getters/setters)
+- Internal implementation details
+- Standard library usage with no special patterns
+- Non-performance-sensitive code
+
+---
+
+## Complete Example
+
+```rust
+/// Validates and creates a new entity in the system.
+///
+/// Takes the provided `properties` and validates them against the entity's
+/// type schema. If validation succeeds, creates a new [`Entity`] with a
+/// generated UUID and stores it in the database. Returns the created entity's
+/// ID.
+///
+/// # Arguments
+///
+/// * `type_id` - The entity type defining the schema
+/// * `properties` - Key-value pairs for entity properties
+/// * `web_id` - The web this entity belongs to
+/// * `account` - Account creating the entity (for permissions)
+///
+/// # Errors
+///
+/// - [`ValidationError`] if properties don't match schema
+/// - [`TypeNotFound`] if entity type doesn't exist
+/// - [`AuthorizationError`] if account lacks permission
+/// - [`DatabaseError`] if storage operation fails
+///
+/// # Examples
+///
+/// ```rust
+/// # use hash_graph::entity::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let properties = vec![
+///     ("name".to_string(), "Example".into()),
+///     ("description".to_string(), "An example entity".into()),
+/// ];
+///
+/// let entity_id = store.create_entity(
+///     type_id,
+///     properties,
+///     web_id,
+///     account,
+/// )?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`ValidationError`]: EntityError::Validation
+/// [`TypeNotFound`]: EntityError::TypeNotFound
+/// [`AuthorizationError`]: EntityError::Authorization
+/// [`DatabaseError`]: EntityError::Database
+pub fn create_entity(
+    &mut self,
+    type_id: EntityTypeId,
+    properties: Vec<(String, Value)>,
+    web_id: WebId,
+    account: &Account,
+) -> Result<EntityId, Report<EntityError>> {
+```
+
+---
+
+## Related
+
+- [error-documentation.md](error-documentation.md) - Documenting errors
+- [examples-and-links.md](examples-and-links.md) - Examples and links
+- [type-documentation.md](type-documentation.md) - Types and traits
+- [SKILL.md](../SKILL.md) - Overview

--- a/components/skills/lang-rust-docs-dev/references/type-documentation.md
+++ b/components/skills/lang-rust-docs-dev/references/type-documentation.md
@@ -1,0 +1,268 @@
+# Type Documentation Guide
+
+Complete guide for documenting types, structs, enums, and traits in Rust.
+
+---
+
+## Struct Documentation
+
+### Basic Structure
+
+```rust
+/// Unique identifier for an entity in the system.
+///
+/// Combines entity UUID and web ID for precise references across the API.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EntityId {
+    pub entity_uuid: EntityUuid,
+    pub web_id: WebId,
+}
+```
+
+### When to Document Fields
+
+✅ **Document when field purpose is NOT obvious:**
+
+```rust
+pub struct EntityQuery {
+    /// Maximum number of results to return (default: 100)
+    pub limit: Option<usize>,
+
+    /// Include deleted entities in results
+    pub include_deleted: bool,
+}
+```
+
+❌ **Don't document obvious fields:**
+
+```rust
+pub struct User {
+    pub id: UserId,        // ID is obvious
+    pub name: String,      // name is obvious
+    pub email: String,     // email is obvious
+}
+```
+
+---
+
+## Enum Documentation
+
+### Document WHY, not WHAT
+
+✅ **Good - explains purpose:**
+
+```rust
+/// Entity lifecycle state.
+///
+/// Controls validation rules and access permissions at each stage.
+pub enum EntityState {
+    Draft,      // No docs needed - obvious
+    Published,
+    Archived,
+    Deleted,
+}
+```
+
+❌ **Bad - restates the obvious:**
+
+```rust
+pub enum EntityState {
+    /// The draft state        // Redundant
+    Draft,
+    /// The published state    // Redundant
+    Published,
+}
+```
+
+### When Variants Need Docs
+
+Document variants only when they:
+
+- Have non-obvious behavior
+- Affect system state in special ways
+- Have constraints or invariants
+
+```rust
+pub enum CacheStrategy {
+    /// Never cache (always fetch fresh)
+    None,
+
+    /// Cache with TTL expiration
+    Timed { seconds: u64 },
+
+    /// Cache until explicitly invalidated
+    Persistent,
+
+    /// Adaptive caching based on access patterns (experimental)
+    Adaptive,
+}
+```
+
+---
+
+## Trait Documentation
+
+Focus on contract and guarantees, not restating method signatures:
+
+```rust
+/// Store for entity data with transactional guarantees.
+///
+/// All operations are atomic and maintain consistency even under
+/// concurrent access.
+pub trait EntityStore: Send + Sync {
+    /// Retrieves entity if it exists and caller has access.
+    ///
+    /// # Errors
+    ///
+    /// - [`NotFound`] if entity doesn't exist
+    /// - [`AccessDenied`] if caller lacks permission
+    ///
+    /// [`NotFound`]: StoreError::NotFound
+    /// [`AccessDenied`]: StoreError::AccessDenied
+    fn get_entity(&self, id: EntityId) -> Result<Entity, Report<StoreError>>;
+}
+```
+
+---
+
+## Newtype Pattern
+
+Document invariants and guarantees, not the wrapping itself:
+
+✅ **Good - explains guarantees:**
+
+```rust
+/// Non-empty string validated at construction.
+///
+/// Guaranteed to contain at least one non-whitespace character.
+#[derive(Debug, Clone)]
+pub struct NonEmptyString(String);
+```
+
+❌ **Bad - states the obvious:**
+
+```rust
+/// A string wrapper
+pub struct NonEmptyString(String);
+```
+
+---
+
+## Generic Types
+
+Document constraints and behavior, not type parameters themselves:
+
+```rust
+/// LRU cache with configurable eviction.
+///
+/// Evicts least-recently-used items when capacity is reached.
+/// All operations are O(1) amortized.
+pub struct LruCache<K, V>
+where
+    K: Hash + Eq,
+{
+    // fields...
+}
+```
+
+---
+
+## Complex Types
+
+Add sections only when behavior is non-obvious:
+
+```rust
+/// Temporal entity with complete version history.
+///
+/// # Version Storage
+///
+/// Versions are stored as deltas from previous state for space efficiency.
+/// Full reconstruction requires replaying deltas (O(n) where n = versions).
+///
+/// # Querying
+///
+/// - `current()` - O(1), returns latest version
+/// - `at_time(t)` - O(log n + m), binary search + delta replay
+///
+/// For frequent historical queries, use snapshot API instead.
+pub struct TemporalEntity {
+    // fields...
+}
+```
+
+---
+
+## What NOT to Document
+
+**Skip documentation for:**
+
+1. **Obvious structs:**
+
+   ```rust
+   struct Point { x: f64, y: f64 }  // No docs needed
+   ```
+
+2. **Standard trait implementations:**
+
+   ```rust
+   impl Debug for MyType { ... }    // No docs needed
+   impl From<A> for B { ... }       // No docs needed
+   ```
+
+3. **Self-explanatory type aliases:**
+
+   ```rust
+   type Result<T> = std::result::Result<T, Error>;  // No docs needed
+   ```
+
+4. **Obvious field names:**
+
+   ```rust
+   struct User {
+       pub id: UserId,     // Don't document
+       pub name: String,   // Don't document
+   }
+   ```
+
+---
+
+## When TO Document
+
+Document when:
+
+1. **Non-obvious invariants:**
+
+   ```rust
+   /// Validated email address (RFC 5322 compliant)
+   pub struct Email(String);
+   ```
+
+2. **Performance characteristics:**
+
+   ```rust
+   /// Sorted vector with O(log n) lookup
+   pub struct SortedVec<T>(Vec<T>);
+   ```
+
+3. **Special behavior:**
+
+   ```rust
+   /// Cache that prefetches adjacent keys on miss
+   pub struct PredictiveCache<K, V> { ... }
+   ```
+
+4. **Complex state machines:**
+
+   ```rust
+   /// Connection state. Transitions: Idle -> Active -> Closing -> Closed
+   pub enum ConnectionState { ... }
+   ```
+
+---
+
+## Related
+
+- [function-documentation.md](function-documentation.md) - Functions and methods
+- [error-documentation.md](error-documentation.md) - Error types
+- [examples-and-links.md](examples-and-links.md) - Examples and links
+- [SKILL.md](../SKILL.md) - Overview

--- a/components/skills/lang-rust-memory-eng/SKILL.md
+++ b/components/skills/lang-rust-memory-eng/SKILL.md
@@ -1,0 +1,604 @@
+---
+name: memory-safety-patterns
+description: Implement memory-safe programming with RAII, ownership, smart pointers, and resource management across Rust, C++, and C. Use when writing safe systems code, managing resources, or preventing memory bugs.
+---
+
+# Memory Safety Patterns
+
+Cross-language patterns for memory-safe programming including RAII, ownership, smart pointers, and resource management.
+
+## When to Use This Skill
+
+- Writing memory-safe systems code
+- Managing resources (files, sockets, memory)
+- Preventing use-after-free and leaks
+- Implementing RAII patterns
+- Choosing between languages for safety
+- Debugging memory issues
+
+## Core Concepts
+
+### 1. Memory Bug Categories
+
+| Bug Type | Description | Prevention |
+|----------|-------------|------------|
+| **Use-after-free** | Access freed memory | Ownership, RAII |
+| **Double-free** | Free same memory twice | Smart pointers |
+| **Memory leak** | Never free memory | RAII, GC |
+| **Buffer overflow** | Write past buffer end | Bounds checking |
+| **Dangling pointer** | Pointer to freed memory | Lifetime tracking |
+| **Data race** | Concurrent unsynchronized access | Ownership, Sync |
+
+### 2. Safety Spectrum
+
+```
+Manual (C) → Smart Pointers (C++) → Ownership (Rust) → GC (Go, Java)
+Less safe                                              More safe
+More control                                           Less control
+```
+
+## Patterns by Language
+
+### Pattern 1: RAII in C++
+
+```cpp
+// RAII: Resource Acquisition Is Initialization
+// Resource lifetime tied to object lifetime
+
+#include <memory>
+#include <fstream>
+#include <mutex>
+
+// File handle with RAII
+class FileHandle {
+public:
+    explicit FileHandle(const std::string& path)
+        : file_(path) {
+        if (!file_.is_open()) {
+            throw std::runtime_error("Failed to open file");
+        }
+    }
+
+    // Destructor automatically closes file
+    ~FileHandle() = default; // fstream closes in its destructor
+
+    // Delete copy (prevent double-close)
+    FileHandle(const FileHandle&) = delete;
+    FileHandle& operator=(const FileHandle&) = delete;
+
+    // Allow move
+    FileHandle(FileHandle&&) = default;
+    FileHandle& operator=(FileHandle&&) = default;
+
+    void write(const std::string& data) {
+        file_ << data;
+    }
+
+private:
+    std::fstream file_;
+};
+
+// Lock guard (RAII for mutexes)
+class Database {
+public:
+    void update(const std::string& key, const std::string& value) {
+        std::lock_guard<std::mutex> lock(mutex_); // Released on scope exit
+        data_[key] = value;
+    }
+
+    std::string get(const std::string& key) {
+        std::shared_lock<std::shared_mutex> lock(shared_mutex_);
+        return data_[key];
+    }
+
+private:
+    std::mutex mutex_;
+    std::shared_mutex shared_mutex_;
+    std::map<std::string, std::string> data_;
+};
+
+// Transaction with rollback (RAII)
+template<typename T>
+class Transaction {
+public:
+    explicit Transaction(T& target)
+        : target_(target), backup_(target), committed_(false) {}
+
+    ~Transaction() {
+        if (!committed_) {
+            target_ = backup_; // Rollback
+        }
+    }
+
+    void commit() { committed_ = true; }
+
+    T& get() { return target_; }
+
+private:
+    T& target_;
+    T backup_;
+    bool committed_;
+};
+```
+
+### Pattern 2: Smart Pointers in C++
+
+```cpp
+#include <memory>
+
+// unique_ptr: Single ownership
+class Engine {
+public:
+    void start() { /* ... */ }
+};
+
+class Car {
+public:
+    Car() : engine_(std::make_unique<Engine>()) {}
+
+    void start() {
+        engine_->start();
+    }
+
+    // Transfer ownership
+    std::unique_ptr<Engine> extractEngine() {
+        return std::move(engine_);
+    }
+
+private:
+    std::unique_ptr<Engine> engine_;
+};
+
+// shared_ptr: Shared ownership
+class Node {
+public:
+    std::string data;
+    std::shared_ptr<Node> next;
+
+    // Use weak_ptr to break cycles
+    std::weak_ptr<Node> parent;
+};
+
+void sharedPtrExample() {
+    auto node1 = std::make_shared<Node>();
+    auto node2 = std::make_shared<Node>();
+
+    node1->next = node2;
+    node2->parent = node1; // Weak reference prevents cycle
+
+    // Access weak_ptr
+    if (auto parent = node2->parent.lock()) {
+        // parent is valid shared_ptr
+    }
+}
+
+// Custom deleter for resources
+class Socket {
+public:
+    static void close(int* fd) {
+        if (fd && *fd >= 0) {
+            ::close(*fd);
+            delete fd;
+        }
+    }
+};
+
+auto createSocket() {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    return std::unique_ptr<int, decltype(&Socket::close)>(
+        new int(fd),
+        &Socket::close
+    );
+}
+
+// make_unique/make_shared best practices
+void bestPractices() {
+    // Good: Exception safe, single allocation
+    auto ptr = std::make_shared<Widget>();
+
+    // Bad: Two allocations, not exception safe
+    std::shared_ptr<Widget> ptr2(new Widget());
+
+    // For arrays
+    auto arr = std::make_unique<int[]>(10);
+}
+```
+
+### Pattern 3: Ownership in Rust
+
+```rust
+// Move semantics (default)
+fn move_example() {
+    let s1 = String::from("hello");
+    let s2 = s1; // s1 is MOVED, no longer valid
+
+    // println!("{}", s1); // Compile error!
+    println!("{}", s2);
+}
+
+// Borrowing (references)
+fn borrow_example() {
+    let s = String::from("hello");
+
+    // Immutable borrow (multiple allowed)
+    let len = calculate_length(&s);
+    println!("{} has length {}", s, len);
+
+    // Mutable borrow (only one allowed)
+    let mut s = String::from("hello");
+    change(&mut s);
+}
+
+fn calculate_length(s: &String) -> usize {
+    s.len()
+} // s goes out of scope, but doesn't drop since borrowed
+
+fn change(s: &mut String) {
+    s.push_str(", world");
+}
+
+// Lifetimes: Compiler tracks reference validity
+fn longest<'a>(x: &'a str, y: &'a str) -> &'a str {
+    if x.len() > y.len() { x } else { y }
+}
+
+// Struct with references needs lifetime annotation
+struct ImportantExcerpt<'a> {
+    part: &'a str,
+}
+
+impl<'a> ImportantExcerpt<'a> {
+    fn level(&self) -> i32 {
+        3
+    }
+
+    // Lifetime elision: compiler infers 'a for &self
+    fn announce_and_return_part(&self, announcement: &str) -> &str {
+        println!("Attention: {}", announcement);
+        self.part
+    }
+}
+
+// Interior mutability
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+struct Stats {
+    count: Cell<i32>,           // Copy types
+    data: RefCell<Vec<String>>, // Non-Copy types
+}
+
+impl Stats {
+    fn increment(&self) {
+        self.count.set(self.count.get() + 1);
+    }
+
+    fn add_data(&self, item: String) {
+        self.data.borrow_mut().push(item);
+    }
+}
+
+// Rc for shared ownership (single-threaded)
+fn rc_example() {
+    let data = Rc::new(vec![1, 2, 3]);
+    let data2 = Rc::clone(&data); // Increment reference count
+
+    println!("Count: {}", Rc::strong_count(&data)); // 2
+}
+
+// Arc for shared ownership (thread-safe)
+use std::sync::Arc;
+use std::thread;
+
+fn arc_example() {
+    let data = Arc::new(vec![1, 2, 3]);
+
+    let handles: Vec<_> = (0..3)
+        .map(|_| {
+            let data = Arc::clone(&data);
+            thread::spawn(move || {
+                println!("{:?}", data);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+```
+
+### Pattern 4: Safe Resource Management in C
+
+```c
+// C doesn't have RAII, but we can use patterns
+
+#include <stdlib.h>
+#include <stdio.h>
+
+// Pattern: goto cleanup
+int process_file(const char* path) {
+    FILE* file = NULL;
+    char* buffer = NULL;
+    int result = -1;
+
+    file = fopen(path, "r");
+    if (!file) {
+        goto cleanup;
+    }
+
+    buffer = malloc(1024);
+    if (!buffer) {
+        goto cleanup;
+    }
+
+    // Process file...
+    result = 0;
+
+cleanup:
+    if (buffer) free(buffer);
+    if (file) fclose(file);
+    return result;
+}
+
+// Pattern: Opaque pointer with create/destroy
+typedef struct Context Context;
+
+Context* context_create(void);
+void context_destroy(Context* ctx);
+int context_process(Context* ctx, const char* data);
+
+// Implementation
+struct Context {
+    int* data;
+    size_t size;
+    FILE* log;
+};
+
+Context* context_create(void) {
+    Context* ctx = calloc(1, sizeof(Context));
+    if (!ctx) return NULL;
+
+    ctx->data = malloc(100 * sizeof(int));
+    if (!ctx->data) {
+        free(ctx);
+        return NULL;
+    }
+
+    ctx->log = fopen("log.txt", "w");
+    if (!ctx->log) {
+        free(ctx->data);
+        free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+void context_destroy(Context* ctx) {
+    if (ctx) {
+        if (ctx->log) fclose(ctx->log);
+        if (ctx->data) free(ctx->data);
+        free(ctx);
+    }
+}
+
+// Pattern: Cleanup attribute (GCC/Clang extension)
+#define AUTO_FREE __attribute__((cleanup(auto_free_func)))
+
+void auto_free_func(void** ptr) {
+    free(*ptr);
+}
+
+void auto_free_example(void) {
+    AUTO_FREE char* buffer = malloc(1024);
+    // buffer automatically freed at end of scope
+}
+```
+
+### Pattern 5: Bounds Checking
+
+```cpp
+// C++: Use containers instead of raw arrays
+#include <vector>
+#include <array>
+#include <span>
+
+void safe_array_access() {
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+
+    // Safe: throws std::out_of_range
+    try {
+        int val = vec.at(10);
+    } catch (const std::out_of_range& e) {
+        // Handle error
+    }
+
+    // Unsafe but faster (no bounds check)
+    int val = vec[2];
+
+    // Modern C++20: std::span for array views
+    std::span<int> view(vec);
+    // Iterators are bounds-safe
+    for (int& x : view) {
+        x *= 2;
+    }
+}
+
+// Fixed-size arrays
+void fixed_array() {
+    std::array<int, 5> arr = {1, 2, 3, 4, 5};
+
+    // Compile-time size known
+    static_assert(arr.size() == 5);
+
+    // Safe access
+    int val = arr.at(2);
+}
+```
+
+```rust
+// Rust: Bounds checking by default
+
+fn rust_bounds_checking() {
+    let vec = vec![1, 2, 3, 4, 5];
+
+    // Runtime bounds check (panics if out of bounds)
+    let val = vec[2];
+
+    // Explicit option (no panic)
+    match vec.get(10) {
+        Some(val) => println!("Got {}", val),
+        None => println!("Index out of bounds"),
+    }
+
+    // Iterators (no bounds checking needed)
+    for val in &vec {
+        println!("{}", val);
+    }
+
+    // Slices are bounds-checked
+    let slice = &vec[1..3]; // [2, 3]
+}
+```
+
+### Pattern 6: Preventing Data Races
+
+```cpp
+// C++: Thread-safe shared state
+#include <mutex>
+#include <shared_mutex>
+#include <atomic>
+
+class ThreadSafeCounter {
+public:
+    void increment() {
+        // Atomic operations
+        count_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    int get() const {
+        return count_.load(std::memory_order_relaxed);
+    }
+
+private:
+    std::atomic<int> count_{0};
+};
+
+class ThreadSafeMap {
+public:
+    void write(const std::string& key, int value) {
+        std::unique_lock lock(mutex_);
+        data_[key] = value;
+    }
+
+    std::optional<int> read(const std::string& key) {
+        std::shared_lock lock(mutex_);
+        auto it = data_.find(key);
+        if (it != data_.end()) {
+            return it->second;
+        }
+        return std::nullopt;
+    }
+
+private:
+    mutable std::shared_mutex mutex_;
+    std::map<std::string, int> data_;
+};
+```
+
+```rust
+// Rust: Data race prevention at compile time
+
+use std::sync::{Arc, Mutex, RwLock};
+use std::sync::atomic::{AtomicI32, Ordering};
+use std::thread;
+
+// Atomic for simple types
+fn atomic_example() {
+    let counter = Arc::new(AtomicI32::new(0));
+
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let counter = Arc::clone(&counter);
+            thread::spawn(move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    println!("Counter: {}", counter.load(Ordering::SeqCst));
+}
+
+// Mutex for complex types
+fn mutex_example() {
+    let data = Arc::new(Mutex::new(vec![]));
+
+    let handles: Vec<_> = (0..10)
+        .map(|i| {
+            let data = Arc::clone(&data);
+            thread::spawn(move || {
+                let mut vec = data.lock().unwrap();
+                vec.push(i);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}
+
+// RwLock for read-heavy workloads
+fn rwlock_example() {
+    let data = Arc::new(RwLock::new(HashMap::new()));
+
+    // Multiple readers OK
+    let read_guard = data.read().unwrap();
+
+    // Writer blocks readers
+    let write_guard = data.write().unwrap();
+}
+```
+
+## Best Practices
+
+### Do's
+- **Prefer RAII** - Tie resource lifetime to scope
+- **Use smart pointers** - Avoid raw pointers in C++
+- **Understand ownership** - Know who owns what
+- **Check bounds** - Use safe access methods
+- **Use tools** - AddressSanitizer, Valgrind, Miri
+
+### Don'ts
+- **Don't use raw pointers** - Unless interfacing with C
+- **Don't return local references** - Dangling pointer
+- **Don't ignore compiler warnings** - They catch bugs
+- **Don't use `unsafe` carelessly** - In Rust, minimize it
+- **Don't assume thread safety** - Be explicit
+
+## Debugging Tools
+
+```bash
+# AddressSanitizer (Clang/GCC)
+clang++ -fsanitize=address -g source.cpp
+
+# Valgrind
+valgrind --leak-check=full ./program
+
+# Rust Miri (undefined behavior detector)
+cargo +nightly miri run
+
+# ThreadSanitizer
+clang++ -fsanitize=thread -g source.cpp
+```
+
+## Resources
+
+- [C++ Core Guidelines](https://isocpp.github.io/CppCoreGuidelines/)
+- [Rust Ownership](https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html)
+- [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)

--- a/components/skills/lang-rust-profiling-eng/SKILL.md
+++ b/components/skills/lang-rust-profiling-eng/SKILL.md
@@ -1,0 +1,480 @@
+---
+name: profiling
+description: Profile code performance using callgrind and valgrind with nextest integration for analyzing instruction counts, cache behavior, and identifying bottlenecks
+---
+
+# Profiling with Valgrind, Callgrind, and Nextest
+
+The facet project has pre-configured valgrind integration for debugging crashes, memory leaks, and performance profiling.
+
+## Quick Usage
+
+```bash
+# Run test under valgrind (memory errors + leaks)
+cargo nextest run --profile valgrind -p PACKAGE TEST_FILTER
+
+# Run test under callgrind (profiling)
+valgrind --tool=callgrind --callgrind-out-file=callgrind.out \
+  cargo nextest run --no-fail-fast -p PACKAGE TEST_FILTER
+
+# Analyze callgrind output
+callgrind_annotate callgrind.out
+# or with GUI
+kcachegrind callgrind.out  # Linux
+qcachegrind callgrind.out  # macOS
+```
+
+## Nextest Valgrind Profile
+
+The project has a pre-configured valgrind profile in `.config/nextest.toml`:
+
+### Configuration
+
+```toml
+[scripts.wrapper.valgrind]
+# Leak checking configuration
+command = 'valgrind --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,indirect --error-exitcode=1'
+
+[profile.valgrind]
+# Apply to all tests on Linux
+platform = 'cfg(target_os = "linux")'
+filter = 'all()'
+run-wrapper = 'valgrind'
+```
+
+**What it does:**
+- `--leak-check=full` - Show details for each leak
+- `--show-leak-kinds=all` - Show all leak types for diagnostics
+- `--errors-for-leak-kinds=definite,indirect` - Only fail on real leaks (not "still reachable")
+- `--error-exitcode=1` - Exit with code 1 if errors found
+
+### Usage
+
+```bash
+# Run specific test
+cargo nextest run --profile valgrind -p facet-format-json test_simple_struct
+
+# Run all tests in a file
+cargo nextest run --profile valgrind -p facet-format-json --test jit_deserialize
+
+# Run with filter
+cargo nextest run --profile valgrind -p facet-json booleans
+```
+
+**Benefits:**
+- ✅ Automatic configuration - no manual valgrind commands
+- ✅ Consistent flags across team
+- ✅ Integrated with nextest filtering
+- ✅ Clean, formatted output
+
+## Profiling with Callgrind
+
+Callgrind is a valgrind tool for profiling instruction counts and function call graphs.
+
+### Basic Profiling
+
+```bash
+# Profile a specific test
+valgrind --tool=callgrind \
+  --callgrind-out-file=callgrind.out \
+  cargo nextest run --no-fail-fast -p PACKAGE TEST_NAME
+
+# Analyze output
+callgrind_annotate callgrind.out
+```
+
+### Advanced Options
+
+```bash
+# Collect cache simulation data (slower but more detailed)
+valgrind --tool=callgrind \
+  --cache-sim=yes \
+  --branch-sim=yes \
+  --callgrind-out-file=callgrind.out \
+  cargo nextest run --no-fail-fast -p PACKAGE TEST_NAME
+
+# Focus on specific function
+valgrind --tool=callgrind \
+  --toggle-collect=main \
+  --callgrind-out-file=callgrind.out \
+  cargo nextest run --no-fail-fast -p PACKAGE TEST_NAME
+
+# Compress output (can get large)
+valgrind --tool=callgrind \
+  --compress-strings=yes \
+  --compress-pos=yes \
+  --callgrind-out-file=callgrind.out.gz \
+  cargo nextest run --no-fail-fast -p PACKAGE TEST_NAME
+```
+
+### Analyzing Callgrind Output
+
+#### Command Line (callgrind_annotate)
+
+```bash
+# Full report
+callgrind_annotate callgrind.out
+
+# Focus on specific functions
+callgrind_annotate --include='facet::' callgrind.out
+
+# Show only top functions
+callgrind_annotate --auto=yes --threshold=1 callgrind.out
+
+# Compare two runs
+callgrind_annotate --diff callgrind.old.out callgrind.new.out
+```
+
+**Reading the output:**
+```
+Ir                                     # Instruction reads (total)
+I1mr                                   # L1 instruction cache misses
+ILmr                                   # Last-level instruction cache misses
+Dr                                     # Data reads
+Dw                                     # Data writes
+D1mr, D1mw                            # L1 data cache read/write misses
+DLmr, DLmw                            # Last-level data cache read/write misses
+
+--------------------------------------------------------------------------------
+Ir               file:function
+--------------------------------------------------------------------------------
+1,234,567 (45%)  facet_format_json::deserialize
+  987,654 (35%)  facet_format::parse_value
+  ...
+```
+
+#### GUI (KCachegrind/QCachegrind)
+
+Install:
+```bash
+# Linux
+sudo apt install kcachegrind
+
+# macOS
+brew install qcachegrind
+
+# Windows (WSL)
+sudo apt install kcachegrind
+```
+
+Launch:
+```bash
+kcachegrind callgrind.out   # Linux
+qcachegrind callgrind.out   # macOS
+```
+
+**GUI features:**
+- Call graph visualization
+- Flamegraph-like views
+- Source code annotation (if debug symbols available)
+- Caller/callee relationships
+- Multiple metrics (instructions, cache misses, branches)
+
+## Profiling Benchmarks
+
+The generated benchmark tests (from `benchmarks.kdl`) can be profiled:
+
+### 1. As Tests (Recommended for Callgrind)
+
+```bash
+# Profile a benchmark test under callgrind
+valgrind --tool=callgrind \
+  --callgrind-out-file=callgrind_simple_struct.out \
+  cargo nextest run --profile valgrind -p facet-json test_simple_struct
+
+# Analyze
+callgrind_annotate callgrind_simple_struct.out
+```
+
+**Why use tests:**
+- Single iteration = cleaner callgrind output
+- No benchmark harness overhead
+- Easier to focus on hot path
+- Faster to run
+
+### 2. As Benchmarks (For Realistic Instruction Counts)
+
+The benchmark harness (gungraun) already uses valgrind internally:
+
+```bash
+# Run gungraun benchmark (uses callgrind automatically)
+cargo bench --bench unified_benchmarks_gungraun --features jit simple_struct
+
+# Check output in bench-reports/gungraun-*.txt
+```
+
+**gungraun automatically collects:**
+- Instructions executed
+- Estimated cycles
+- L1/LL cache hits
+- RAM hits
+- Total read/write operations
+
+This data appears in `bench-reports/perf/RESULTS.md`.
+
+## Common Profiling Workflows
+
+### Debug a Crash
+
+```bash
+# 1. Run under valgrind to find memory error
+cargo nextest run --profile valgrind -p PACKAGE TEST_NAME
+
+# 2. Read valgrind output for exact error location
+# Example: "Invalid read of size 8 at 0x123456"
+
+# 3. Fix the bug
+
+# 4. Verify fix
+cargo nextest run -p PACKAGE TEST_NAME
+```
+
+### Find Performance Bottleneck
+
+```bash
+# 1. Profile with callgrind
+valgrind --tool=callgrind \
+  --callgrind-out-file=profile.out \
+  cargo nextest run --no-fail-fast -p facet-json test_booleans
+
+# 2. Analyze
+callgrind_annotate --auto=yes profile.out | head -30
+
+# 3. Identify hot functions (high instruction counts)
+
+# 4. Optimize hot functions
+
+# 5. Re-profile and compare
+valgrind --tool=callgrind \
+  --callgrind-out-file=profile_after.out \
+  cargo nextest run --no-fail-fast -p facet-json test_booleans
+
+callgrind_annotate --diff profile.out profile_after.out
+```
+
+### Optimize Tier-2 JIT
+
+```bash
+# 1. Check RESULTS.md for slow benchmarks
+grep "⚠" bench-reports/perf/RESULTS.md
+
+# 2. Profile the slow benchmark test
+valgrind --tool=callgrind \
+  --callgrind-out-file=jit_profile.out \
+  cargo nextest run --profile valgrind -p facet-json test_long_strings --features jit
+
+# 3. Analyze with GUI for visual call graph
+kcachegrind jit_profile.out
+
+# 4. Look for:
+#    - Helper function calls in tight loops
+#    - Redundant alignment checks
+#    - Allocation hot spots
+
+# 5. Optimize based on findings
+
+# 6. Verify with benchmarks
+cargo xtask bench long_strings
+```
+
+### Compare Before/After Optimization
+
+```bash
+# Before
+git checkout main
+valgrind --tool=callgrind --callgrind-out-file=before.out \
+  cargo nextest run --no-fail-fast -p facet-json test_target
+
+# After
+git checkout my-optimization-branch
+valgrind --tool=callgrind --callgrind-out-file=after.out \
+  cargo nextest run --no-fail-fast -p facet-json test_target
+
+# Compare
+callgrind_annotate --diff before.out after.out
+```
+
+## Interpreting Valgrind Output
+
+### Memory Error Example
+
+```
+==12345== Invalid read of size 8
+==12345==    at 0x123456: facet_format_json::parse_number (parse.rs:42)
+==12345==    by 0x234567: facet_format_json::deserialize (lib.rs:123)
+==12345==  Address 0x789abc is 0 bytes after a block of size 16 alloc'd
+==12345==    at 0x345678: alloc (alloc.rs:88)
+==12345==    by 0x456789: Vec::push (vec.rs:1234)
+```
+
+**Translation:**
+- Reading 8 bytes from invalid address
+- Happened in `parse_number` at line 42
+- Address is just past end of 16-byte allocation
+- **Fix:** Check bounds before reading, or fix off-by-one error
+
+### Leak Example
+
+```
+==12345== 128 bytes in 1 blocks are definitely lost in loss record 1 of 10
+==12345==    at 0x123456: malloc (vg_replace_malloc.c:299)
+==12345==    by 0x234567: alloc (alloc.rs:88)
+==12345==    by 0x345678: Box::new (boxed.rs:123)
+==12345==    by 0x456789: setup_jit (jit.rs:456)
+```
+
+**Translation:**
+- 128 bytes allocated but never freed
+- Allocated in `setup_jit` function
+- **Fix:** Ensure cleanup/Drop implementation
+
+### Cachegrind Output Example
+
+```
+Ir               I1mr  ILmr  Dr        D1mr   DLmr   Dw        D1mw   DLmw
+--------------------------------------------------------------------------------
+1,234,567        123   45    456,789   234    12     123,456   67     8   facet::deserialize
+  987,654        98    32    345,678   189    9      98,765    43     5   - facet::parse_value
+  234,567        23    10    98,765    45     2      23,456    12     1   - facet::parse_string
+```
+
+**Key metrics:**
+- `Ir` - Instructions executed (most important for optimization)
+- `D1mr/D1mw` - L1 data cache misses (indicates poor locality)
+- `DLmr/DLmw` - Last-level cache misses (very expensive)
+
+**Optimization targets:**
+1. High `Ir` count = time-consuming function
+2. High `D1mr` = poor data locality, consider restructuring
+3. High `DLmr` = main memory accesses, critical to optimize
+
+## Profiling Flags
+
+### Valgrind (Memory Debugging)
+
+```bash
+--leak-check=full          # Detailed leak info
+--show-leak-kinds=all      # Show all leak types
+--track-origins=yes        # Track uninitialized values (slower)
+--verbose                  # More diagnostic info
+--log-file=valgrind.log    # Save output to file
+```
+
+### Callgrind (Profiling)
+
+```bash
+--callgrind-out-file=FILE  # Output file (default: callgrind.out.<pid>)
+--cache-sim=yes            # Simulate cache behavior
+--branch-sim=yes           # Simulate branch prediction
+--collect-jumps=yes        # Collect jump information
+--dump-instr=yes           # Dump instruction info
+--compress-strings=yes     # Compress output (smaller files)
+```
+
+### Cargo Nextest
+
+```bash
+--no-fail-fast            # Continue running after first failure
+--profile valgrind        # Use valgrind profile from nextest.toml
+--test-threads=1          # Run single-threaded (better for profiling)
+```
+
+## Tips and Tricks
+
+### Speed Up Profiling
+
+1. **Profile in release mode** (but keep debug symbols):
+   ```bash
+   # Add to Cargo.toml
+   [profile.release]
+   debug = true
+   ```
+
+2. **Use `--no-fail-fast` to avoid stopping early**
+
+3. **Filter to specific tests** - don't profile everything at once
+
+4. **Disable address randomization** for reproducible runs:
+   ```bash
+   setarch $(uname -m) -R valgrind --tool=callgrind ...
+   ```
+
+### Read Callgrind Data Programmatically
+
+```python
+# Example: Parse callgrind output for automation
+def parse_callgrind(filename):
+    import re
+    costs = {}
+    with open(filename) as f:
+        for line in f:
+            if m := re.match(r'(\d+)\s+(.+)', line):
+                cost, func = m.groups()
+                costs[func] = int(cost)
+    return costs
+
+# Compare two profiles
+before = parse_callgrind('before.out')
+after = parse_callgrind('after.out')
+
+for func in before:
+    if func in after:
+        delta = after[func] - before[func]
+        percent = (delta / before[func]) * 100
+        if abs(percent) > 5:  # More than 5% change
+            print(f"{func}: {percent:+.1f}% ({delta:+,} instructions)")
+```
+
+## Don't Do This
+
+❌ Run valgrind without nextest profile - inconsistent flags
+❌ Profile debug builds - too slow and unrepresentative
+❌ Ignore "still reachable" leaks in FFI code - sometimes OK
+❌ Profile with multiple test threads - non-deterministic results
+❌ Forget to clean between profiling runs - stale data
+
+## Do This Instead
+
+✅ Use `--profile valgrind` for memory debugging
+✅ Use callgrind for performance profiling
+✅ Profile release builds with debug symbols
+✅ Focus on hot paths (high `Ir` counts)
+✅ Compare before/after with `--diff`
+✅ Use GUI tools (kcachegrind) for complex call graphs
+
+## Files and Locations
+
+```
+.config/nextest.toml         # Valgrind profile configuration
+callgrind.out.*              # Callgrind output files (gitignored)
+bench-reports/gungraun-*.txt # Gungraun output (includes instruction counts)
+```
+
+## Troubleshooting
+
+### Valgrind complains about "unrecognized instruction"
+- Update valgrind: `sudo apt update && sudo apt install valgrind`
+- Or use `--vex-iropt-register-updates=allregs-at-mem-access`
+
+### Callgrind output is huge
+- Use `--compress-strings=yes --compress-pos=yes`
+- Or filter to specific functions with `--toggle-collect=function_name`
+
+### Profile doesn't match benchmark results
+- Ensure you're profiling the same code path
+- Check if JIT compilation is cached (use setup functions in gungraun)
+- Profile release build, not debug
+
+### Can't open callgrind file in GUI
+- Check file permissions
+- Ensure file isn't corrupted (run `callgrind_annotate` first)
+- Try different viewer (kcachegrind vs qcachegrind)
+
+## See Also
+
+- Valgrind manual: https://valgrind.org/docs/manual/manual.html
+- Callgrind manual: https://valgrind.org/docs/manual/cl-manual.html
+- Nextest wrapper scripts: https://nexte.st/docs/configuration/wrapper-scripts/
+- KCachegrind handbook: https://docs.kde.org/stable5/en/kcachegrind/
+- Project nextest config: `.config/nextest.toml`
+- Benchmark debugging: See `benchmarking.md`

--- a/components/skills/lang-rust-valgrind-ops/SKILL.md
+++ b/components/skills/lang-rust-valgrind-ops/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: debug-with-valgrind
+description: Debug crashes, segfaults, and memory errors using valgrind integration with nextest through pre-configured profiles
+---
+
+# Debugging with Valgrind + Nextest
+
+When you encounter crashes, segfaults, or memory errors in tests, use valgrind for proper debugging.
+
+## Quick Usage
+
+```bash
+# Run a specific test under valgrind
+cargo nextest run --profile valgrind -p PACKAGE --test TEST_FILE TEST_NAME
+
+# Example
+cargo nextest run --profile valgrind -p facet-format-json --test jit_deserialize test_jit_option_some
+```
+
+## How It Works
+
+The project has valgrind pre-configured in `.config/nextest.toml`:
+
+1. **Wrapper script**: Defined as `[scripts.wrapper.valgrind]`
+   - Command: `valgrind --leak-check=full --show-leak-kinds=all ...`
+   - Automatically wraps test execution
+
+2. **Profile**: `[profile.valgrind]` applies the wrapper to all tests on Linux
+
+3. **Running**: Use `--profile valgrind` flag with nextest
+
+## Benefits
+
+- ✅ **Automatic setup** - no manual valgrind commands needed
+- ✅ **Proper configuration** - leak checking, error codes pre-configured
+- ✅ **Integrated** - works with nextest filtering and test selection
+- ✅ **Clean output** - nextest captures and formats valgrind output
+
+## Don't Do This
+
+❌ Running valgrind manually: `valgrind ./target/debug/deps/test-binary`
+❌ Using raw `--no-run` + valgrind commands
+❌ Playing hunt-the-segfault without proper tools
+
+## Do This Instead
+
+✅ Use the pre-configured profile: `cargo nextest run --profile valgrind <filters>`
+✅ Let nextest handle the wrapper script integration
+✅ Get clean, actionable valgrind output immediately
+
+## Debugging Workflow
+
+1. Test crashes with SIGSEGV
+2. Run: `cargo nextest run --profile valgrind -p PACKAGE --test FILE TEST_NAME`
+3. Valgrind shows exact line where invalid read/write occurs
+4. Fix the bug
+5. Verify with regular tests
+
+## See Also
+
+- Nextest wrapper scripts docs: https://nexte.st/docs/configuration/wrapper-scripts/
+- Project nextest config: `.config/nextest.toml`


### PR DESCRIPTION
## Summary

- Add 7 Rust language skills from external registries
- Skills cover development, engineering, and operations focus levels
- Includes reference materials for cargo and documentation skills

Closes #47

## Skills Added

| Skill | Focus | Source |
|-------|-------|--------|
| lang-rust-memory-eng | eng | wshobson/agents |
| lang-rust-cargo-dev | dev | hashintel/hash |
| lang-rust-docs-dev | dev | hashintel/hash |
| lang-rust-crates-dev | dev | hashintel/hash |
| lang-rust-profiling-eng | eng | facet-rs/facet |
| lang-rust-benchmarking-eng | eng | facet-rs/facet |
| lang-rust-valgrind-ops | ops | facet-rs/facet |

## Test plan

- [ ] Verify all SKILL.md files are valid
- [ ] Run `just validate-skill <skill>` for each
- [ ] Confirm reference files are included where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)