### PR TITLE
feat(skills): expand iac-terraform-modules-eng with 40+ providers

### DIFF
--- a/components/skills/iac-terraform-modules-eng/SKILL.md
+++ b/components/skills/iac-terraform-modules-eng/SKILL.md
@@ -1,22 +1,29 @@
 ---
 name: iac-terraform-modules-eng
-description: Build reusable Terraform modules for AWS, Azure, and GCP infrastructure following infrastructure-as-code best practices. Use when creating infrastructure modules, standardizing cloud provisioning, or implementing reusable IaC components.
+description: Build reusable Terraform modules and provider configurations for multi-cloud infrastructure, Kubernetes, CI/CD, databases, networking, security, observability, and virtualization. Use when creating infrastructure modules, standardizing provisioning, or implementing IaC patterns across 40+ Terraform providers.
 ---
 
 # Terraform Module Library
 
-Production-ready Terraform module patterns for AWS, Azure, and GCP infrastructure.
+Production-ready Terraform module patterns for multi-cloud infrastructure and 40+ providers including AWS, Azure, GCP, Kubernetes, Cloudflare, Vault, Grafana, and more.
 
 ## Purpose
 
-Create reusable, well-tested Terraform modules for common cloud infrastructure patterns across multiple cloud providers.
+Create reusable, well-tested Terraform modules for common infrastructure patterns across cloud providers, SaaS platforms, and on-premises virtualization.
 
 ## When to Use
 
-- Build reusable infrastructure components
-- Standardize cloud resource provisioning
-- Implement infrastructure as code best practices
-- Create multi-cloud compatible modules
+- Build reusable infrastructure components for AWS, Azure, GCP
+- Configure Kubernetes clusters with Helm, Talos, or managed services
+- Set up CI/CD pipelines with GitHub, GitLab, or Buildkite
+- Manage databases: MongoDB Atlas, CockroachDB, Elastic, Pinecone
+- Configure networking: Cloudflare, DNS, CDN, VPN (ZeroTier)
+- Implement secrets management with HashiCorp Vault
+- Deploy to PaaS platforms: Vercel, Heroku, DigitalOcean, Linode, Vultr
+- Configure observability with Grafana stack
+- Manage on-premises infrastructure: vSphere, VMC, Proxmox
+- Orchestrate workflows with Ansible, Kestra, or Prefect
+- Implement feature flags with Flagsmith
 - Establish organizational Terraform standards
 
 ## Module Structure
@@ -59,19 +66,39 @@ module-name/
 
 **main.tf:**
 ```hcl
+locals {
+  nat_gateway_count = var.create_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.availability_zones)) : 0
+}
+
 resource "aws_vpc" "main" {
   cidr_block           = var.cidr_block
   enable_dns_hostnames = var.enable_dns_hostnames
   enable_dns_support   = var.enable_dns_support
 
   tags = merge(
+    { Name = var.name },
+    var.tags
+  )
+}
+
+# Public Subnets
+resource "aws_subnet" "public" {
+  count                   = length(var.public_subnet_cidrs)
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(
     {
-      Name = var.name
+      Name = "${var.name}-public-${count.index + 1}"
+      Tier = "public"
     },
     var.tags
   )
 }
 
+# Private Subnets
 resource "aws_subnet" "private" {
   count             = length(var.private_subnet_cidrs)
   vpc_id            = aws_vpc.main.id
@@ -87,16 +114,86 @@ resource "aws_subnet" "private" {
   )
 }
 
+# Internet Gateway
 resource "aws_internet_gateway" "main" {
   count  = var.create_internet_gateway ? 1 : 0
   vpc_id = aws_vpc.main.id
 
   tags = merge(
-    {
-      Name = "${var.name}-igw"
-    },
+    { Name = "${var.name}-igw" },
     var.tags
   )
+}
+
+# Elastic IPs for NAT Gateways
+resource "aws_eip" "nat" {
+  count  = local.nat_gateway_count
+  domain = "vpc"
+
+  tags = merge(
+    { Name = "${var.name}-nat-eip-${count.index + 1}" },
+    var.tags
+  )
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# NAT Gateways
+resource "aws_nat_gateway" "main" {
+  count         = local.nat_gateway_count
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(
+    { Name = "${var.name}-nat-${count.index + 1}" },
+    var.tags
+  )
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Public Route Table
+resource "aws_route_table" "public" {
+  count  = var.create_internet_gateway ? 1 : 0
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main[0].id
+  }
+
+  tags = merge(
+    { Name = "${var.name}-public-rt" },
+    var.tags
+  )
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnet_cidrs)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public[0].id
+}
+
+# Private Route Tables (one per NAT Gateway)
+resource "aws_route_table" "private" {
+  count  = local.nat_gateway_count > 0 ? length(var.private_subnet_cidrs) : 0
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main[var.single_nat_gateway ? 0 : count.index].id
+  }
+
+  tags = merge(
+    { Name = "${var.name}-private-rt-${count.index + 1}" },
+    var.tags
+  )
+}
+
+resource "aws_route_table_association" "private" {
+  count          = local.nat_gateway_count > 0 ? length(var.private_subnet_cidrs) : 0
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
 }
 ```
 
@@ -121,6 +218,12 @@ variable "availability_zones" {
   type        = list(string)
 }
 
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets"
+  type        = list(string)
+  default     = []
+}
+
 variable "private_subnet_cidrs" {
   description = "CIDR blocks for private subnets"
   type        = list(string)
@@ -133,10 +236,48 @@ variable "enable_dns_hostnames" {
   default     = true
 }
 
+variable "enable_dns_support" {
+  description = "Enable DNS support in VPC"
+  type        = bool
+  default     = true
+}
+
+variable "create_internet_gateway" {
+  description = "Create an Internet Gateway for public subnets"
+  type        = bool
+  default     = true
+}
+
+variable "create_nat_gateway" {
+  description = "Create NAT Gateway(s) for private subnets"
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway for all AZs (cost savings)"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "Additional tags"
   type        = map(string)
   default     = {}
+}
+```
+
+**versions.tf:**
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
 }
 ```
 
@@ -147,14 +288,39 @@ output "vpc_id" {
   value       = aws_vpc.main.id
 }
 
+output "vpc_cidr_block" {
+  description = "CIDR block of VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of public subnets"
+  value       = aws_subnet.public[*].id
+}
+
 output "private_subnet_ids" {
   description = "IDs of private subnets"
   value       = aws_subnet.private[*].id
 }
 
-output "vpc_cidr_block" {
-  description = "CIDR block of VPC"
-  value       = aws_vpc.main.cidr_block
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway"
+  value       = try(aws_internet_gateway.main[0].id, null)
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of NAT Gateways"
+  value       = aws_nat_gateway.main[*].id
+}
+
+output "public_route_table_id" {
+  description = "ID of public route table"
+  value       = try(aws_route_table.public[0].id, null)
+}
+
+output "private_route_table_ids" {
+  description = "IDs of private route tables"
+  value       = aws_route_table.private[*].id
 }
 ```
 
@@ -181,11 +347,20 @@ module "vpc" {
   cidr_block         = "10.0.0.0/16"
   availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
 
-  private_subnet_cidrs = [
+  public_subnet_cidrs = [
     "10.0.1.0/24",
     "10.0.2.0/24",
     "10.0.3.0/24"
   ]
+
+  private_subnet_cidrs = [
+    "10.0.11.0/24",
+    "10.0.12.0/24",
+    "10.0.13.0/24"
+  ]
+
+  create_nat_gateway = true
+  single_nat_gateway = false  # HA: one NAT per AZ
 
   tags = {
     Environment = "production"
@@ -198,7 +373,7 @@ module "rds" {
 
   identifier     = "production-db"
   engine         = "postgres"
-  engine_version = "15.3"
+  engine_version = "15.4"
   instance_class = "db.t3.large"
 
   vpc_id     = module.vpc.vpc_id
@@ -208,15 +383,67 @@ module "rds" {
     Environment = "production"
   }
 }
+
+module "eks" {
+  source = "../../modules/aws/eks"
+
+  cluster_name    = "production"
+  cluster_version = "1.29"
+
+  vpc_id          = module.vpc.vpc_id
+  subnet_ids      = module.vpc.private_subnet_ids
+
+  node_groups = {
+    default = {
+      instance_types = ["t3.large"]
+      min_size       = 2
+      max_size       = 10
+      desired_size   = 3
+    }
+  }
+
+  tags = {
+    Environment = "production"
+  }
+}
 ```
 
 ## Reference Files
 
-- `assets/vpc-module/` - Complete VPC module example
-- `assets/rds-module/` - RDS module example
-- `references/aws-modules.md` - AWS module patterns
-- `references/azure-modules.md` - Azure module patterns
-- `references/gcp-modules.md` - GCP module patterns
+### Cloud Providers
+- `references/aws-modules.md` - AWS module patterns (VPC, EKS, RDS, S3, ALB, Lambda)
+- `references/azure-modules.md` - Azure module patterns (VNet, AKS, SQL, Storage)
+- `references/gcp-modules.md` - GCP module patterns (VPC, GKE, Cloud SQL, Cloud Run)
+
+### CI/CD & Version Control
+- `references/cicd-providers.md` - GitHub, GitLab, Buildkite provider patterns
+
+### Kubernetes & Containers
+- `references/kubernetes-providers.md` - Kubernetes, Helm, Talos, Coder provider patterns
+
+### Databases & Data
+- `references/database-providers.md` - MongoDB Atlas, CockroachDB, Elastic, Pinecone, Atlas, Airbyte patterns
+
+### Networking & CDN
+- `references/networking-providers.md` - Cloudflare, DNS, NS1, ZeroTier, Fastly, Akamai patterns
+
+### Security
+- `references/security-providers.md` - HashiCorp Vault, TLS provider patterns
+
+### Utility Providers
+- `references/utility-providers.md` - Template, Time, Local, HTTP provider patterns
+
+### Orchestration & Feature Flags
+- `references/orchestration-providers.md` - Ansible AAP, Kestra, Prefect, Flagsmith patterns
+
+### Observability
+- `references/observability-providers.md` - Grafana, Grafana Cloud, Synthetic Monitoring, Adaptive Metrics
+
+### Platform as a Service
+- `references/platform-providers.md` - Vercel, Heroku, DigitalOcean, Linode, Vultr patterns
+
+### Virtualization
+- `references/virtualization-providers.md` - vSphere, VMware Cloud, Proxmox patterns
 
 ## Testing
 

--- a/components/skills/iac-terraform-modules-eng/references/aws-modules.md
+++ b/components/skills/iac-terraform-modules-eng/references/aws-modules.md
@@ -1,63 +1,348 @@
 # AWS Terraform Module Patterns
 
 ## VPC Module
+
+### Resources
 - VPC with public/private subnets
 - Internet Gateway and NAT Gateways
 - Route tables and associations
 - Network ACLs
 - VPC Flow Logs
 
+### Common Variables
+```hcl
+variable "enable_flow_logs" {
+  description = "Enable VPC Flow Logs"
+  type        = bool
+  default     = true
+}
+
+variable "flow_log_destination_type" {
+  description = "Type of destination for flow logs (cloud-watch-logs, s3)"
+  type        = string
+  default     = "cloud-watch-logs"
+}
+```
+
+### Security Considerations
+- Enable VPC Flow Logs for network monitoring
+- Use private subnets for databases and internal services
+- Restrict default security group rules
+
+---
+
 ## EKS Module
+
+### Resources
 - EKS cluster with managed node groups
 - IRSA (IAM Roles for Service Accounts)
 - Cluster autoscaler
 - VPC CNI configuration
 - Cluster logging
 
+### Common Variables
+```hcl
+variable "cluster_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Enable private API endpoint"
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Enable public API endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "node_groups" {
+  description = "Map of node group configurations"
+  type = map(object({
+    instance_types = list(string)
+    min_size       = number
+    max_size       = number
+    desired_size   = number
+    disk_size      = optional(number, 50)
+    labels         = optional(map(string), {})
+    taints         = optional(list(object({
+      key    = string
+      value  = string
+      effect = string
+    })), [])
+  }))
+}
+```
+
+### Security Considerations
+- Use private endpoint access only in production
+- Enable secrets encryption with KMS
+- Implement Pod Security Standards
+- Use IRSA instead of node instance profiles
+
+---
+
 ## RDS Module
-- RDS instance or cluster
+
+### Resources
+- RDS instance or Aurora cluster
 - Automated backups
 - Read replicas
 - Parameter groups
 - Subnet groups
 - Security groups
 
+### Common Variables
+```hcl
+variable "engine" {
+  description = "Database engine (postgres, mysql, mariadb)"
+  type        = string
+}
+
+variable "engine_version" {
+  description = "Database engine version"
+  type        = string
+}
+
+variable "instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.t3.medium"
+}
+
+variable "allocated_storage" {
+  description = "Storage size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "storage_encrypted" {
+  description = "Enable storage encryption"
+  type        = bool
+  default     = true
+}
+
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment"
+  type        = bool
+  default     = false
+}
+
+variable "backup_retention_period" {
+  description = "Days to retain backups"
+  type        = number
+  default     = 7
+}
+```
+
+### Security Considerations
+- Always enable storage encryption
+- Use Secrets Manager for credentials
+- Enable deletion protection in production
+- Use private subnets only
+
+---
+
 ## S3 Module
+
+### Resources
 - S3 bucket with versioning
-- Encryption at rest
+- Encryption at rest (SSE-S3 or SSE-KMS)
 - Bucket policies
 - Lifecycle rules
 - Replication configuration
 
+### Common Variables
+```hcl
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}
+
+variable "versioning_enabled" {
+  description = "Enable versioning"
+  type        = bool
+  default     = true
+}
+
+variable "encryption_type" {
+  description = "Encryption type (AES256, aws:kms)"
+  type        = string
+  default     = "AES256"
+}
+
+variable "block_public_access" {
+  description = "Block all public access"
+  type        = bool
+  default     = true
+}
+
+variable "lifecycle_rules" {
+  description = "Lifecycle rules for objects"
+  type = list(object({
+    id                       = string
+    enabled                  = bool
+    prefix                   = optional(string, "")
+    expiration_days          = optional(number)
+    noncurrent_expiration_days = optional(number)
+    transition = optional(list(object({
+      days          = number
+      storage_class = string
+    })), [])
+  }))
+  default = []
+}
+```
+
+### Security Considerations
+- Block public access by default
+- Enable versioning for critical data
+- Use KMS encryption for sensitive data
+- Enable access logging
+
+---
+
 ## ALB Module
+
+### Resources
 - Application Load Balancer
 - Target groups
 - Listener rules
 - SSL/TLS certificates
 - Access logs
 
+### Common Variables
+```hcl
+variable "name" {
+  description = "Name of the ALB"
+  type        = string
+}
+
+variable "internal" {
+  description = "Internal or internet-facing"
+  type        = bool
+  default     = false
+}
+
+variable "enable_deletion_protection" {
+  description = "Enable deletion protection"
+  type        = bool
+  default     = true
+}
+
+variable "access_logs_bucket" {
+  description = "S3 bucket for access logs"
+  type        = string
+  default     = null
+}
+
+variable "ssl_policy" {
+  description = "SSL policy for HTTPS listeners"
+  type        = string
+  default     = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+}
+```
+
+---
+
 ## Lambda Module
+
+### Resources
 - Lambda function
 - IAM execution role
 - CloudWatch Logs
 - Environment variables
 - VPC configuration (optional)
 
+### Common Variables
+```hcl
+variable "function_name" {
+  description = "Name of the Lambda function"
+  type        = string
+}
+
+variable "runtime" {
+  description = "Lambda runtime"
+  type        = string
+  default     = "python3.11"
+}
+
+variable "handler" {
+  description = "Function handler"
+  type        = string
+  default     = "main.handler"
+}
+
+variable "memory_size" {
+  description = "Memory in MB"
+  type        = number
+  default     = 128
+}
+
+variable "timeout" {
+  description = "Timeout in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "vpc_config" {
+  description = "VPC configuration"
+  type = object({
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
+  })
+  default = null
+}
+```
+
+---
+
 ## Security Group Module
-- Reusable security group rules
-- Ingress/egress rules
-- Dynamic rule creation
-- Rule descriptions
+
+### Pattern
+```hcl
+variable "rules" {
+  description = "Security group rules"
+  type = list(object({
+    type        = string  # ingress or egress
+    from_port   = number
+    to_port     = number
+    protocol    = string
+    cidr_blocks = optional(list(string))
+    source_security_group_id = optional(string)
+    description = string
+  }))
+}
+
+resource "aws_security_group_rule" "this" {
+  for_each = { for idx, rule in var.rules : idx => rule }
+
+  type                     = each.value.type
+  from_port                = each.value.from_port
+  to_port                  = each.value.to_port
+  protocol                 = each.value.protocol
+  cidr_blocks              = each.value.cidr_blocks
+  source_security_group_id = each.value.source_security_group_id
+  security_group_id        = aws_security_group.this.id
+  description              = each.value.description
+}
+```
+
+---
 
 ## Best Practices
 
-1. Use AWS provider version ~> 5.0
-2. Enable encryption by default
-3. Use least-privilege IAM
-4. Tag all resources consistently
-5. Enable logging and monitoring
-6. Use KMS for encryption
-7. Implement backup strategies
-8. Use PrivateLink when possible
-9. Enable GuardDuty/SecurityHub
-10. Follow AWS Well-Architected Framework
+1. **Use AWS provider version ~> 5.0** - Latest features and security patches
+2. **Enable encryption by default** - S3, RDS, EBS, Secrets Manager
+3. **Use least-privilege IAM** - Specific policies per resource
+4. **Tag all resources consistently** - Cost allocation, ownership
+5. **Enable logging and monitoring** - CloudWatch, VPC Flow Logs
+6. **Use KMS for encryption** - Customer-managed keys for sensitive data
+7. **Implement backup strategies** - RDS snapshots, S3 versioning
+8. **Use PrivateLink when possible** - Keep traffic within AWS
+9. **Enable GuardDuty/SecurityHub** - Threat detection
+10. **Follow AWS Well-Architected Framework** - Reliability, security, cost

--- a/components/skills/iac-terraform-modules-eng/references/azure-modules.md
+++ b/components/skills/iac-terraform-modules-eng/references/azure-modules.md
@@ -1,0 +1,360 @@
+# Azure Terraform Module Patterns
+
+## VNet Module
+
+### Resources
+- Virtual Network with subnets
+- Network Security Groups
+- Route Tables
+- NAT Gateway
+- VNet Peering
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Name of the VNet"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "address_space" {
+  description = "VNet address space"
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
+}
+
+variable "subnets" {
+  description = "Subnet configurations"
+  type = map(object({
+    address_prefixes = list(string)
+    service_endpoints = optional(list(string), [])
+    delegation = optional(object({
+      name    = string
+      actions = list(string)
+    }))
+  }))
+}
+
+variable "enable_nat_gateway" {
+  description = "Enable NAT Gateway for outbound connectivity"
+  type        = bool
+  default     = true
+}
+```
+
+### Example
+```hcl
+resource "azurerm_virtual_network" "main" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  address_space       = var.address_space
+
+  tags = var.tags
+}
+
+resource "azurerm_subnet" "this" {
+  for_each = var.subnets
+
+  name                 = each.key
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = each.value.address_prefixes
+  service_endpoints    = each.value.service_endpoints
+
+  dynamic "delegation" {
+    for_each = each.value.delegation != null ? [each.value.delegation] : []
+    content {
+      name = delegation.value.name
+      service_delegation {
+        name    = delegation.value.name
+        actions = delegation.value.actions
+      }
+    }
+  }
+}
+```
+
+---
+
+## AKS Module
+
+### Resources
+- AKS cluster with node pools
+- Azure AD integration
+- Container Registry integration
+- Network policies
+- Cluster autoscaler
+
+### Common Variables
+```hcl
+variable "cluster_name" {
+  description = "Name of the AKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "default_node_pool" {
+  description = "Default node pool configuration"
+  type = object({
+    name                = string
+    vm_size             = string
+    node_count          = number
+    min_count           = optional(number)
+    max_count           = optional(number)
+    enable_auto_scaling = optional(bool, true)
+    os_disk_size_gb     = optional(number, 50)
+    zones               = optional(list(string), ["1", "2", "3"])
+  })
+}
+
+variable "network_profile" {
+  description = "Network configuration"
+  type = object({
+    network_plugin     = string  # azure or kubenet
+    network_policy     = optional(string, "calico")
+    service_cidr       = string
+    dns_service_ip     = string
+    docker_bridge_cidr = optional(string)
+  })
+}
+
+variable "azure_ad_rbac" {
+  description = "Azure AD RBAC configuration"
+  type = object({
+    managed                = bool
+    admin_group_object_ids = list(string)
+  })
+  default = null
+}
+```
+
+### Security Considerations
+- Enable Azure AD integration
+- Use managed identities
+- Enable network policies (Calico or Azure)
+- Use private cluster endpoint
+- Enable Defender for Containers
+
+---
+
+## Azure SQL Module
+
+### Resources
+- Azure SQL Server
+- Databases
+- Firewall rules
+- Elastic pools
+- Failover groups
+
+### Common Variables
+```hcl
+variable "server_name" {
+  description = "SQL Server name"
+  type        = string
+}
+
+variable "administrator_login" {
+  description = "Admin username"
+  type        = string
+}
+
+variable "databases" {
+  description = "Database configurations"
+  type = map(object({
+    sku_name    = string
+    max_size_gb = number
+    collation   = optional(string, "SQL_Latin1_General_CP1_CI_AS")
+  }))
+}
+
+variable "enable_threat_detection" {
+  description = "Enable Advanced Threat Protection"
+  type        = bool
+  default     = true
+}
+
+variable "minimum_tls_version" {
+  description = "Minimum TLS version"
+  type        = string
+  default     = "1.2"
+}
+```
+
+### Security Considerations
+- Use Azure AD authentication
+- Enable TDE (Transparent Data Encryption)
+- Enable auditing to Log Analytics
+- Use private endpoints
+- Enable Advanced Threat Protection
+
+---
+
+## Storage Account Module
+
+### Resources
+- Storage Account
+- Blob containers
+- File shares
+- Queues
+- Tables
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Storage account name"
+  type        = string
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,24}$", var.name))
+    error_message = "Storage account name must be 3-24 lowercase alphanumeric characters."
+  }
+}
+
+variable "account_tier" {
+  description = "Account tier (Standard or Premium)"
+  type        = string
+  default     = "Standard"
+}
+
+variable "account_replication_type" {
+  description = "Replication type (LRS, GRS, RAGRS, ZRS)"
+  type        = string
+  default     = "GRS"
+}
+
+variable "enable_https_traffic_only" {
+  description = "Force HTTPS"
+  type        = bool
+  default     = true
+}
+
+variable "min_tls_version" {
+  description = "Minimum TLS version"
+  type        = string
+  default     = "TLS1_2"
+}
+
+variable "blob_containers" {
+  description = "Blob container configurations"
+  type = map(object({
+    container_access_type = string  # private, blob, container
+  }))
+  default = {}
+}
+```
+
+### Security Considerations
+- Disable public blob access
+- Use private endpoints
+- Enable soft delete for blobs
+- Enable versioning
+- Use customer-managed keys for encryption
+
+---
+
+## Application Gateway Module
+
+### Resources
+- Application Gateway
+- Backend pools
+- HTTP settings
+- Listeners
+- Routing rules
+- WAF policies
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Application Gateway name"
+  type        = string
+}
+
+variable "sku" {
+  description = "SKU configuration"
+  type = object({
+    name     = string  # Standard_v2, WAF_v2
+    tier     = string
+    capacity = number
+  })
+  default = {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+}
+
+variable "waf_configuration" {
+  description = "WAF configuration"
+  type = object({
+    enabled          = bool
+    firewall_mode    = string  # Detection or Prevention
+    rule_set_type    = string
+    rule_set_version = string
+  })
+  default = {
+    enabled          = true
+    firewall_mode    = "Prevention"
+    rule_set_type    = "OWASP"
+    rule_set_version = "3.2"
+  }
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use AzureRM provider version ~> 3.0** - Latest features
+2. **Use managed identities** - Avoid storing credentials
+3. **Enable diagnostic settings** - Log Analytics workspace
+4. **Use private endpoints** - Keep traffic on Azure backbone
+5. **Enable Azure Defender** - Threat detection
+6. **Use availability zones** - High availability
+7. **Tag all resources** - Cost management, ownership
+8. **Use resource locks** - Prevent accidental deletion
+9. **Enable soft delete** - Recovery options
+10. **Follow Azure Well-Architected Framework**
+
+## Provider Configuration
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = true
+    }
+  }
+}
+```

--- a/components/skills/iac-terraform-modules-eng/references/cicd-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/cicd-providers.md
@@ -1,0 +1,315 @@
+# CI/CD Provider Patterns
+
+## GitHub Provider (integrations/github)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = var.github_owner
+  # Token via GITHUB_TOKEN env var
+}
+```
+
+### Repository Module
+```hcl
+variable "repositories" {
+  description = "Repository configurations"
+  type = map(object({
+    description          = string
+    visibility           = optional(string, "private")
+    has_issues           = optional(bool, true)
+    has_wiki             = optional(bool, false)
+    has_projects         = optional(bool, false)
+    allow_merge_commit   = optional(bool, true)
+    allow_squash_merge   = optional(bool, true)
+    allow_rebase_merge   = optional(bool, false)
+    delete_branch_on_merge = optional(bool, true)
+    auto_init            = optional(bool, true)
+    gitignore_template   = optional(string)
+    license_template     = optional(string)
+    topics               = optional(list(string), [])
+    vulnerability_alerts = optional(bool, true)
+    archive_on_destroy   = optional(bool, true)
+  }))
+}
+
+resource "github_repository" "this" {
+  for_each = var.repositories
+
+  name                   = each.key
+  description            = each.value.description
+  visibility             = each.value.visibility
+  has_issues             = each.value.has_issues
+  has_wiki               = each.value.has_wiki
+  has_projects           = each.value.has_projects
+  allow_merge_commit     = each.value.allow_merge_commit
+  allow_squash_merge     = each.value.allow_squash_merge
+  allow_rebase_merge     = each.value.allow_rebase_merge
+  delete_branch_on_merge = each.value.delete_branch_on_merge
+  auto_init              = each.value.auto_init
+  gitignore_template     = each.value.gitignore_template
+  license_template       = each.value.license_template
+  topics                 = each.value.topics
+  vulnerability_alerts   = each.value.vulnerability_alerts
+  archive_on_destroy     = each.value.archive_on_destroy
+}
+```
+
+### Branch Protection Module
+```hcl
+variable "branch_protections" {
+  description = "Branch protection rules"
+  type = map(object({
+    repository                  = string
+    pattern                     = string
+    enforce_admins              = optional(bool, true)
+    require_signed_commits      = optional(bool, false)
+    required_linear_history     = optional(bool, false)
+    require_conversation_resolution = optional(bool, true)
+    required_status_checks = optional(object({
+      strict   = bool
+      contexts = list(string)
+    }))
+    required_pull_request_reviews = optional(object({
+      dismiss_stale_reviews           = bool
+      require_code_owner_reviews      = bool
+      required_approving_review_count = number
+    }))
+  }))
+}
+
+resource "github_branch_protection" "this" {
+  for_each = var.branch_protections
+
+  repository_id                   = each.value.repository
+  pattern                         = each.value.pattern
+  enforce_admins                  = each.value.enforce_admins
+  require_signed_commits          = each.value.require_signed_commits
+  required_linear_history         = each.value.required_linear_history
+  require_conversation_resolution = each.value.require_conversation_resolution
+
+  dynamic "required_status_checks" {
+    for_each = each.value.required_status_checks != null ? [each.value.required_status_checks] : []
+    content {
+      strict   = required_status_checks.value.strict
+      contexts = required_status_checks.value.contexts
+    }
+  }
+
+  dynamic "required_pull_request_reviews" {
+    for_each = each.value.required_pull_request_reviews != null ? [each.value.required_pull_request_reviews] : []
+    content {
+      dismiss_stale_reviews           = required_pull_request_reviews.value.dismiss_stale_reviews
+      require_code_owner_reviews      = required_pull_request_reviews.value.require_code_owner_reviews
+      required_approving_review_count = required_pull_request_reviews.value.required_approving_review_count
+    }
+  }
+}
+```
+
+### GitHub Actions Secrets
+```hcl
+resource "github_actions_secret" "this" {
+  for_each = var.repository_secrets
+
+  repository      = each.value.repository
+  secret_name     = each.value.name
+  plaintext_value = each.value.value  # Use encrypted_value in production
+}
+
+resource "github_actions_organization_secret" "this" {
+  for_each = var.organization_secrets
+
+  secret_name     = each.key
+  visibility      = each.value.visibility  # all, private, selected
+  plaintext_value = each.value.value
+}
+```
+
+---
+
+## GitLab Provider (gitlabhq/gitlab)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    gitlab = {
+      source  = "gitlabhq/gitlab"
+      version = "~> 16.0"
+    }
+  }
+}
+
+provider "gitlab" {
+  base_url = var.gitlab_url  # Optional for self-hosted
+  # Token via GITLAB_TOKEN env var
+}
+```
+
+### Project Module
+```hcl
+variable "projects" {
+  description = "GitLab project configurations"
+  type = map(object({
+    namespace_id               = number
+    description                = string
+    visibility_level           = optional(string, "private")
+    default_branch             = optional(string, "main")
+    merge_method               = optional(string, "merge")  # merge, rebase_merge, ff
+    squash_option              = optional(string, "default_on")
+    remove_source_branch_after_merge = optional(bool, true)
+    only_allow_merge_if_pipeline_succeeds = optional(bool, true)
+    only_allow_merge_if_all_discussions_are_resolved = optional(bool, true)
+    container_registry_enabled = optional(bool, true)
+    packages_enabled           = optional(bool, true)
+    wiki_enabled               = optional(bool, false)
+    issues_enabled             = optional(bool, true)
+    shared_runners_enabled     = optional(bool, true)
+    topics                     = optional(list(string), [])
+  }))
+}
+
+resource "gitlab_project" "this" {
+  for_each = var.projects
+
+  name                       = each.key
+  namespace_id               = each.value.namespace_id
+  description                = each.value.description
+  visibility_level           = each.value.visibility_level
+  default_branch             = each.value.default_branch
+  merge_method               = each.value.merge_method
+  squash_option              = each.value.squash_option
+  remove_source_branch_after_merge = each.value.remove_source_branch_after_merge
+  only_allow_merge_if_pipeline_succeeds = each.value.only_allow_merge_if_pipeline_succeeds
+  only_allow_merge_if_all_discussions_are_resolved = each.value.only_allow_merge_if_all_discussions_are_resolved
+  container_registry_enabled = each.value.container_registry_enabled
+  packages_enabled           = each.value.packages_enabled
+  wiki_enabled               = each.value.wiki_enabled
+  issues_enabled             = each.value.issues_enabled
+  shared_runners_enabled     = each.value.shared_runners_enabled
+  topics                     = each.value.topics
+}
+```
+
+### GitLab CI/CD Variables
+```hcl
+resource "gitlab_project_variable" "this" {
+  for_each = var.project_variables
+
+  project           = each.value.project
+  key               = each.value.key
+  value             = each.value.value
+  protected         = each.value.protected
+  masked            = each.value.masked
+  environment_scope = each.value.environment_scope
+}
+
+resource "gitlab_group_variable" "this" {
+  for_each = var.group_variables
+
+  group             = each.value.group
+  key               = each.value.key
+  value             = each.value.value
+  protected         = each.value.protected
+  masked            = each.value.masked
+  environment_scope = each.value.environment_scope
+}
+```
+
+---
+
+## Buildkite Provider (buildkite/buildkite)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    buildkite = {
+      source  = "buildkite/buildkite"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "buildkite" {
+  organization = var.buildkite_org
+  # Token via BUILDKITE_API_TOKEN env var
+}
+```
+
+### Pipeline Module
+```hcl
+variable "pipelines" {
+  description = "Buildkite pipeline configurations"
+  type = map(object({
+    repository                     = string
+    description                    = optional(string)
+    default_branch                 = optional(string, "main")
+    branch_configuration           = optional(string)
+    skip_queued_branch_builds      = optional(bool, true)
+    skip_queued_branch_builds_filter = optional(string, "!main")
+    cancel_running_branch_builds   = optional(bool, true)
+    cancel_running_branch_builds_filter = optional(string, "!main")
+    steps                          = string  # YAML pipeline definition
+    cluster_id                     = optional(string)
+    tags                           = optional(list(string), [])
+  }))
+}
+
+resource "buildkite_pipeline" "this" {
+  for_each = var.pipelines
+
+  name                           = each.key
+  repository                     = each.value.repository
+  description                    = each.value.description
+  default_branch                 = each.value.default_branch
+  branch_configuration           = each.value.branch_configuration
+  skip_queued_branch_builds      = each.value.skip_queued_branch_builds
+  skip_queued_branch_builds_filter = each.value.skip_queued_branch_builds_filter
+  cancel_running_branch_builds   = each.value.cancel_running_branch_builds
+  cancel_running_branch_builds_filter = each.value.cancel_running_branch_builds_filter
+  steps                          = each.value.steps
+  cluster_id                     = each.value.cluster_id
+  tags                           = each.value.tags
+}
+```
+
+### Pipeline Schedule
+```hcl
+resource "buildkite_pipeline_schedule" "this" {
+  for_each = var.pipeline_schedules
+
+  pipeline_id = each.value.pipeline_id
+  label       = each.value.label
+  cronline    = each.value.cronline
+  branch      = each.value.branch
+  message     = each.value.message
+  enabled     = each.value.enabled
+  env         = each.value.env
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use environment variables for tokens** - Never hardcode credentials
+2. **Enable branch protection** - Require reviews and status checks
+3. **Use organization/group-level secrets** - Reduce duplication
+4. **Archive instead of delete** - Preserve history
+5. **Enable vulnerability alerts** - Security scanning
+6. **Use CODEOWNERS files** - Automate review assignments
+7. **Configure merge strategies** - Squash for clean history
+8. **Enable required status checks** - Gate on CI passing
+9. **Use project/repo templates** - Standardize configurations
+10. **Implement least-privilege access** - Team-based permissions

--- a/components/skills/iac-terraform-modules-eng/references/database-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/database-providers.md
@@ -1,0 +1,499 @@
+# Database Provider Patterns
+
+## MongoDB Atlas (mongodb/mongodbatlas)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.14"
+    }
+  }
+}
+
+provider "mongodbatlas" {
+  public_key  = var.mongodb_public_key
+  private_key = var.mongodb_private_key
+}
+```
+
+### Cluster Module
+```hcl
+variable "clusters" {
+  description = "MongoDB Atlas cluster configurations"
+  type = map(object({
+    project_id                   = string
+    provider_name                = string  # AWS, GCP, AZURE
+    provider_region_name         = string
+    provider_instance_size_name  = string
+    cluster_type                 = optional(string, "REPLICASET")
+    mongo_db_major_version       = optional(string, "7.0")
+    disk_size_gb                 = optional(number, 10)
+    auto_scaling_disk_gb_enabled = optional(bool, true)
+    auto_scaling_compute_enabled = optional(bool, true)
+    backup_enabled               = optional(bool, true)
+    pit_enabled                  = optional(bool, true)
+    termination_protection_enabled = optional(bool, true)
+  }))
+}
+
+resource "mongodbatlas_cluster" "this" {
+  for_each = var.clusters
+
+  project_id                   = each.value.project_id
+  name                         = each.key
+  provider_name                = each.value.provider_name
+  provider_region_name         = each.value.provider_region_name
+  provider_instance_size_name  = each.value.provider_instance_size_name
+  cluster_type                 = each.value.cluster_type
+  mongo_db_major_version       = each.value.mongo_db_major_version
+  disk_size_gb                 = each.value.disk_size_gb
+  auto_scaling_disk_gb_enabled = each.value.auto_scaling_disk_gb_enabled
+  auto_scaling_compute_enabled = each.value.auto_scaling_compute_enabled
+  backup_enabled               = each.value.backup_enabled
+  pit_enabled                  = each.value.pit_enabled
+  termination_protection_enabled = each.value.termination_protection_enabled
+}
+```
+
+### Database User Module
+```hcl
+resource "mongodbatlas_database_user" "this" {
+  for_each = var.database_users
+
+  project_id         = each.value.project_id
+  username           = each.key
+  password           = each.value.password
+  auth_database_name = "admin"
+
+  dynamic "roles" {
+    for_each = each.value.roles
+    content {
+      role_name       = roles.value.role_name
+      database_name   = roles.value.database_name
+      collection_name = roles.value.collection_name
+    }
+  }
+
+  dynamic "scopes" {
+    for_each = each.value.scopes
+    content {
+      name = scopes.value.name
+      type = scopes.value.type  # CLUSTER, DATA_LAKE
+    }
+  }
+}
+```
+
+---
+
+## CockroachDB (cockroachdb/cockroach)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    cockroach = {
+      source  = "cockroachdb/cockroach"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "cockroach" {
+  # API key via COCKROACH_API_KEY env var
+}
+```
+
+### Cluster Module
+```hcl
+variable "clusters" {
+  description = "CockroachDB cluster configurations"
+  type = map(object({
+    cloud_provider = string  # GCP, AWS, AZURE
+    plan           = string  # BASIC, STANDARD, ADVANCED
+    regions = list(object({
+      name       = string
+      node_count = number
+    }))
+    serverless = optional(object({
+      spend_limit   = number
+      routing_id    = string
+      usage_limits  = optional(object({
+        request_unit_limit = number
+        storage_mib_limit  = number
+      }))
+    }))
+    dedicated = optional(object({
+      machine_type       = string
+      storage_gib        = number
+      disk_iops          = optional(number)
+      memory_gib         = optional(number)
+      num_virtual_cpus   = optional(number)
+    }))
+  }))
+}
+
+resource "cockroach_cluster" "this" {
+  for_each = var.clusters
+
+  name           = each.key
+  cloud_provider = each.value.cloud_provider
+  plan           = each.value.plan
+
+  dynamic "regions" {
+    for_each = each.value.regions
+    content {
+      name       = regions.value.name
+      node_count = regions.value.node_count
+    }
+  }
+
+  dynamic "serverless" {
+    for_each = each.value.serverless != null ? [each.value.serverless] : []
+    content {
+      spend_limit  = serverless.value.spend_limit
+      routing_id   = serverless.value.routing_id
+    }
+  }
+
+  dynamic "dedicated" {
+    for_each = each.value.dedicated != null ? [each.value.dedicated] : []
+    content {
+      machine_type     = dedicated.value.machine_type
+      storage_gib      = dedicated.value.storage_gib
+      disk_iops        = dedicated.value.disk_iops
+      memory_gib       = dedicated.value.memory_gib
+      num_virtual_cpus = dedicated.value.num_virtual_cpus
+    }
+  }
+}
+```
+
+---
+
+## Elastic Stack (elastic/elasticstack)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    elasticstack = {
+      source  = "elastic/elasticstack"
+      version = "~> 0.11"
+    }
+  }
+}
+
+provider "elasticstack" {
+  elasticsearch {
+    endpoints = var.elasticsearch_endpoints
+    username  = var.elasticsearch_username
+    password  = var.elasticsearch_password
+  }
+
+  kibana {
+    endpoints = var.kibana_endpoints
+  }
+}
+```
+
+### Index Lifecycle Policy
+```hcl
+resource "elasticstack_elasticsearch_index_lifecycle" "this" {
+  for_each = var.ilm_policies
+
+  name = each.key
+
+  hot {
+    min_age = each.value.hot_min_age
+    rollover {
+      max_age  = each.value.rollover_max_age
+      max_size = each.value.rollover_max_size
+    }
+    set_priority {
+      priority = 100
+    }
+  }
+
+  warm {
+    min_age = each.value.warm_min_age
+    set_priority {
+      priority = 50
+    }
+    shrink {
+      number_of_shards = 1
+    }
+    forcemerge {
+      max_num_segments = 1
+    }
+  }
+
+  cold {
+    min_age = each.value.cold_min_age
+    set_priority {
+      priority = 0
+    }
+  }
+
+  delete {
+    min_age = each.value.delete_min_age
+    delete {}
+  }
+}
+```
+
+### Index Template
+```hcl
+resource "elasticstack_elasticsearch_index_template" "this" {
+  for_each = var.index_templates
+
+  name           = each.key
+  index_patterns = each.value.index_patterns
+  priority       = each.value.priority
+
+  template {
+    settings = jsonencode({
+      number_of_shards   = each.value.number_of_shards
+      number_of_replicas = each.value.number_of_replicas
+      "index.lifecycle.name" = each.value.ilm_policy
+    })
+
+    mappings = jsonencode(each.value.mappings)
+  }
+}
+```
+
+---
+
+## Pinecone (pinecone-io/pinecone)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    pinecone = {
+      source  = "pinecone-io/pinecone"
+      version = "~> 0.7"
+    }
+  }
+}
+
+provider "pinecone" {
+  # API key via PINECONE_API_KEY env var
+}
+```
+
+### Index Module
+```hcl
+variable "indexes" {
+  description = "Pinecone index configurations"
+  type = map(object({
+    dimension  = number
+    metric     = optional(string, "cosine")  # cosine, euclidean, dotproduct
+    cloud      = optional(string, "aws")
+    region     = optional(string, "us-east-1")
+    spec = object({
+      serverless = optional(object({}))
+      pod = optional(object({
+        environment  = string
+        pod_type     = string
+        pods         = number
+        replicas     = optional(number, 1)
+        shards       = optional(number, 1)
+        metadata_config = optional(object({
+          indexed = list(string)
+        }))
+      }))
+    })
+  }))
+}
+
+resource "pinecone_index" "this" {
+  for_each = var.indexes
+
+  name      = each.key
+  dimension = each.value.dimension
+  metric    = each.value.metric
+
+  spec {
+    dynamic "serverless" {
+      for_each = each.value.spec.serverless != null ? [1] : []
+      content {
+        cloud  = each.value.cloud
+        region = each.value.region
+      }
+    }
+
+    dynamic "pod" {
+      for_each = each.value.spec.pod != null ? [each.value.spec.pod] : []
+      content {
+        environment = pod.value.environment
+        pod_type    = pod.value.pod_type
+        pods        = pod.value.pods
+        replicas    = pod.value.replicas
+        shards      = pod.value.shards
+
+        dynamic "metadata_config" {
+          for_each = pod.value.metadata_config != null ? [pod.value.metadata_config] : []
+          content {
+            indexed = metadata_config.value.indexed
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Atlas (ariga/atlas)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    atlas = {
+      source  = "ariga/atlas"
+      version = "~> 0.4"
+    }
+  }
+}
+
+provider "atlas" {}
+```
+
+### Schema Migration
+```hcl
+resource "atlas_schema" "this" {
+  for_each = var.schemas
+
+  hcl = each.value.hcl
+  url = each.value.database_url
+
+  dev_url = each.value.dev_database_url
+}
+
+# Example HCL schema
+locals {
+  user_schema = <<-EOT
+    table "users" {
+      schema = schema.public
+      column "id" {
+        null = false
+        type = uuid
+        default = sql("gen_random_uuid()")
+      }
+      column "email" {
+        null = false
+        type = varchar(255)
+      }
+      column "created_at" {
+        null = false
+        type = timestamptz
+        default = sql("now()")
+      }
+      primary_key {
+        columns = [column.id]
+      }
+      index "users_email_idx" {
+        unique = true
+        columns = [column.email]
+      }
+    }
+  EOT
+}
+```
+
+---
+
+## Airbyte (airbytehq/airbyte)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    airbyte = {
+      source  = "airbytehq/airbyte"
+      version = "~> 0.5"
+    }
+  }
+}
+
+provider "airbyte" {
+  server_url = var.airbyte_server_url
+  # Bearer token via AIRBYTE_BEARER_TOKEN env var
+}
+```
+
+### Connection Module
+```hcl
+resource "airbyte_source_postgres" "source" {
+  name          = "production-db"
+  workspace_id  = var.workspace_id
+
+  configuration = {
+    host     = var.source_host
+    port     = var.source_port
+    database = var.source_database
+    username = var.source_username
+    password = var.source_password
+    ssl_mode = {
+      mode = "require"
+    }
+    replication_method = {
+      method = "CDC"
+      publication = "airbyte_publication"
+      replication_slot = "airbyte_slot"
+    }
+  }
+}
+
+resource "airbyte_destination_bigquery" "destination" {
+  name          = "analytics-warehouse"
+  workspace_id  = var.workspace_id
+
+  configuration = {
+    project_id  = var.gcp_project_id
+    dataset_id  = var.bigquery_dataset
+    credentials_json = var.gcp_credentials
+    loading_method = {
+      method = "GCS Staging"
+      gcs_bucket_name = var.staging_bucket
+      gcs_bucket_path = "airbyte"
+    }
+  }
+}
+
+resource "airbyte_connection" "this" {
+  name           = "postgres-to-bigquery"
+  source_id      = airbyte_source_postgres.source.source_id
+  destination_id = airbyte_destination_bigquery.destination.destination_id
+
+  schedule = {
+    schedule_type = "cron"
+    cron_expression = "0 0 * * *"
+  }
+
+  namespace_definition = "destination"
+  namespace_format     = "raw_${SOURCE_NAMESPACE}"
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use connection strings from secrets** - Never hardcode credentials
+2. **Enable encryption at rest** - All database providers support this
+3. **Configure automated backups** - Point-in-time recovery
+4. **Use private networking** - VPC peering, Private Link
+5. **Implement connection pooling** - PgBouncer, ProxySQL
+6. **Monitor performance** - Metrics, slow query logs
+7. **Use read replicas** - Offload read traffic
+8. **Plan for scaling** - Auto-scaling, sharding
+9. **Test migrations** - Use dev/staging environments
+10. **Document schema changes** - Version control migrations

--- a/components/skills/iac-terraform-modules-eng/references/gcp-modules.md
+++ b/components/skills/iac-terraform-modules-eng/references/gcp-modules.md
@@ -1,0 +1,468 @@
+# GCP Terraform Module Patterns
+
+## VPC Module
+
+### Resources
+- VPC Network
+- Subnets (regional)
+- Cloud Router
+- Cloud NAT
+- Firewall rules
+- VPC Peering
+
+### Common Variables
+```hcl
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+}
+
+variable "routing_mode" {
+  description = "Network routing mode (GLOBAL or REGIONAL)"
+  type        = string
+  default     = "GLOBAL"
+}
+
+variable "subnets" {
+  description = "Subnet configurations"
+  type = list(object({
+    name          = string
+    ip_cidr_range = string
+    region        = string
+    secondary_ranges = optional(list(object({
+      range_name    = string
+      ip_cidr_range = string
+    })), [])
+    private_google_access = optional(bool, true)
+    flow_logs = optional(object({
+      aggregation_interval = string
+      flow_sampling        = number
+      metadata             = string
+    }))
+  }))
+}
+
+variable "enable_cloud_nat" {
+  description = "Enable Cloud NAT for private instances"
+  type        = bool
+  default     = true
+}
+```
+
+### Example
+```hcl
+resource "google_compute_network" "main" {
+  name                    = var.network_name
+  project                 = var.project_id
+  auto_create_subnetworks = false
+  routing_mode            = var.routing_mode
+}
+
+resource "google_compute_subnetwork" "this" {
+  for_each = { for s in var.subnets : s.name => s }
+
+  name                     = each.value.name
+  project                  = var.project_id
+  region                   = each.value.region
+  network                  = google_compute_network.main.id
+  ip_cidr_range            = each.value.ip_cidr_range
+  private_ip_google_access = each.value.private_google_access
+
+  dynamic "secondary_ip_range" {
+    for_each = each.value.secondary_ranges
+    content {
+      range_name    = secondary_ip_range.value.range_name
+      ip_cidr_range = secondary_ip_range.value.ip_cidr_range
+    }
+  }
+
+  dynamic "log_config" {
+    for_each = each.value.flow_logs != null ? [each.value.flow_logs] : []
+    content {
+      aggregation_interval = log_config.value.aggregation_interval
+      flow_sampling        = log_config.value.flow_sampling
+      metadata             = log_config.value.metadata
+    }
+  }
+}
+
+resource "google_compute_router" "main" {
+  count   = var.enable_cloud_nat ? 1 : 0
+  name    = "${var.network_name}-router"
+  project = var.project_id
+  region  = var.subnets[0].region
+  network = google_compute_network.main.id
+}
+
+resource "google_compute_router_nat" "main" {
+  count                              = var.enable_cloud_nat ? 1 : 0
+  name                               = "${var.network_name}-nat"
+  project                            = var.project_id
+  router                             = google_compute_router.main[0].name
+  region                             = google_compute_router.main[0].region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+```
+
+---
+
+## GKE Module
+
+### Resources
+- GKE cluster (Autopilot or Standard)
+- Node pools
+- Workload Identity
+- Network policies
+- Binary Authorization
+
+### Common Variables
+```hcl
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+}
+
+variable "location" {
+  description = "Cluster location (region or zone)"
+  type        = string
+}
+
+variable "min_master_version" {
+  description = "Minimum Kubernetes version"
+  type        = string
+  default     = "1.29"
+}
+
+variable "enable_autopilot" {
+  description = "Enable Autopilot mode"
+  type        = bool
+  default     = false
+}
+
+variable "node_pools" {
+  description = "Node pool configurations (Standard mode only)"
+  type = map(object({
+    machine_type   = string
+    min_node_count = number
+    max_node_count = number
+    disk_size_gb   = optional(number, 100)
+    disk_type      = optional(string, "pd-standard")
+    preemptible    = optional(bool, false)
+    spot           = optional(bool, false)
+    labels         = optional(map(string), {})
+    taints = optional(list(object({
+      key    = string
+      value  = string
+      effect = string
+    })), [])
+  }))
+  default = {}
+}
+
+variable "master_authorized_networks" {
+  description = "Networks authorized to access master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "enable_private_nodes" {
+  description = "Enable private nodes"
+  type        = bool
+  default     = true
+}
+
+variable "enable_private_endpoint" {
+  description = "Enable private master endpoint"
+  type        = bool
+  default     = false
+}
+```
+
+### Security Considerations
+- Enable Workload Identity
+- Use private clusters
+- Enable Binary Authorization
+- Enable network policies
+- Use Shielded GKE Nodes
+- Enable GKE Dataplane V2
+
+---
+
+## Cloud SQL Module
+
+### Resources
+- Cloud SQL instance
+- Databases
+- Users
+- SSL certificates
+- Replicas
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Instance name"
+  type        = string
+}
+
+variable "database_version" {
+  description = "Database version (POSTGRES_15, MYSQL_8_0)"
+  type        = string
+}
+
+variable "region" {
+  description = "Instance region"
+  type        = string
+}
+
+variable "tier" {
+  description = "Machine tier"
+  type        = string
+  default     = "db-custom-2-4096"
+}
+
+variable "availability_type" {
+  description = "HA type (REGIONAL or ZONAL)"
+  type        = string
+  default     = "REGIONAL"
+}
+
+variable "disk_size" {
+  description = "Disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "disk_autoresize" {
+  description = "Enable disk autoresize"
+  type        = bool
+  default     = true
+}
+
+variable "backup_configuration" {
+  description = "Backup configuration"
+  type = object({
+    enabled                        = bool
+    binary_log_enabled             = optional(bool, false)
+    start_time                     = optional(string, "03:00")
+    point_in_time_recovery_enabled = optional(bool, true)
+    transaction_log_retention_days = optional(number, 7)
+    retained_backups               = optional(number, 7)
+  })
+  default = {
+    enabled = true
+  }
+}
+
+variable "require_ssl" {
+  description = "Require SSL connections"
+  type        = bool
+  default     = true
+}
+```
+
+### Security Considerations
+- Use private IP only
+- Enable SSL/TLS
+- Use Cloud SQL Auth Proxy
+- Enable automated backups
+- Use IAM database authentication
+
+---
+
+## Cloud Storage Module
+
+### Resources
+- Storage bucket
+- Lifecycle rules
+- IAM bindings
+- Versioning
+- Encryption
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Bucket name"
+  type        = string
+}
+
+variable "location" {
+  description = "Bucket location"
+  type        = string
+}
+
+variable "storage_class" {
+  description = "Storage class"
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "versioning" {
+  description = "Enable versioning"
+  type        = bool
+  default     = true
+}
+
+variable "uniform_bucket_level_access" {
+  description = "Enable uniform bucket-level access"
+  type        = bool
+  default     = true
+}
+
+variable "lifecycle_rules" {
+  description = "Lifecycle rules"
+  type = list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                   = optional(number)
+      with_state            = optional(string)
+      num_newer_versions    = optional(number)
+      matches_storage_class = optional(list(string))
+    })
+  }))
+  default = []
+}
+
+variable "encryption_key" {
+  description = "Customer-managed encryption key"
+  type        = string
+  default     = null
+}
+```
+
+### Security Considerations
+- Enable uniform bucket-level access
+- Use customer-managed encryption keys (CMEK)
+- Enable versioning for critical data
+- Use signed URLs for temporary access
+- Enable access logs
+
+---
+
+## Cloud Run Module
+
+### Resources
+- Cloud Run service
+- IAM bindings
+- Domain mappings
+- Traffic splitting
+
+### Common Variables
+```hcl
+variable "name" {
+  description = "Service name"
+  type        = string
+}
+
+variable "location" {
+  description = "Service location"
+  type        = string
+}
+
+variable "image" {
+  description = "Container image"
+  type        = string
+}
+
+variable "port" {
+  description = "Container port"
+  type        = number
+  default     = 8080
+}
+
+variable "cpu" {
+  description = "CPU allocation"
+  type        = string
+  default     = "1000m"
+}
+
+variable "memory" {
+  description = "Memory allocation"
+  type        = string
+  default     = "512Mi"
+}
+
+variable "min_instances" {
+  description = "Minimum instances"
+  type        = number
+  default     = 0
+}
+
+variable "max_instances" {
+  description = "Maximum instances"
+  type        = number
+  default     = 100
+}
+
+variable "allow_unauthenticated" {
+  description = "Allow unauthenticated access"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_connector" {
+  description = "VPC connector for private networking"
+  type        = string
+  default     = null
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use Google provider version ~> 5.0** - Latest features
+2. **Use Workload Identity** - Avoid service account keys
+3. **Enable VPC Service Controls** - Data exfiltration prevention
+4. **Use private networking** - Private Google Access, Private Service Connect
+5. **Enable audit logging** - Cloud Audit Logs
+6. **Use customer-managed encryption keys** - Cloud KMS
+7. **Enable organization policies** - Guardrails
+8. **Use hierarchical firewall policies** - Centralized security
+9. **Enable Security Command Center** - Threat detection
+10. **Follow Google Cloud Architecture Framework**
+
+## Provider Configuration
+
+```hcl
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+```

--- a/components/skills/iac-terraform-modules-eng/references/kubernetes-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/kubernetes-providers.md
@@ -1,0 +1,450 @@
+# Kubernetes & Container Provider Patterns
+
+## Kubernetes Provider (hashicorp/kubernetes)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# Option 1: From kubeconfig
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = var.kube_context
+}
+
+# Option 2: From EKS
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+# Option 3: From GKE
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.cluster.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.cluster.master_auth[0].cluster_ca_certificate)
+}
+```
+
+### Namespace Module
+```hcl
+variable "namespaces" {
+  description = "Namespace configurations"
+  type = map(object({
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+    resource_quota = optional(object({
+      hard = map(string)
+    }))
+    limit_range = optional(object({
+      default_limit   = map(string)
+      default_request = map(string)
+    }))
+  }))
+}
+
+resource "kubernetes_namespace" "this" {
+  for_each = var.namespaces
+
+  metadata {
+    name        = each.key
+    labels      = each.value.labels
+    annotations = each.value.annotations
+  }
+}
+
+resource "kubernetes_resource_quota" "this" {
+  for_each = { for k, v in var.namespaces : k => v if v.resource_quota != null }
+
+  metadata {
+    name      = "${each.key}-quota"
+    namespace = kubernetes_namespace.this[each.key].metadata[0].name
+  }
+
+  spec {
+    hard = each.value.resource_quota.hard
+  }
+}
+
+resource "kubernetes_limit_range" "this" {
+  for_each = { for k, v in var.namespaces : k => v if v.limit_range != null }
+
+  metadata {
+    name      = "${each.key}-limits"
+    namespace = kubernetes_namespace.this[each.key].metadata[0].name
+  }
+
+  spec {
+    limit {
+      type           = "Container"
+      default        = each.value.limit_range.default_limit
+      default_request = each.value.limit_range.default_request
+    }
+  }
+}
+```
+
+### ConfigMap & Secret Module
+```hcl
+resource "kubernetes_config_map" "this" {
+  for_each = var.config_maps
+
+  metadata {
+    name      = each.key
+    namespace = each.value.namespace
+    labels    = each.value.labels
+  }
+
+  data        = each.value.data
+  binary_data = each.value.binary_data
+}
+
+resource "kubernetes_secret" "this" {
+  for_each = var.secrets
+
+  metadata {
+    name      = each.key
+    namespace = each.value.namespace
+    labels    = each.value.labels
+  }
+
+  type = each.value.type  # Opaque, kubernetes.io/tls, etc.
+  data = each.value.data
+}
+```
+
+### Service Account with RBAC
+```hcl
+resource "kubernetes_service_account" "this" {
+  for_each = var.service_accounts
+
+  metadata {
+    name      = each.key
+    namespace = each.value.namespace
+    annotations = each.value.annotations  # For IRSA/Workload Identity
+  }
+}
+
+resource "kubernetes_cluster_role" "this" {
+  for_each = var.cluster_roles
+
+  metadata {
+    name = each.key
+  }
+
+  dynamic "rule" {
+    for_each = each.value.rules
+    content {
+      api_groups = rule.value.api_groups
+      resources  = rule.value.resources
+      verbs      = rule.value.verbs
+    }
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "this" {
+  for_each = var.cluster_role_bindings
+
+  metadata {
+    name = each.key
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = each.value.cluster_role
+  }
+
+  dynamic "subject" {
+    for_each = each.value.subjects
+    content {
+      kind      = subject.value.kind
+      name      = subject.value.name
+      namespace = subject.value.namespace
+    }
+  }
+}
+```
+
+---
+
+## Helm Provider (hashicorp/helm)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+```
+
+### Helm Release Module
+```hcl
+variable "helm_releases" {
+  description = "Helm release configurations"
+  type = map(object({
+    repository       = string
+    chart            = string
+    version          = string
+    namespace        = string
+    create_namespace = optional(bool, true)
+    values           = optional(list(string), [])
+    set              = optional(map(string), {})
+    set_sensitive    = optional(map(string), {})
+    timeout          = optional(number, 300)
+    wait             = optional(bool, true)
+    wait_for_jobs    = optional(bool, false)
+    atomic           = optional(bool, false)
+    cleanup_on_fail  = optional(bool, true)
+    max_history      = optional(number, 10)
+    dependency_update = optional(bool, true)
+  }))
+}
+
+resource "helm_release" "this" {
+  for_each = var.helm_releases
+
+  name             = each.key
+  repository       = each.value.repository
+  chart            = each.value.chart
+  version          = each.value.version
+  namespace        = each.value.namespace
+  create_namespace = each.value.create_namespace
+  timeout          = each.value.timeout
+  wait             = each.value.wait
+  wait_for_jobs    = each.value.wait_for_jobs
+  atomic           = each.value.atomic
+  cleanup_on_fail  = each.value.cleanup_on_fail
+  max_history      = each.value.max_history
+  dependency_update = each.value.dependency_update
+
+  dynamic "set" {
+    for_each = each.value.set
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+
+  dynamic "set_sensitive" {
+    for_each = each.value.set_sensitive
+    content {
+      name  = set_sensitive.key
+      value = set_sensitive.value
+    }
+  }
+
+  values = each.value.values
+}
+```
+
+### Common Helm Charts
+```hcl
+# Ingress NGINX
+resource "helm_release" "ingress_nginx" {
+  name             = "ingress-nginx"
+  repository       = "https://kubernetes.github.io/ingress-nginx"
+  chart            = "ingress-nginx"
+  version          = "4.9.0"
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  set {
+    name  = "controller.replicaCount"
+    value = "2"
+  }
+}
+
+# Cert Manager
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.14.0"
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+}
+
+# External Secrets
+resource "helm_release" "external_secrets" {
+  name             = "external-secrets"
+  repository       = "https://charts.external-secrets.io"
+  chart            = "external-secrets"
+  version          = "0.9.0"
+  namespace        = "external-secrets"
+  create_namespace = true
+}
+```
+
+---
+
+## Talos Provider (siderolabs/talos)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    talos = {
+      source  = "siderolabs/talos"
+      version = "~> 0.5"
+    }
+  }
+}
+
+provider "talos" {}
+```
+
+### Talos Cluster Module
+```hcl
+resource "talos_machine_secrets" "this" {}
+
+data "talos_machine_configuration" "controlplane" {
+  cluster_name     = var.cluster_name
+  machine_type     = "controlplane"
+  cluster_endpoint = var.cluster_endpoint
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+
+  config_patches = [
+    yamlencode({
+      cluster = {
+        network = {
+          cni = {
+            name = "none"  # Use Cilium
+          }
+        }
+      }
+    })
+  ]
+}
+
+data "talos_machine_configuration" "worker" {
+  cluster_name     = var.cluster_name
+  machine_type     = "worker"
+  cluster_endpoint = var.cluster_endpoint
+  machine_secrets  = talos_machine_secrets.this.machine_secrets
+}
+
+resource "talos_machine_configuration_apply" "controlplane" {
+  for_each = var.controlplane_nodes
+
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
+  node                        = each.value.ip
+}
+
+resource "talos_machine_configuration_apply" "worker" {
+  for_each = var.worker_nodes
+
+  client_configuration        = talos_machine_secrets.this.client_configuration
+  machine_configuration_input = data.talos_machine_configuration.worker.machine_configuration
+  node                        = each.value.ip
+}
+
+resource "talos_machine_bootstrap" "this" {
+  depends_on = [talos_machine_configuration_apply.controlplane]
+
+  client_configuration = talos_machine_secrets.this.client_configuration
+  node                 = values(var.controlplane_nodes)[0].ip
+}
+
+data "talos_cluster_kubeconfig" "this" {
+  depends_on = [talos_machine_bootstrap.this]
+
+  client_configuration = talos_machine_secrets.this.client_configuration
+  node                 = values(var.controlplane_nodes)[0].ip
+}
+```
+
+---
+
+## Coder Provider (coder/coder)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "~> 0.12"
+    }
+  }
+}
+
+provider "coder" {
+  url = var.coder_url
+  # Token via CODER_SESSION_TOKEN env var
+}
+```
+
+### Workspace Template
+```hcl
+data "coder_workspace" "me" {}
+
+resource "coder_agent" "main" {
+  os   = "linux"
+  arch = "amd64"
+
+  startup_script = <<-EOT
+    #!/bin/bash
+    # Install development tools
+    sudo apt-get update
+    sudo apt-get install -y git vim
+  EOT
+
+  env = {
+    GIT_AUTHOR_NAME     = data.coder_workspace.me.owner
+    GIT_AUTHOR_EMAIL    = "${data.coder_workspace.me.owner}@example.com"
+    GIT_COMMITTER_NAME  = data.coder_workspace.me.owner
+    GIT_COMMITTER_EMAIL = "${data.coder_workspace.me.owner}@example.com"
+  }
+}
+
+resource "coder_app" "code_server" {
+  agent_id     = coder_agent.main.id
+  slug         = "code-server"
+  display_name = "VS Code"
+  url          = "http://localhost:8080?folder=/home/coder"
+  icon         = "/icon/code.svg"
+  subdomain    = true
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use provider aliases** - Manage multiple clusters
+2. **Pin chart versions** - Reproducible deployments
+3. **Use values files** - Keep configurations in source control
+4. **Enable atomic deploys** - Rollback on failure
+5. **Limit history** - Clean up old releases
+6. **Use namespaces** - Isolation and resource quotas
+7. **Implement RBAC** - Least privilege access
+8. **Use service accounts** - Pod-level permissions
+9. **Configure resource limits** - Prevent resource exhaustion
+10. **Use Helm hooks** - Lifecycle management

--- a/components/skills/iac-terraform-modules-eng/references/networking-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/networking-providers.md
@@ -1,0 +1,687 @@
+# Networking Provider Patterns
+
+## Cloudflare Provider (cloudflare/cloudflare)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  # API token via CLOUDFLARE_API_TOKEN env var
+}
+```
+
+### Zone Module
+```hcl
+variable "zones" {
+  description = "Cloudflare zone configurations"
+  type = map(object({
+    account_id = string
+    plan       = optional(string, "free")  # free, pro, business, enterprise
+    type       = optional(string, "full")  # full, partial
+    jump_start = optional(bool, false)
+  }))
+}
+
+resource "cloudflare_zone" "this" {
+  for_each = var.zones
+
+  zone       = each.key
+  account_id = each.value.account_id
+  plan       = each.value.plan
+  type       = each.value.type
+  jump_start = each.value.jump_start
+}
+```
+
+### DNS Records Module
+```hcl
+variable "dns_records" {
+  description = "DNS record configurations"
+  type = map(object({
+    zone_id  = string
+    name     = string
+    type     = string  # A, AAAA, CNAME, TXT, MX, etc.
+    value    = optional(string)
+    data     = optional(map(string))  # For complex records
+    priority = optional(number)
+    ttl      = optional(number, 1)  # 1 = auto
+    proxied  = optional(bool, false)
+  }))
+}
+
+resource "cloudflare_record" "this" {
+  for_each = var.dns_records
+
+  zone_id  = each.value.zone_id
+  name     = each.value.name
+  type     = each.value.type
+  value    = each.value.value
+  priority = each.value.priority
+  ttl      = each.value.ttl
+  proxied  = each.value.proxied
+
+  dynamic "data" {
+    for_each = each.value.data != null ? [each.value.data] : []
+    content {
+      # SRV, CAA, etc. specific fields
+    }
+  }
+}
+```
+
+### Workers Module
+```hcl
+resource "cloudflare_worker_script" "this" {
+  for_each = var.worker_scripts
+
+  account_id = each.value.account_id
+  name       = each.key
+  content    = each.value.content
+  module     = each.value.module  # ES module format
+
+  dynamic "plain_text_binding" {
+    for_each = each.value.plain_text_bindings
+    content {
+      name = plain_text_binding.key
+      text = plain_text_binding.value
+    }
+  }
+
+  dynamic "secret_text_binding" {
+    for_each = each.value.secret_text_bindings
+    content {
+      name = secret_text_binding.key
+      text = secret_text_binding.value
+    }
+  }
+
+  dynamic "kv_namespace_binding" {
+    for_each = each.value.kv_namespace_bindings
+    content {
+      name         = kv_namespace_binding.key
+      namespace_id = kv_namespace_binding.value
+    }
+  }
+
+  dynamic "r2_bucket_binding" {
+    for_each = each.value.r2_bucket_bindings
+    content {
+      name        = r2_bucket_binding.key
+      bucket_name = r2_bucket_binding.value
+    }
+  }
+}
+
+resource "cloudflare_worker_route" "this" {
+  for_each = var.worker_routes
+
+  zone_id     = each.value.zone_id
+  pattern     = each.value.pattern
+  script_name = each.value.script_name
+}
+```
+
+### Pages Project
+```hcl
+resource "cloudflare_pages_project" "this" {
+  for_each = var.pages_projects
+
+  account_id        = each.value.account_id
+  name              = each.key
+  production_branch = each.value.production_branch
+
+  source {
+    type = "github"
+    config {
+      owner                         = each.value.github_owner
+      repo_name                     = each.value.github_repo
+      production_branch             = each.value.production_branch
+      pr_comments_enabled           = each.value.pr_comments_enabled
+      deployments_enabled           = each.value.deployments_enabled
+      production_deployment_enabled = each.value.production_deployment_enabled
+    }
+  }
+
+  build_config {
+    build_command   = each.value.build_command
+    destination_dir = each.value.destination_dir
+    root_dir        = each.value.root_dir
+  }
+
+  deployment_configs {
+    production {
+      environment_variables = each.value.production_env_vars
+    }
+    preview {
+      environment_variables = each.value.preview_env_vars
+    }
+  }
+}
+```
+
+### Tunnel (Cloudflare Argo)
+```hcl
+resource "cloudflare_tunnel" "this" {
+  for_each = var.tunnels
+
+  account_id = each.value.account_id
+  name       = each.key
+  secret     = each.value.secret
+}
+
+resource "cloudflare_tunnel_config" "this" {
+  for_each = var.tunnels
+
+  account_id = each.value.account_id
+  tunnel_id  = cloudflare_tunnel.this[each.key].id
+
+  config {
+    dynamic "ingress_rule" {
+      for_each = each.value.ingress_rules
+      content {
+        hostname = ingress_rule.value.hostname
+        path     = ingress_rule.value.path
+        service  = ingress_rule.value.service
+      }
+    }
+
+    # Catch-all rule (required)
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+```
+
+---
+
+## DNS Provider (hashicorp/dns)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    dns = {
+      source  = "hashicorp/dns"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# For RFC 2136 dynamic updates
+provider "dns" {
+  update {
+    server        = var.dns_server
+    key_name      = var.tsig_key_name
+    key_algorithm = var.tsig_key_algorithm
+    key_secret    = var.tsig_key_secret
+  }
+}
+```
+
+### A Record Set
+```hcl
+resource "dns_a_record_set" "this" {
+  for_each = var.a_records
+
+  zone      = each.value.zone
+  name      = each.value.name
+  addresses = each.value.addresses
+  ttl       = each.value.ttl
+}
+```
+
+### CNAME Record Set
+```hcl
+resource "dns_cname_record" "this" {
+  for_each = var.cname_records
+
+  zone  = each.value.zone
+  name  = each.value.name
+  cname = each.value.cname
+  ttl   = each.value.ttl
+}
+```
+
+### PTR Record Set
+```hcl
+resource "dns_ptr_record" "this" {
+  for_each = var.ptr_records
+
+  zone = each.value.zone
+  name = each.value.name
+  ptr  = each.value.ptr
+  ttl  = each.value.ttl
+}
+```
+
+---
+
+## NS1 Provider (ns1-terraform/ns1)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    ns1 = {
+      source  = "ns1-terraform/ns1"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "ns1" {
+  # API key via NS1_APIKEY env var
+}
+```
+
+### Zone Module
+```hcl
+resource "ns1_zone" "this" {
+  for_each = var.zones
+
+  zone    = each.key
+  ttl     = each.value.ttl
+  refresh = each.value.refresh
+  retry   = each.value.retry
+  expiry  = each.value.expiry
+  nx_ttl  = each.value.nx_ttl
+
+  primary   = each.value.primary
+  dnssec    = each.value.dnssec
+  link      = each.value.link
+  networks  = each.value.networks
+}
+```
+
+### Record Module
+```hcl
+resource "ns1_record" "this" {
+  for_each = var.records
+
+  zone   = each.value.zone
+  domain = each.value.domain
+  type   = each.value.type
+  ttl    = each.value.ttl
+
+  dynamic "answers" {
+    for_each = each.value.answers
+    content {
+      answer = answers.value.answer
+      region = answers.value.region
+      meta   = answers.value.meta
+    }
+  }
+
+  dynamic "filters" {
+    for_each = each.value.filters
+    content {
+      filter = filters.value.filter
+      config = filters.value.config
+    }
+  }
+}
+```
+
+### Monitoring Job
+```hcl
+resource "ns1_monitoringjob" "this" {
+  for_each = var.monitoring_jobs
+
+  name          = each.key
+  active        = each.value.active
+  regions       = each.value.regions
+  job_type      = each.value.job_type  # tcp, http, ping, dns
+  frequency     = each.value.frequency
+  rapid_recheck = each.value.rapid_recheck
+
+  config = each.value.config  # Job-type specific config
+
+  rules {
+    value      = each.value.rules.value
+    comparison = each.value.rules.comparison
+    key        = each.value.rules.key
+  }
+
+  notify_delay     = each.value.notify_delay
+  notify_repeat    = each.value.notify_repeat
+  notify_failback  = each.value.notify_failback
+  notify_regional  = each.value.notify_regional
+  notify_list      = each.value.notify_list
+}
+```
+
+---
+
+## ZeroTier Provider (zerotier/zerotier)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    zerotier = {
+      source  = "zerotier/zerotier"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "zerotier" {
+  # API token via ZEROTIER_CENTRAL_TOKEN env var
+}
+```
+
+### Network Module
+```hcl
+resource "zerotier_network" "this" {
+  for_each = var.networks
+
+  name        = each.key
+  description = each.value.description
+  private     = each.value.private
+
+  route {
+    target = each.value.route_target
+    via    = each.value.route_via
+  }
+
+  assignment_pool {
+    start = each.value.ip_pool_start
+    end   = each.value.ip_pool_end
+  }
+
+  flow_rules = each.value.flow_rules
+}
+```
+
+### Member Module
+```hcl
+resource "zerotier_member" "this" {
+  for_each = var.members
+
+  network_id  = each.value.network_id
+  member_id   = each.value.member_id
+  name        = each.key
+  description = each.value.description
+  hidden      = each.value.hidden
+
+  authorized              = each.value.authorized
+  allow_ethernet_bridging = each.value.allow_ethernet_bridging
+  no_auto_assign_ips      = each.value.no_auto_assign_ips
+  ip_assignments          = each.value.ip_assignments
+  capabilities            = each.value.capabilities
+  tags                    = each.value.tags
+}
+```
+
+---
+
+## Fastly Provider (fastly/fastly)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "fastly" {
+  # API key via FASTLY_API_KEY env var
+}
+```
+
+### Service VCL Module
+```hcl
+resource "fastly_service_vcl" "this" {
+  for_each = var.services
+
+  name = each.key
+
+  dynamic "domain" {
+    for_each = each.value.domains
+    content {
+      name    = domain.value.name
+      comment = domain.value.comment
+    }
+  }
+
+  dynamic "backend" {
+    for_each = each.value.backends
+    content {
+      address           = backend.value.address
+      name              = backend.value.name
+      port              = backend.value.port
+      ssl_cert_hostname = backend.value.ssl_cert_hostname
+      ssl_sni_hostname  = backend.value.ssl_sni_hostname
+      use_ssl           = backend.value.use_ssl
+      override_host     = backend.value.override_host
+
+      # Health check
+      healthcheck = backend.value.healthcheck
+    }
+  }
+
+  dynamic "healthcheck" {
+    for_each = each.value.healthchecks
+    content {
+      name              = healthcheck.value.name
+      host              = healthcheck.value.host
+      path              = healthcheck.value.path
+      check_interval    = healthcheck.value.check_interval
+      expected_response = healthcheck.value.expected_response
+      initial           = healthcheck.value.initial
+      threshold         = healthcheck.value.threshold
+      timeout           = healthcheck.value.timeout
+      window            = healthcheck.value.window
+    }
+  }
+
+  dynamic "gzip" {
+    for_each = each.value.gzip_enabled ? [1] : []
+    content {
+      name       = "gzip"
+      extensions = ["css", "js", "html", "json", "svg"]
+    }
+  }
+
+  dynamic "request_setting" {
+    for_each = each.value.request_settings
+    content {
+      name      = request_setting.value.name
+      force_ssl = request_setting.value.force_ssl
+    }
+  }
+
+  dynamic "vcl" {
+    for_each = each.value.custom_vcl
+    content {
+      name    = vcl.value.name
+      content = vcl.value.content
+      main    = vcl.value.main
+    }
+  }
+
+  force_destroy = each.value.force_destroy
+}
+```
+
+### TLS Certificate
+```hcl
+resource "fastly_tls_certificate" "this" {
+  for_each = var.tls_certificates
+
+  name                 = each.key
+  certificate_body     = each.value.certificate_body
+  intermediates_blob   = each.value.intermediates_blob
+}
+
+resource "fastly_tls_activation" "this" {
+  for_each = var.tls_activations
+
+  certificate_id       = each.value.certificate_id
+  configuration_id     = each.value.configuration_id
+  domain               = each.value.domain
+  mutual_authentication_id = each.value.mtls_id
+}
+```
+
+---
+
+## Akamai Provider (akamai/akamai)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    akamai = {
+      source  = "akamai/akamai"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "akamai" {
+  edgerc         = "~/.edgerc"
+  config_section = var.akamai_section
+}
+```
+
+### Property Module
+```hcl
+data "akamai_group" "this" {
+  group_name  = var.group_name
+  contract_id = var.contract_id
+}
+
+data "akamai_contract" "this" {
+  group_name = data.akamai_group.this.group_name
+}
+
+resource "akamai_cp_code" "this" {
+  for_each = var.cp_codes
+
+  product_id  = each.value.product_id
+  contract_id = data.akamai_contract.this.id
+  group_id    = data.akamai_group.this.id
+  name        = each.key
+}
+
+resource "akamai_edge_hostname" "this" {
+  for_each = var.edge_hostnames
+
+  product_id    = each.value.product_id
+  contract_id   = data.akamai_contract.this.id
+  group_id      = data.akamai_group.this.id
+  ip_behavior   = each.value.ip_behavior  # IPV4, IPV6_COMPLIANCE, IPV6_PERFORMANCE
+  edge_hostname = each.key
+  certificate   = each.value.certificate
+}
+
+resource "akamai_property" "this" {
+  for_each = var.properties
+
+  name        = each.key
+  product_id  = each.value.product_id
+  contract_id = data.akamai_contract.this.id
+  group_id    = data.akamai_group.this.id
+
+  dynamic "hostnames" {
+    for_each = each.value.hostnames
+    content {
+      cname_from             = hostnames.value.cname_from
+      cname_to               = hostnames.value.cname_to
+      cert_provisioning_type = hostnames.value.cert_provisioning_type
+    }
+  }
+
+  rule_format = each.value.rule_format
+  rules       = each.value.rules  # JSON rules tree
+}
+
+resource "akamai_property_activation" "this" {
+  for_each = var.property_activations
+
+  property_id                    = each.value.property_id
+  contact                        = each.value.contacts
+  version                        = each.value.version
+  network                        = each.value.network  # STAGING, PRODUCTION
+  note                           = each.value.note
+  auto_acknowledge_rule_warnings = each.value.auto_acknowledge
+}
+```
+
+### DNS Zone
+```hcl
+resource "akamai_dns_zone" "this" {
+  for_each = var.dns_zones
+
+  contract      = data.akamai_contract.this.id
+  group         = data.akamai_group.this.id
+  zone          = each.key
+  type          = each.value.type  # PRIMARY, SECONDARY, ALIAS
+  masters       = each.value.masters
+  comment       = each.value.comment
+  sign_and_serve = each.value.dnssec_enabled
+}
+
+resource "akamai_dns_record" "this" {
+  for_each = var.dns_records
+
+  zone       = each.value.zone
+  name       = each.value.name
+  recordtype = each.value.recordtype
+  ttl        = each.value.ttl
+  target     = each.value.target
+  priority   = each.value.priority
+  weight     = each.value.weight
+  port       = each.value.port
+}
+```
+
+### Application Security
+```hcl
+resource "akamai_appsec_configuration" "this" {
+  for_each = var.appsec_configs
+
+  name        = each.key
+  description = each.value.description
+  contract_id = data.akamai_contract.this.id
+  group_id    = data.akamai_group.this.id
+  host_names  = each.value.host_names
+}
+
+resource "akamai_appsec_security_policy" "this" {
+  for_each = var.security_policies
+
+  config_id              = each.value.config_id
+  security_policy_name   = each.key
+  security_policy_prefix = each.value.prefix
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use API tokens over global API keys** - Least privilege access
+2. **Enable DNSSEC where supported** - DNS integrity
+3. **Use origin certificates** - Secure backend connections
+4. **Enable WAF rules** - Application protection
+5. **Configure rate limiting** - DDoS mitigation
+6. **Use cache keys wisely** - Optimal cache hit rates
+7. **Enable logging** - Request/response visibility
+8. **Test in staging** - Validate before production
+9. **Use version control for rules** - Track configuration changes
+10. **Monitor edge performance** - Real User Metrics (RUM)

--- a/components/skills/iac-terraform-modules-eng/references/observability-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/observability-providers.md
@@ -1,0 +1,642 @@
+# Observability Provider Patterns
+
+## Grafana Provider (grafana/grafana)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Grafana OSS/Enterprise
+provider "grafana" {
+  url  = var.grafana_url
+  auth = var.grafana_api_key  # Or service account token
+
+  # Optional TLS configuration
+  tls_key              = var.tls_key
+  tls_cert             = var.tls_cert
+  insecure_skip_verify = var.skip_tls_verify
+}
+
+# Grafana Cloud
+provider "grafana" {
+  alias         = "cloud"
+  cloud_api_key = var.grafana_cloud_api_key
+}
+
+# Multiple stacks
+provider "grafana" {
+  alias = "stack_1"
+  url   = "https://stack1.grafana.net"
+  auth  = var.stack1_token
+}
+
+provider "grafana" {
+  alias = "stack_2"
+  url   = "https://stack2.grafana.net"
+  auth  = var.stack2_token
+}
+```
+
+### Organization & User Module
+```hcl
+resource "grafana_organization" "this" {
+  for_each = var.organizations
+
+  name         = each.key
+  admin_user   = each.value.admin_user
+  create_users = each.value.create_users
+  admins       = each.value.admins
+  editors      = each.value.editors
+  viewers      = each.value.viewers
+}
+
+resource "grafana_user" "this" {
+  for_each = var.users
+
+  email    = each.value.email
+  name     = each.key
+  login    = each.value.login
+  password = each.value.password
+  is_admin = each.value.is_admin
+}
+
+resource "grafana_team" "this" {
+  for_each = var.teams
+
+  name    = each.key
+  email   = each.value.email
+  members = each.value.members
+}
+```
+
+### Folder Module
+```hcl
+resource "grafana_folder" "this" {
+  for_each = var.folders
+
+  title                        = each.key
+  uid                          = each.value.uid
+  parent_folder_uid            = each.value.parent_folder_uid
+  prevent_destroy_if_not_empty = each.value.prevent_destroy
+}
+
+resource "grafana_folder_permission" "this" {
+  for_each = var.folder_permissions
+
+  folder_uid = each.value.folder_uid
+
+  dynamic "permissions" {
+    for_each = each.value.permissions
+    content {
+      role       = permissions.value.role
+      permission = permissions.value.permission  # View, Edit, Admin
+    }
+  }
+
+  dynamic "permissions" {
+    for_each = each.value.team_permissions
+    content {
+      team_id    = permissions.value.team_id
+      permission = permissions.value.permission
+    }
+  }
+
+  dynamic "permissions" {
+    for_each = each.value.user_permissions
+    content {
+      user_id    = permissions.value.user_id
+      permission = permissions.value.permission
+    }
+  }
+}
+```
+
+### Data Source Module
+```hcl
+resource "grafana_data_source" "prometheus" {
+  for_each = var.prometheus_datasources
+
+  name = each.key
+  type = "prometheus"
+  url  = each.value.url
+  uid  = each.value.uid
+
+  is_default               = each.value.is_default
+  basic_auth_enabled       = each.value.basic_auth_enabled
+  basic_auth_username      = each.value.basic_auth_username
+
+  secure_json_data_encoded = jsonencode({
+    basicAuthPassword = each.value.basic_auth_password
+    httpHeaderValue1  = each.value.bearer_token
+  })
+
+  json_data_encoded = jsonencode({
+    httpMethod           = "POST"
+    manageAlerts         = each.value.manage_alerts
+    prometheusType       = each.value.prometheus_type  # Prometheus, Cortex, Mimir, Thanos
+    prometheusVersion    = each.value.prometheus_version
+    cacheLevel           = each.value.cache_level
+    incrementalQuerying  = each.value.incremental_querying
+    httpHeaderName1      = each.value.bearer_token != null ? "Authorization" : null
+  })
+}
+
+resource "grafana_data_source" "loki" {
+  for_each = var.loki_datasources
+
+  name = each.key
+  type = "loki"
+  url  = each.value.url
+  uid  = each.value.uid
+
+  json_data_encoded = jsonencode({
+    maxLines              = each.value.max_lines
+    derivedFields         = each.value.derived_fields
+    alertmanagerUid       = each.value.alertmanager_uid
+  })
+}
+
+resource "grafana_data_source" "tempo" {
+  for_each = var.tempo_datasources
+
+  name = each.key
+  type = "tempo"
+  url  = each.value.url
+  uid  = each.value.uid
+
+  json_data_encoded = jsonencode({
+    tracesToLogs = {
+      datasourceUid       = each.value.loki_uid
+      filterByTraceID     = true
+      filterBySpanID      = true
+      mapTagNamesEnabled  = true
+      mappedTags          = each.value.mapped_tags
+    }
+    tracesToMetrics = {
+      datasourceUid = each.value.prometheus_uid
+    }
+    serviceMap = {
+      datasourceUid = each.value.prometheus_uid
+    }
+    nodeGraph = {
+      enabled = true
+    }
+    search = {
+      hide = false
+    }
+    lokiSearch = {
+      datasourceUid = each.value.loki_uid
+    }
+  })
+}
+
+resource "grafana_data_source" "cloudwatch" {
+  for_each = var.cloudwatch_datasources
+
+  name = each.key
+  type = "cloudwatch"
+  uid  = each.value.uid
+
+  json_data_encoded = jsonencode({
+    authType      = "keys"
+    defaultRegion = each.value.default_region
+  })
+
+  secure_json_data_encoded = jsonencode({
+    accessKey = each.value.access_key
+    secretKey = each.value.secret_key
+  })
+}
+```
+
+### Dashboard Module
+```hcl
+resource "grafana_dashboard" "this" {
+  for_each = var.dashboards
+
+  folder      = each.value.folder_uid
+  config_json = each.value.config_json
+  overwrite   = each.value.overwrite
+  message     = each.value.message
+}
+
+# Dashboard from file
+resource "grafana_dashboard" "from_file" {
+  for_each = var.dashboard_files
+
+  folder = each.value.folder_uid
+  config_json = templatefile("${path.module}/dashboards/${each.key}.json", {
+    datasource_uid = each.value.datasource_uid
+    environment    = each.value.environment
+  })
+}
+
+# Dashboard from JSON API
+data "http" "dashboard" {
+  for_each = var.dashboard_urls
+
+  url = each.value
+}
+
+resource "grafana_dashboard" "from_url" {
+  for_each = var.dashboard_urls
+
+  config_json = data.http.dashboard[each.key].response_body
+}
+```
+
+### Alerting Module
+```hcl
+resource "grafana_contact_point" "this" {
+  for_each = var.contact_points
+
+  name = each.key
+
+  dynamic "slack" {
+    for_each = each.value.slack != null ? [each.value.slack] : []
+    content {
+      url                     = slack.value.webhook_url
+      recipient               = slack.value.recipient
+      username                = slack.value.username
+      icon_emoji              = slack.value.icon_emoji
+      text                    = slack.value.text
+      title                   = slack.value.title
+      mention_channel         = slack.value.mention_channel
+      mention_users           = slack.value.mention_users
+      mention_groups          = slack.value.mention_groups
+    }
+  }
+
+  dynamic "email" {
+    for_each = each.value.email != null ? [each.value.email] : []
+    content {
+      addresses               = email.value.addresses
+      single_email            = email.value.single_email
+      message                 = email.value.message
+      subject                 = email.value.subject
+    }
+  }
+
+  dynamic "pagerduty" {
+    for_each = each.value.pagerduty != null ? [each.value.pagerduty] : []
+    content {
+      integration_key = pagerduty.value.integration_key
+      severity        = pagerduty.value.severity
+      class           = pagerduty.value.class
+      component       = pagerduty.value.component
+      group           = pagerduty.value.group
+    }
+  }
+
+  dynamic "opsgenie" {
+    for_each = each.value.opsgenie != null ? [each.value.opsgenie] : []
+    content {
+      api_key          = opsgenie.value.api_key
+      api_url          = opsgenie.value.api_url
+      auto_close       = opsgenie.value.auto_close
+      override_priority = opsgenie.value.override_priority
+      send_tags_as     = opsgenie.value.send_tags_as
+    }
+  }
+
+  dynamic "webhook" {
+    for_each = each.value.webhook != null ? [each.value.webhook] : []
+    content {
+      url                   = webhook.value.url
+      http_method           = webhook.value.http_method
+      username              = webhook.value.username
+      password              = webhook.value.password
+      authorization_scheme  = webhook.value.auth_scheme
+      authorization_credentials = webhook.value.auth_credentials
+      max_alerts            = webhook.value.max_alerts
+      message               = webhook.value.message
+      title                 = webhook.value.title
+    }
+  }
+}
+
+resource "grafana_notification_policy" "this" {
+  for_each = var.notification_policies
+
+  contact_point   = each.value.contact_point
+  group_by        = each.value.group_by
+  group_wait      = each.value.group_wait
+  group_interval  = each.value.group_interval
+  repeat_interval = each.value.repeat_interval
+
+  dynamic "policy" {
+    for_each = each.value.policies
+    content {
+      contact_point = policy.value.contact_point
+      group_by      = policy.value.group_by
+      continue      = policy.value.continue
+
+      dynamic "matcher" {
+        for_each = policy.value.matchers
+        content {
+          label = matcher.value.label
+          match = matcher.value.match  # =, !=, =~, !~
+          value = matcher.value.value
+        }
+      }
+
+      mute_timings = policy.value.mute_timings
+    }
+  }
+}
+
+resource "grafana_mute_timing" "this" {
+  for_each = var.mute_timings
+
+  name = each.key
+
+  dynamic "intervals" {
+    for_each = each.value.intervals
+    content {
+      weekdays      = intervals.value.weekdays
+      days_of_month = intervals.value.days_of_month
+      months        = intervals.value.months
+      years         = intervals.value.years
+      location      = intervals.value.location
+
+      dynamic "times" {
+        for_each = intervals.value.times
+        content {
+          start = times.value.start
+          end   = times.value.end
+        }
+      }
+    }
+  }
+}
+
+resource "grafana_rule_group" "this" {
+  for_each = var.rule_groups
+
+  name             = each.key
+  folder_uid       = each.value.folder_uid
+  interval_seconds = each.value.interval_seconds
+  org_id           = each.value.org_id
+
+  dynamic "rule" {
+    for_each = each.value.rules
+    content {
+      name           = rule.value.name
+      for            = rule.value.for
+      condition      = rule.value.condition
+      no_data_state  = rule.value.no_data_state  # Alerting, NoData, OK
+      exec_err_state = rule.value.exec_err_state  # Alerting, Error, OK
+
+      annotations = rule.value.annotations
+      labels      = rule.value.labels
+
+      dynamic "data" {
+        for_each = rule.value.data
+        content {
+          ref_id         = data.value.ref_id
+          datasource_uid = data.value.datasource_uid
+          query_type     = data.value.query_type
+
+          relative_time_range {
+            from = data.value.from
+            to   = data.value.to
+          }
+
+          model = jsonencode(data.value.model)
+        }
+      }
+    }
+  }
+}
+```
+
+### Service Account Module
+```hcl
+resource "grafana_service_account" "this" {
+  for_each = var.service_accounts
+
+  name        = each.key
+  role        = each.value.role  # Viewer, Editor, Admin
+  is_disabled = each.value.is_disabled
+}
+
+resource "grafana_service_account_token" "this" {
+  for_each = var.service_account_tokens
+
+  name               = each.key
+  service_account_id = each.value.service_account_id
+  seconds_to_live    = each.value.seconds_to_live
+}
+
+resource "grafana_service_account_permission" "this" {
+  for_each = var.service_account_permissions
+
+  service_account_id = each.value.service_account_id
+
+  dynamic "permissions" {
+    for_each = each.value.permissions
+    content {
+      team_id    = permissions.value.team_id
+      user_id    = permissions.value.user_id
+      permission = permissions.value.permission  # Edit, Admin
+    }
+  }
+}
+```
+
+---
+
+## Grafana Cloud Module
+
+### Stack Management
+```hcl
+resource "grafana_cloud_stack" "this" {
+  provider = grafana.cloud
+
+  for_each = var.cloud_stacks
+
+  name        = each.key
+  slug        = each.value.slug
+  region_slug = each.value.region  # us, eu, au, prod-ap-southeast-0, etc.
+  description = each.value.description
+
+  wait_for_readiness = each.value.wait_for_readiness
+}
+
+resource "grafana_cloud_stack_service_account" "this" {
+  provider = grafana.cloud
+
+  for_each = var.cloud_service_accounts
+
+  stack_slug  = each.value.stack_slug
+  name        = each.key
+  role        = each.value.role
+  is_disabled = each.value.is_disabled
+}
+
+resource "grafana_cloud_stack_service_account_token" "this" {
+  provider = grafana.cloud
+
+  for_each = var.cloud_service_account_tokens
+
+  stack_slug         = each.value.stack_slug
+  service_account_id = each.value.service_account_id
+  name               = each.key
+  seconds_to_live    = each.value.seconds_to_live
+}
+```
+
+### Synthetic Monitoring
+```hcl
+resource "grafana_synthetic_monitoring_installation" "this" {
+  provider = grafana.cloud
+
+  stack_id              = grafana_cloud_stack.main.id
+  metrics_publisher_key = var.metrics_publisher_key
+}
+
+resource "grafana_synthetic_monitoring_check" "http" {
+  for_each = var.synthetic_http_checks
+
+  job     = each.key
+  target  = each.value.target
+  enabled = each.value.enabled
+  probes  = each.value.probes
+
+  labels = each.value.labels
+
+  settings {
+    http {
+      method           = each.value.method
+      body             = each.value.body
+      bearer_token     = each.value.bearer_token
+      cache_busting_query_param_name = each.value.cache_busting_param
+
+      valid_status_codes   = each.value.valid_status_codes
+      valid_http_versions  = each.value.valid_http_versions
+
+      tls_config {
+        insecure_skip_verify = each.value.skip_tls_verify
+        server_name          = each.value.tls_server_name
+      }
+
+      dynamic "basic_auth" {
+        for_each = each.value.basic_auth != null ? [each.value.basic_auth] : []
+        content {
+          username = basic_auth.value.username
+          password = basic_auth.value.password
+        }
+      }
+    }
+  }
+
+  frequency   = each.value.frequency
+  timeout     = each.value.timeout
+  alert_sensitivity = each.value.alert_sensitivity
+}
+
+resource "grafana_synthetic_monitoring_check" "dns" {
+  for_each = var.synthetic_dns_checks
+
+  job     = each.key
+  target  = each.value.target
+  enabled = each.value.enabled
+  probes  = each.value.probes
+
+  settings {
+    dns {
+      record_type = each.value.record_type  # A, AAAA, CNAME, MX, NS, etc.
+      server      = each.value.server
+      port        = each.value.port
+      protocol    = each.value.protocol  # UDP, TCP
+
+      valid_r_codes = each.value.valid_rcodes
+    }
+  }
+
+  frequency = each.value.frequency
+  timeout   = each.value.timeout
+}
+
+resource "grafana_synthetic_monitoring_check" "tcp" {
+  for_each = var.synthetic_tcp_checks
+
+  job     = each.key
+  target  = each.value.target
+  enabled = each.value.enabled
+  probes  = each.value.probes
+
+  settings {
+    tcp {
+      tls = each.value.tls
+
+      tls_config {
+        insecure_skip_verify = each.value.skip_tls_verify
+      }
+    }
+  }
+
+  frequency = each.value.frequency
+  timeout   = each.value.timeout
+}
+```
+
+### Adaptive Metrics
+```hcl
+# grafana/grafana-adaptive-metrics provider
+terraform {
+  required_providers {
+    grafana-adaptive-metrics = {
+      source  = "grafana/grafana-adaptive-metrics"
+      version = "~> 0.2"
+    }
+  }
+}
+
+provider "grafana-adaptive-metrics" {
+  url   = "${grafana_cloud_stack.main.url}/api/v1/recommendations"
+  token = grafana_cloud_stack_service_account_token.main.key
+}
+
+resource "grafana-adaptive-metrics_exemption" "this" {
+  for_each = var.metric_exemptions
+
+  metric           = each.key
+  reason           = each.value.reason
+  keep_labels      = each.value.keep_labels
+  disable_recommendations = each.value.disable_recommendations
+}
+
+resource "grafana-adaptive-metrics_rule" "this" {
+  for_each = var.aggregation_rules
+
+  metric      = each.key
+  match_type  = each.value.match_type  # exact, prefix
+  drop_labels = each.value.drop_labels
+  aggregations = each.value.aggregations  # ["sum", "count"]
+  aggregation_interval = each.value.aggregation_interval
+  aggregation_delay    = each.value.aggregation_delay
+}
+```
+
+---
+
+## Best Practices
+
+1. **Use folders for organization** - Logical dashboard grouping
+2. **Implement role-based access** - Teams and permissions
+3. **Use provisioning where possible** - GitOps workflows
+4. **Configure alerting properly** - Contact points, policies, mute timings
+5. **Use service accounts** - Machine-to-machine auth over user tokens
+6. **Set up data source correlation** - Link logs, traces, metrics
+7. **Enable synthetic monitoring** - Proactive availability checks
+8. **Use adaptive metrics** - Cost optimization for Grafana Cloud
+9. **Version control dashboards** - JSON export/import
+10. **Monitor Grafana itself** - Self-monitoring dashboards

--- a/components/skills/iac-terraform-modules-eng/references/orchestration-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/orchestration-providers.md
@@ -1,0 +1,755 @@
+# Orchestration Provider Patterns
+
+## Ansible Automation Platform Provider (ansible/aap)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    aap = {
+      source  = "ansible/aap"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "aap" {
+  host     = var.aap_host
+  username = var.aap_username
+  password = var.aap_password
+
+  # Or use token
+  # token = var.aap_token
+
+  insecure_skip_verify = var.skip_tls_verify
+}
+```
+
+### Organization Module
+```hcl
+resource "aap_organization" "this" {
+  for_each = var.organizations
+
+  name        = each.key
+  description = each.value.description
+
+  max_hosts                = each.value.max_hosts
+  default_environment      = each.value.default_environment
+  custom_virtualenv        = each.value.custom_virtualenv
+}
+```
+
+### Inventory Module
+```hcl
+resource "aap_inventory" "this" {
+  for_each = var.inventories
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+
+  variables = yamlencode(each.value.variables)
+}
+
+resource "aap_host" "this" {
+  for_each = var.hosts
+
+  name        = each.key
+  description = each.value.description
+  inventory   = each.value.inventory_id
+  enabled     = each.value.enabled
+
+  variables = yamlencode({
+    ansible_host       = each.value.ansible_host
+    ansible_user       = each.value.ansible_user
+    ansible_connection = each.value.ansible_connection
+  })
+}
+
+resource "aap_group" "this" {
+  for_each = var.groups
+
+  name        = each.key
+  description = each.value.description
+  inventory   = each.value.inventory_id
+
+  variables = yamlencode(each.value.variables)
+}
+
+# Dynamic inventory source
+resource "aap_inventory_source" "aws" {
+  for_each = var.aws_inventory_sources
+
+  name                 = each.key
+  description          = each.value.description
+  inventory            = each.value.inventory_id
+  source               = "amazon.aws.aws_ec2"
+  credential           = each.value.credential_id
+  update_on_launch     = each.value.update_on_launch
+  overwrite            = each.value.overwrite
+  overwrite_variables  = each.value.overwrite_variables
+
+  source_variables = yamlencode({
+    regions          = each.value.regions
+    keyed_groups     = each.value.keyed_groups
+    hostnames        = each.value.hostnames
+    filters          = each.value.filters
+    compose          = each.value.compose
+  })
+}
+```
+
+### Project Module
+```hcl
+resource "aap_project" "this" {
+  for_each = var.projects
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+
+  scm_type             = each.value.scm_type  # git, svn, insights, archive
+  scm_url              = each.value.scm_url
+  scm_branch           = each.value.scm_branch
+  scm_credential       = each.value.scm_credential_id
+  scm_clean            = each.value.scm_clean
+  scm_delete_on_update = each.value.scm_delete_on_update
+  scm_update_on_launch = each.value.scm_update_on_launch
+
+  default_environment = each.value.default_environment
+}
+```
+
+### Job Template Module
+```hcl
+resource "aap_job_template" "this" {
+  for_each = var.job_templates
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+  inventory    = each.value.inventory_id
+  project      = each.value.project_id
+  playbook     = each.value.playbook
+
+  job_type          = each.value.job_type  # run, check
+  limit             = each.value.limit
+  verbosity         = each.value.verbosity  # 0-5
+  forks             = each.value.forks
+  extra_vars        = yamlencode(each.value.extra_vars)
+  ask_variables_on_launch = each.value.ask_variables_on_launch
+  ask_limit_on_launch     = each.value.ask_limit_on_launch
+  ask_inventory_on_launch = each.value.ask_inventory_on_launch
+
+  become_enabled = each.value.become_enabled
+  diff_mode      = each.value.diff_mode
+
+  execution_environment = each.value.execution_environment_id
+  credentials           = each.value.credential_ids
+}
+```
+
+### Workflow Template Module
+```hcl
+resource "aap_workflow_job_template" "this" {
+  for_each = var.workflow_templates
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+  inventory    = each.value.inventory_id
+
+  extra_vars                  = yamlencode(each.value.extra_vars)
+  ask_variables_on_launch     = each.value.ask_variables_on_launch
+  ask_inventory_on_launch     = each.value.ask_inventory_on_launch
+  allow_simultaneous          = each.value.allow_simultaneous
+  survey_enabled              = each.value.survey_enabled
+  webhook_service             = each.value.webhook_service
+  webhook_credential          = each.value.webhook_credential_id
+}
+
+resource "aap_workflow_job_template_node" "this" {
+  for_each = var.workflow_nodes
+
+  workflow_job_template = each.value.workflow_template_id
+  identifier            = each.key
+  unified_job_template  = each.value.job_template_id
+
+  all_parents_must_converge = each.value.all_parents_must_converge
+  extra_data                = yamlencode(each.value.extra_data)
+}
+```
+
+### Credential Module
+```hcl
+resource "aap_credential" "machine" {
+  for_each = var.machine_credentials
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+  credential_type = aap_credential_type.machine.id
+
+  inputs = jsonencode({
+    username       = each.value.username
+    password       = each.value.password
+    ssh_key_data   = each.value.ssh_key
+    become_method  = each.value.become_method
+    become_username = each.value.become_username
+    become_password = each.value.become_password
+  })
+}
+
+resource "aap_credential" "aws" {
+  for_each = var.aws_credentials
+
+  name         = each.key
+  description  = each.value.description
+  organization = each.value.organization_id
+  credential_type = aap_credential_type.amazon_web_services.id
+
+  inputs = jsonencode({
+    username = each.value.access_key
+    password = each.value.secret_key
+    security_token = each.value.session_token
+  })
+}
+```
+
+---
+
+## Kestra Provider (kestra-io/kestra)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    kestra = {
+      source  = "kestra-io/kestra"
+      version = "~> 0.15"
+    }
+  }
+}
+
+provider "kestra" {
+  url      = var.kestra_url
+  username = var.kestra_username
+  password = var.kestra_password
+
+  # Or API token
+  # api_token = var.kestra_api_token
+}
+```
+
+### Namespace Module
+```hcl
+resource "kestra_namespace" "this" {
+  for_each = var.namespaces
+
+  namespace_id = each.key
+  description  = each.value.description
+}
+
+resource "kestra_namespace_secret" "this" {
+  for_each = var.namespace_secrets
+
+  namespace    = each.value.namespace
+  secret_key   = each.key
+  secret_value = each.value.value
+}
+```
+
+### Flow Module
+```hcl
+resource "kestra_flow" "this" {
+  for_each = var.flows
+
+  namespace = each.value.namespace
+  flow_id   = each.key
+  content   = each.value.content  # YAML flow definition
+}
+
+# Example flow content
+locals {
+  example_flow = <<-YAML
+    id: example-etl
+    namespace: production
+    description: Example ETL pipeline
+
+    inputs:
+      - id: date
+        type: DATE
+        defaults: "{{ now() | date('yyyy-MM-dd') }}"
+
+    tasks:
+      - id: extract
+        type: io.kestra.plugin.jdbc.postgresql.Query
+        url: jdbc:postgresql://db:5432/source
+        username: "{{ secret('DB_USER') }}"
+        password: "{{ secret('DB_PASS') }}"
+        sql: SELECT * FROM data WHERE date = '{{ inputs.date }}'
+        store: true
+
+      - id: transform
+        type: io.kestra.plugin.scripts.python.Script
+        script: |
+          import pandas as pd
+          df = pd.read_csv('{{ outputs.extract.uri }}')
+          df['processed'] = True
+          df.to_csv('output.csv', index=False)
+        outputFiles:
+          - output.csv
+
+      - id: load
+        type: io.kestra.plugin.gcp.bigquery.Load
+        from: "{{ outputs.transform.outputFiles['output.csv'] }}"
+        projectId: my-project
+        dataset: analytics
+        table: processed_data
+        format: CSV
+
+    triggers:
+      - id: daily
+        type: io.kestra.core.models.triggers.types.Schedule
+        cron: "0 2 * * *"
+  YAML
+}
+```
+
+### Template Module
+```hcl
+resource "kestra_template" "this" {
+  for_each = var.templates
+
+  namespace   = each.value.namespace
+  template_id = each.key
+  content     = each.value.content
+}
+
+# Reusable task template
+locals {
+  slack_notification_template = <<-YAML
+    id: slack-notification
+    namespace: shared.templates
+
+    tasks:
+      - id: notify
+        type: io.kestra.plugin.notifications.slack.SlackIncomingWebhook
+        url: "{{ secret('SLACK_WEBHOOK') }}"
+        payload: |
+          {
+            "text": "{{ inputs.message }}"
+          }
+  YAML
+}
+```
+
+### Trigger Configuration
+```hcl
+resource "kestra_flow" "webhook_triggered" {
+  namespace = "production"
+  flow_id   = "webhook-handler"
+
+  content = <<-YAML
+    id: webhook-handler
+    namespace: production
+
+    inputs:
+      - id: payload
+        type: JSON
+
+    tasks:
+      - id: process
+        type: io.kestra.plugin.scripts.shell.Commands
+        commands:
+          - echo "Processing webhook payload"
+
+    triggers:
+      - id: webhook
+        type: io.kestra.core.models.triggers.types.Webhook
+        key: "{{ secret('WEBHOOK_KEY') }}"
+  YAML
+}
+```
+
+---
+
+## Prefect Provider (PrefectHQ/prefect)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    prefect = {
+      source  = "PrefectHQ/prefect"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "prefect" {
+  # Uses PREFECT_API_URL and PREFECT_API_KEY env vars
+  # Or configure explicitly
+  api_url = var.prefect_api_url
+  api_key = var.prefect_api_key
+}
+```
+
+### Work Pool Module
+```hcl
+resource "prefect_work_pool" "this" {
+  for_each = var.work_pools
+
+  name        = each.key
+  type        = each.value.type  # kubernetes, docker, process, etc.
+  description = each.value.description
+  paused      = each.value.paused
+
+  base_job_template = jsonencode(each.value.base_job_template)
+}
+
+# Kubernetes work pool example
+resource "prefect_work_pool" "kubernetes" {
+  name = "k8s-pool"
+  type = "kubernetes"
+
+  base_job_template = jsonencode({
+    job_configuration = {
+      image                  = "prefecthq/prefect:2-python3.11"
+      namespace              = "prefect"
+      service_account_name   = "prefect-worker"
+      finished_job_ttl       = 300
+      image_pull_policy      = "IfNotPresent"
+
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "256Mi"
+        }
+        limits = {
+          cpu    = "500m"
+          memory = "512Mi"
+        }
+      }
+    }
+    variables = {
+      type = "object"
+      properties = {
+        image = {
+          type        = "string"
+          default     = "prefecthq/prefect:2-python3.11"
+          description = "Container image to use"
+        }
+      }
+    }
+  })
+}
+```
+
+### Deployment Module
+```hcl
+resource "prefect_deployment" "this" {
+  for_each = var.deployments
+
+  name        = each.key
+  flow_name   = each.value.flow_name
+  entrypoint  = each.value.entrypoint  # path/to/flow.py:flow_function
+  description = each.value.description
+
+  work_pool_name  = each.value.work_pool_name
+  work_queue_name = each.value.work_queue_name
+
+  parameters = jsonencode(each.value.parameters)
+  tags       = each.value.tags
+
+  enforce_parameter_schema = each.value.enforce_parameter_schema
+  paused                   = each.value.paused
+
+  # Storage block reference
+  storage_document_id = each.value.storage_document_id
+
+  # Schedule
+  schedule {
+    cron     = each.value.schedule_cron
+    timezone = each.value.schedule_timezone
+    active   = each.value.schedule_active
+  }
+}
+```
+
+### Block Module
+```hcl
+resource "prefect_block" "s3_storage" {
+  for_each = var.s3_blocks
+
+  name       = each.key
+  type_slug  = "s3"
+
+  data = jsonencode({
+    bucket_path           = each.value.bucket_path
+    aws_access_key_id     = each.value.access_key_id
+    aws_secret_access_key = each.value.secret_access_key
+    region_name           = each.value.region
+  })
+}
+
+resource "prefect_block" "gcs_storage" {
+  for_each = var.gcs_blocks
+
+  name       = each.key
+  type_slug  = "gcs"
+
+  data = jsonencode({
+    bucket_path               = each.value.bucket_path
+    service_account_info      = each.value.service_account_json
+  })
+}
+
+resource "prefect_block" "slack_webhook" {
+  for_each = var.slack_blocks
+
+  name       = each.key
+  type_slug  = "slack-webhook"
+
+  data = jsonencode({
+    url = each.value.webhook_url
+  })
+}
+
+resource "prefect_block" "secret" {
+  for_each = var.secret_blocks
+
+  name       = each.key
+  type_slug  = "secret"
+
+  data = jsonencode({
+    value = each.value.value
+  })
+}
+```
+
+### Automation Module
+```hcl
+resource "prefect_automation" "this" {
+  for_each = var.automations
+
+  name        = each.key
+  description = each.value.description
+  enabled     = each.value.enabled
+
+  trigger {
+    type = each.value.trigger_type  # event, compound, sequence
+
+    # For event triggers
+    expect     = each.value.expect
+    match      = each.value.match
+    after      = each.value.after
+    posture    = each.value.posture  # Reactive, Proactive
+
+    # For compound triggers
+    require = each.value.require  # all, any, number
+    within  = each.value.within
+  }
+
+  actions {
+    type = each.value.action_type  # run-deployment, pause-work-pool, send-notification
+
+    # For run-deployment
+    deployment_id = each.value.deployment_id
+    parameters    = each.value.parameters
+
+    # For notifications
+    block_document_id = each.value.notification_block_id
+    body              = each.value.notification_body
+    subject           = each.value.notification_subject
+  }
+}
+```
+
+---
+
+## Flagsmith Provider (Flagsmith/flagsmith)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    flagsmith = {
+      source  = "Flagsmith/flagsmith"
+      version = "~> 0.5"
+    }
+  }
+}
+
+provider "flagsmith" {
+  # Master API key via FLAGSMITH_MASTER_API_KEY env var
+  # Or configure explicitly
+  master_api_key = var.flagsmith_master_api_key
+  base_api_url   = var.flagsmith_api_url
+}
+```
+
+### Project & Environment Module
+```hcl
+resource "flagsmith_project" "this" {
+  for_each = var.projects
+
+  name         = each.key
+  organisation = each.value.organisation_id
+}
+
+resource "flagsmith_environment" "this" {
+  for_each = var.environments
+
+  name    = each.key
+  project = each.value.project_id
+
+  description              = each.value.description
+  hide_disabled_flags      = each.value.hide_disabled_flags
+  allow_client_traits      = each.value.allow_client_traits
+  use_identity_composite_key_for_hashing = each.value.use_identity_composite_key
+}
+```
+
+### Feature Flag Module
+```hcl
+resource "flagsmith_feature" "this" {
+  for_each = var.features
+
+  feature_name = each.key
+  project_id   = each.value.project_id
+  type         = each.value.type  # STANDARD, MULTIVARIATE
+
+  description      = each.value.description
+  initial_value    = each.value.initial_value
+  default_enabled  = each.value.default_enabled
+  is_archived      = each.value.is_archived
+
+  tags = each.value.tags
+}
+
+resource "flagsmith_feature_state" "this" {
+  for_each = var.feature_states
+
+  feature        = each.value.feature_id
+  environment    = each.value.environment_id
+  enabled        = each.value.enabled
+  feature_state_value {
+    type         = each.value.value_type  # string, int, bool
+    string_value = each.value.string_value
+    integer_value = each.value.integer_value
+    boolean_value = each.value.boolean_value
+  }
+}
+```
+
+### Segment Module
+```hcl
+resource "flagsmith_segment" "this" {
+  for_each = var.segments
+
+  name       = each.key
+  project    = each.value.project_id
+  feature    = each.value.feature_id
+
+  description = each.value.description
+
+  dynamic "rules" {
+    for_each = each.value.rules
+    content {
+      type = rules.value.type  # ALL, ANY, NONE
+
+      dynamic "conditions" {
+        for_each = rules.value.conditions
+        content {
+          operator = conditions.value.operator  # EQUAL, NOT_EQUAL, GREATER_THAN, etc.
+          property = conditions.value.property
+          value    = conditions.value.value
+        }
+      }
+    }
+  }
+}
+```
+
+### Multivariate Feature
+```hcl
+resource "flagsmith_feature" "multivariate" {
+  feature_name = "checkout-button-color"
+  project_id   = flagsmith_project.main.id
+  type         = "MULTIVARIATE"
+
+  description     = "A/B test for checkout button colors"
+  default_enabled = true
+}
+
+resource "flagsmith_mv_feature_option" "blue" {
+  feature = flagsmith_feature.multivariate.id
+  environment = flagsmith_environment.production.id
+
+  type         = "string"
+  string_value = "blue"
+  default_percentage_allocation = 50
+}
+
+resource "flagsmith_mv_feature_option" "green" {
+  feature = flagsmith_feature.multivariate.id
+  environment = flagsmith_environment.production.id
+
+  type         = "string"
+  string_value = "green"
+  default_percentage_allocation = 50
+}
+```
+
+---
+
+## Best Practices
+
+### Ansible AAP
+1. **Use execution environments** - Containerized consistency
+2. **Implement RBAC** - Role-based access control
+3. **Use credential types** - Secure secret management
+4. **Enable job isolation** - Container group isolation
+5. **Use workflow templates** - Complex orchestration
+6. **Enable inventory sources** - Dynamic inventory
+7. **Configure webhooks** - Event-driven automation
+8. **Use surveys** - Parameterized job templates
+9. **Enable logging** - External logging integration
+10. **Implement approval workflows** - Change control
+
+### Kestra
+1. **Use namespaces for isolation** - Multi-tenant workflows
+2. **Store secrets in namespace secrets** - Secure credential storage
+3. **Use templates for reusability** - DRY principles
+4. **Implement error handling** - Retry and fallback
+5. **Use flow inputs** - Parameterized execution
+6. **Enable flow versioning** - Track changes
+7. **Configure triggers appropriately** - Schedule, webhook, flow
+8. **Use task outputs** - Chain task data
+9. **Implement notifications** - Alert on failures
+10. **Monitor flow metrics** - Observability
+
+### Prefect
+1. **Use work pools** - Environment-specific execution
+2. **Configure proper storage** - Remote code storage
+3. **Use blocks for credentials** - Centralized secrets
+4. **Implement automations** - Event-driven responses
+5. **Use deployment parameters** - Flexible execution
+6. **Enable caching** - Performance optimization
+7. **Use tags for organization** - Filter and group
+8. **Configure retries** - Fault tolerance
+9. **Use subflows** - Modular flow design
+10. **Monitor with Prefect Cloud** - Observability
+
+### Flagsmith
+1. **Use environments** - Dev/staging/prod isolation
+2. **Implement segments** - Targeted rollouts
+3. **Use multivariate flags** - A/B testing
+4. **Enable audit logs** - Track changes
+5. **Use remote config** - Dynamic configuration
+6. **Implement percentage rollouts** - Gradual releases
+7. **Use feature tags** - Organization
+8. **Enable webhooks** - Integration events
+9. **Use server-side evaluation** - Security
+10. **Cache feature states** - Performance

--- a/components/skills/iac-terraform-modules-eng/references/platform-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/platform-providers.md
@@ -1,0 +1,868 @@
+# Platform Provider Patterns
+
+## Vercel Provider (vercel/vercel)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "vercel" {
+  # API token via VERCEL_API_TOKEN env var
+  team = var.vercel_team_id
+}
+```
+
+### Project Module
+```hcl
+resource "vercel_project" "this" {
+  for_each = var.projects
+
+  name      = each.key
+  framework = each.value.framework  # nextjs, nuxtjs, gatsby, etc.
+  team_id   = var.team_id
+
+  git_repository {
+    type              = each.value.git_type  # github, gitlab, bitbucket
+    repo              = each.value.git_repo
+    production_branch = each.value.production_branch
+  }
+
+  root_directory           = each.value.root_directory
+  build_command            = each.value.build_command
+  output_directory         = each.value.output_directory
+  install_command          = each.value.install_command
+  dev_command              = each.value.dev_command
+  ignore_command           = each.value.ignore_command
+  serverless_function_region = each.value.serverless_region
+
+  public_source            = each.value.public_source
+  automatically_expose_system_environment_variables = each.value.expose_system_vars
+
+  vercel_authentication {
+    deployment_type = each.value.auth_type  # standard_protection, none
+  }
+}
+
+resource "vercel_project_environment_variable" "this" {
+  for_each = var.project_env_vars
+
+  project_id = each.value.project_id
+  key        = each.value.key
+  value      = each.value.value
+  target     = each.value.target  # production, preview, development
+  sensitive  = each.value.sensitive
+  git_branch = each.value.git_branch
+}
+```
+
+### Deployment Module
+```hcl
+resource "vercel_deployment" "this" {
+  for_each = var.deployments
+
+  project_id  = each.value.project_id
+  production  = each.value.production
+  ref         = each.value.ref
+  path_prefix = each.value.path_prefix
+
+  files = each.value.files
+
+  environment = each.value.environment
+
+  project_settings {
+    build_command    = each.value.build_command
+    output_directory = each.value.output_directory
+    framework        = each.value.framework
+  }
+}
+```
+
+### Domain Module
+```hcl
+resource "vercel_project_domain" "this" {
+  for_each = var.project_domains
+
+  project_id = each.value.project_id
+  domain     = each.key
+
+  redirect             = each.value.redirect
+  redirect_status_code = each.value.redirect_status_code
+  git_branch           = each.value.git_branch
+}
+
+resource "vercel_dns_record" "this" {
+  for_each = var.dns_records
+
+  domain  = each.value.domain
+  name    = each.value.name
+  type    = each.value.type  # A, AAAA, CNAME, TXT, MX, etc.
+  value   = each.value.value
+  ttl     = each.value.ttl
+  mx_priority = each.value.mx_priority
+}
+```
+
+### Edge Config
+```hcl
+resource "vercel_edge_config" "this" {
+  for_each = var.edge_configs
+
+  name = each.key
+}
+
+resource "vercel_edge_config_item" "this" {
+  for_each = var.edge_config_items
+
+  edge_config_id = each.value.edge_config_id
+  key            = each.value.key
+  value          = each.value.value
+}
+
+resource "vercel_edge_config_token" "this" {
+  for_each = var.edge_config_tokens
+
+  edge_config_id = each.value.edge_config_id
+  label          = each.key
+}
+
+resource "vercel_project_environment_variable" "edge_config" {
+  for_each = var.edge_config_connections
+
+  project_id = each.value.project_id
+  key        = "EDGE_CONFIG"
+  value      = vercel_edge_config_token.this[each.value.token_key].connection_string
+  target     = ["production", "preview", "development"]
+}
+```
+
+---
+
+## Heroku Provider (heroku/heroku)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    heroku = {
+      source  = "heroku/heroku"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "heroku" {
+  # API key via HEROKU_API_KEY env var
+  # Email via HEROKU_EMAIL env var
+}
+```
+
+### App Module
+```hcl
+resource "heroku_app" "this" {
+  for_each = var.apps
+
+  name   = each.key
+  region = each.value.region  # us, eu
+  stack  = each.value.stack   # heroku-22, heroku-20, container
+
+  space        = each.value.space
+  organization = each.value.organization
+  acm          = each.value.acm  # Automated Certificate Management
+  internal_routing = each.value.internal_routing
+
+  buildpacks = each.value.buildpacks
+
+  sensitive_config_vars = each.value.sensitive_config_vars
+  config_vars           = each.value.config_vars
+}
+
+resource "heroku_app_config_association" "this" {
+  for_each = var.app_configs
+
+  app_id = each.value.app_id
+
+  vars           = each.value.vars
+  sensitive_vars = each.value.sensitive_vars
+}
+```
+
+### Addon Module
+```hcl
+resource "heroku_addon" "this" {
+  for_each = var.addons
+
+  app_id = each.value.app_id
+  plan   = each.value.plan  # heroku-postgresql:standard-0, heroku-redis:premium-0
+
+  config = each.value.config
+}
+
+resource "heroku_addon_attachment" "this" {
+  for_each = var.addon_attachments
+
+  app_id   = each.value.app_id
+  addon_id = each.value.addon_id
+  name     = each.key
+}
+```
+
+### Formation (Dyno) Module
+```hcl
+resource "heroku_formation" "this" {
+  for_each = var.formations
+
+  app_id   = each.value.app_id
+  type     = each.value.type  # web, worker, etc.
+  quantity = each.value.quantity
+  size     = each.value.size  # basic, standard-1x, standard-2x, performance-m, etc.
+}
+```
+
+### Domain & SSL
+```hcl
+resource "heroku_domain" "this" {
+  for_each = var.domains
+
+  app_id   = each.value.app_id
+  hostname = each.key
+
+  sni_endpoint_id = each.value.sni_endpoint_id
+}
+
+resource "heroku_ssl" "this" {
+  for_each = var.ssl_certs
+
+  app_id            = each.value.app_id
+  certificate_chain = each.value.certificate_chain
+  private_key       = each.value.private_key
+}
+```
+
+### Pipeline Module
+```hcl
+resource "heroku_pipeline" "this" {
+  for_each = var.pipelines
+
+  name = each.key
+
+  owner {
+    id   = each.value.owner_id
+    type = each.value.owner_type  # user, team
+  }
+}
+
+resource "heroku_pipeline_coupling" "this" {
+  for_each = var.pipeline_couplings
+
+  app_id   = each.value.app_id
+  pipeline = each.value.pipeline_id
+  stage    = each.value.stage  # review, development, staging, production
+}
+```
+
+---
+
+## DigitalOcean Provider (digitalocean/digitalocean)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  # Token via DIGITALOCEAN_TOKEN env var
+  # Or Spaces access credentials
+  spaces_access_id  = var.spaces_access_id
+  spaces_secret_key = var.spaces_secret_key
+}
+```
+
+### Droplet Module
+```hcl
+variable "droplets" {
+  description = "Droplet configurations"
+  type = map(object({
+    image              = string
+    region             = string
+    size               = string
+    backups            = optional(bool, false)
+    monitoring         = optional(bool, true)
+    ipv6               = optional(bool, false)
+    vpc_uuid           = optional(string)
+    ssh_keys           = optional(list(string), [])
+    resize_disk        = optional(bool, true)
+    tags               = optional(list(string), [])
+    user_data          = optional(string)
+    droplet_agent      = optional(bool, true)
+    graceful_shutdown  = optional(bool, false)
+  }))
+}
+
+resource "digitalocean_droplet" "this" {
+  for_each = var.droplets
+
+  name               = each.key
+  image              = each.value.image
+  region             = each.value.region
+  size               = each.value.size
+  backups            = each.value.backups
+  monitoring         = each.value.monitoring
+  ipv6               = each.value.ipv6
+  vpc_uuid           = each.value.vpc_uuid
+  ssh_keys           = each.value.ssh_keys
+  resize_disk        = each.value.resize_disk
+  tags               = each.value.tags
+  user_data          = each.value.user_data
+  droplet_agent      = each.value.droplet_agent
+  graceful_shutdown  = each.value.graceful_shutdown
+}
+
+resource "digitalocean_reserved_ip" "this" {
+  for_each = { for k, v in var.droplets : k => v if v.reserved_ip }
+
+  region     = each.value.region
+  droplet_id = digitalocean_droplet.this[each.key].id
+}
+```
+
+### Kubernetes Module
+```hcl
+resource "digitalocean_kubernetes_cluster" "this" {
+  for_each = var.kubernetes_clusters
+
+  name         = each.key
+  region       = each.value.region
+  version      = each.value.version  # 1.29.x, 1.28.x
+  vpc_uuid     = each.value.vpc_uuid
+  auto_upgrade = each.value.auto_upgrade
+  surge_upgrade = each.value.surge_upgrade
+  ha           = each.value.ha
+
+  maintenance_policy {
+    start_time = each.value.maintenance_start
+    day        = each.value.maintenance_day
+  }
+
+  dynamic "node_pool" {
+    for_each = each.value.node_pools
+    content {
+      name       = node_pool.value.name
+      size       = node_pool.value.size
+      node_count = node_pool.value.node_count
+      auto_scale = node_pool.value.auto_scale
+      min_nodes  = node_pool.value.min_nodes
+      max_nodes  = node_pool.value.max_nodes
+      tags       = node_pool.value.tags
+      labels     = node_pool.value.labels
+
+      dynamic "taint" {
+        for_each = node_pool.value.taints
+        content {
+          key    = taint.value.key
+          value  = taint.value.value
+          effect = taint.value.effect
+        }
+      }
+    }
+  }
+
+  tags = each.value.tags
+}
+```
+
+### Database Module
+```hcl
+resource "digitalocean_database_cluster" "this" {
+  for_each = var.database_clusters
+
+  name       = each.key
+  engine     = each.value.engine  # pg, mysql, redis, mongodb
+  version    = each.value.version
+  size       = each.value.size
+  region     = each.value.region
+  node_count = each.value.node_count
+
+  private_network_uuid = each.value.private_network_uuid
+
+  maintenance_window {
+    day  = each.value.maintenance_day
+    hour = each.value.maintenance_hour
+  }
+
+  tags = each.value.tags
+}
+
+resource "digitalocean_database_db" "this" {
+  for_each = var.databases
+
+  cluster_id = each.value.cluster_id
+  name       = each.key
+}
+
+resource "digitalocean_database_user" "this" {
+  for_each = var.database_users
+
+  cluster_id = each.value.cluster_id
+  name       = each.key
+  mysql_auth_plugin = each.value.mysql_auth_plugin
+}
+
+resource "digitalocean_database_firewall" "this" {
+  for_each = var.database_firewalls
+
+  cluster_id = each.value.cluster_id
+
+  dynamic "rule" {
+    for_each = each.value.rules
+    content {
+      type  = rule.value.type  # droplet, k8s, ip_addr, tag, app
+      value = rule.value.value
+    }
+  }
+}
+```
+
+### Spaces (Object Storage) Module
+```hcl
+resource "digitalocean_spaces_bucket" "this" {
+  for_each = var.spaces_buckets
+
+  name   = each.key
+  region = each.value.region
+  acl    = each.value.acl  # private, public-read
+
+  cors_rule {
+    allowed_headers = each.value.cors_headers
+    allowed_methods = each.value.cors_methods
+    allowed_origins = each.value.cors_origins
+    max_age_seconds = each.value.cors_max_age
+  }
+
+  lifecycle_rule {
+    id                                     = "cleanup"
+    enabled                                = each.value.lifecycle_enabled
+    abort_incomplete_multipart_upload_days = each.value.abort_incomplete_days
+    expiration {
+      days = each.value.expiration_days
+    }
+  }
+
+  versioning {
+    enabled = each.value.versioning
+  }
+
+  force_destroy = each.value.force_destroy
+}
+
+resource "digitalocean_spaces_bucket_policy" "this" {
+  for_each = var.spaces_bucket_policies
+
+  bucket = each.value.bucket
+  region = each.value.region
+  policy = each.value.policy
+}
+
+resource "digitalocean_cdn" "this" {
+  for_each = var.cdn_endpoints
+
+  origin         = each.value.origin
+  ttl            = each.value.ttl
+  certificate_id = each.value.certificate_id
+  custom_domain  = each.value.custom_domain
+}
+```
+
+### App Platform
+```hcl
+resource "digitalocean_app" "this" {
+  for_each = var.apps
+
+  spec {
+    name   = each.key
+    region = each.value.region
+
+    dynamic "service" {
+      for_each = each.value.services
+      content {
+        name               = service.value.name
+        instance_count     = service.value.instance_count
+        instance_size_slug = service.value.instance_size
+        http_port          = service.value.http_port
+
+        git {
+          repo_clone_url = service.value.repo_url
+          branch         = service.value.branch
+        }
+
+        build_command = service.value.build_command
+        run_command   = service.value.run_command
+        source_dir    = service.value.source_dir
+
+        dynamic "env" {
+          for_each = service.value.env_vars
+          content {
+            key   = env.key
+            value = env.value
+            scope = "RUN_AND_BUILD_TIME"
+            type  = "GENERAL"
+          }
+        }
+
+        health_check {
+          http_path             = service.value.health_path
+          initial_delay_seconds = service.value.initial_delay
+          period_seconds        = service.value.period_seconds
+        }
+
+        dynamic "autoscaling" {
+          for_each = service.value.autoscaling != null ? [service.value.autoscaling] : []
+          content {
+            min_instance_count = autoscaling.value.min_instances
+            max_instance_count = autoscaling.value.max_instances
+            metrics {
+              cpu {
+                percent = autoscaling.value.cpu_percent
+              }
+            }
+          }
+        }
+      }
+    }
+
+    dynamic "database" {
+      for_each = each.value.databases
+      content {
+        name         = database.value.name
+        engine       = database.value.engine
+        version      = database.value.version
+        production   = database.value.production
+        cluster_name = database.value.cluster_name
+        db_name      = database.value.db_name
+        db_user      = database.value.db_user
+      }
+    }
+
+    dynamic "domain" {
+      for_each = each.value.domains
+      content {
+        name = domain.value.name
+        type = domain.value.type  # DEFAULT, PRIMARY, ALIAS
+        zone = domain.value.zone
+      }
+    }
+  }
+}
+```
+
+---
+
+## Linode Provider (linode/linode)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "linode" {
+  # Token via LINODE_TOKEN env var
+}
+```
+
+### Instance Module
+```hcl
+resource "linode_instance" "this" {
+  for_each = var.instances
+
+  label           = each.key
+  image           = each.value.image
+  region          = each.value.region
+  type            = each.value.type
+  authorized_keys = each.value.authorized_keys
+  root_pass       = each.value.root_pass
+  tags            = each.value.tags
+  private_ip      = each.value.private_ip
+  watchdog_enabled = each.value.watchdog_enabled
+  backups_enabled  = each.value.backups_enabled
+  booted          = each.value.booted
+  resize_disk     = each.value.resize_disk
+  swap_size       = each.value.swap_size
+  group           = each.value.group
+
+  stackscript_id   = each.value.stackscript_id
+  stackscript_data = each.value.stackscript_data
+}
+```
+
+### LKE (Kubernetes) Module
+```hcl
+resource "linode_lke_cluster" "this" {
+  for_each = var.lke_clusters
+
+  label       = each.key
+  k8s_version = each.value.k8s_version
+  region      = each.value.region
+  tags        = each.value.tags
+
+  control_plane {
+    high_availability = each.value.ha
+  }
+
+  dynamic "pool" {
+    for_each = each.value.pools
+    content {
+      type  = pool.value.type
+      count = pool.value.count
+
+      dynamic "autoscaler" {
+        for_each = pool.value.autoscaler != null ? [pool.value.autoscaler] : []
+        content {
+          min = autoscaler.value.min
+          max = autoscaler.value.max
+        }
+      }
+    }
+  }
+}
+```
+
+### Object Storage Module
+```hcl
+resource "linode_object_storage_key" "this" {
+  for_each = var.object_storage_keys
+
+  label = each.key
+
+  dynamic "bucket_access" {
+    for_each = each.value.bucket_access
+    content {
+      bucket_name = bucket_access.value.bucket_name
+      cluster     = bucket_access.value.cluster
+      permissions = bucket_access.value.permissions  # read_only, read_write
+    }
+  }
+}
+
+resource "linode_object_storage_bucket" "this" {
+  for_each = var.object_storage_buckets
+
+  cluster = each.value.cluster
+  label   = each.key
+  acl     = each.value.acl  # private, public-read, etc.
+
+  dynamic "lifecycle_rule" {
+    for_each = each.value.lifecycle_rules
+    content {
+      id      = lifecycle_rule.value.id
+      enabled = lifecycle_rule.value.enabled
+      prefix  = lifecycle_rule.value.prefix
+
+      expiration {
+        days = lifecycle_rule.value.expiration_days
+      }
+    }
+  }
+
+  versioning = each.value.versioning
+}
+```
+
+---
+
+## Vultr Provider (vultr/vultr)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "vultr" {
+  # API key via VULTR_API_KEY env var
+}
+```
+
+### Instance Module
+```hcl
+resource "vultr_instance" "this" {
+  for_each = var.instances
+
+  label       = each.key
+  plan        = each.value.plan
+  region      = each.value.region
+  os_id       = each.value.os_id
+  app_id      = each.value.app_id
+  iso_id      = each.value.iso_id
+  snapshot_id = each.value.snapshot_id
+
+  enable_ipv6           = each.value.enable_ipv6
+  enable_vpc            = each.value.enable_vpc
+  vpc_ids               = each.value.vpc_ids
+  ddos_protection       = each.value.ddos_protection
+  activation_email      = each.value.activation_email
+  hostname              = each.value.hostname
+  firewall_group_id     = each.value.firewall_group_id
+  backups               = each.value.backups ? "enabled" : "disabled"
+  reserved_ip_id        = each.value.reserved_ip_id
+
+  ssh_key_ids = each.value.ssh_key_ids
+  user_data   = each.value.user_data
+  tags        = each.value.tags
+
+  script_id = each.value.script_id
+}
+```
+
+### Kubernetes Module
+```hcl
+resource "vultr_kubernetes" "this" {
+  for_each = var.kubernetes_clusters
+
+  label   = each.key
+  region  = each.value.region
+  version = each.value.version
+  ha_controlplanes = each.value.ha
+  enable_firewall  = each.value.enable_firewall
+
+  dynamic "node_pools" {
+    for_each = each.value.node_pools
+    content {
+      node_quantity = node_pools.value.node_quantity
+      plan          = node_pools.value.plan
+      label         = node_pools.value.label
+      auto_scaler   = node_pools.value.auto_scaler
+      min_nodes     = node_pools.value.min_nodes
+      max_nodes     = node_pools.value.max_nodes
+    }
+  }
+}
+
+resource "vultr_kubernetes_node_pools" "this" {
+  for_each = var.additional_node_pools
+
+  cluster_id    = each.value.cluster_id
+  node_quantity = each.value.node_quantity
+  plan          = each.value.plan
+  label         = each.key
+  auto_scaler   = each.value.auto_scaler
+  min_nodes     = each.value.min_nodes
+  max_nodes     = each.value.max_nodes
+}
+```
+
+### Database Module
+```hcl
+resource "vultr_database" "this" {
+  for_each = var.databases
+
+  label                   = each.key
+  database_engine         = each.value.engine
+  database_engine_version = each.value.version
+  region                  = each.value.region
+  plan                    = each.value.plan
+  cluster_time_zone       = each.value.timezone
+
+  maintenance_dow  = each.value.maintenance_dow
+  maintenance_time = each.value.maintenance_time
+
+  mysql_sql_modes                 = each.value.mysql_sql_modes
+  mysql_require_primary_key       = each.value.mysql_require_primary_key
+  mysql_slow_query_log            = each.value.mysql_slow_query_log
+  mysql_long_query_time           = each.value.mysql_long_query_time
+
+  redis_eviction_policy = each.value.redis_eviction_policy
+
+  trusted_ips       = each.value.trusted_ips
+  vpc_id            = each.value.vpc_id
+  public_host       = each.value.public_host
+
+  read_replicas = each.value.read_replicas
+}
+
+resource "vultr_database_user" "this" {
+  for_each = var.database_users
+
+  database_id = each.value.database_id
+  username    = each.key
+  password    = each.value.password
+}
+
+resource "vultr_database_db" "this" {
+  for_each = var.database_dbs
+
+  database_id = each.value.database_id
+  name        = each.key
+}
+```
+
+### Object Storage Module
+```hcl
+resource "vultr_object_storage" "this" {
+  for_each = var.object_storage
+
+  cluster_id = each.value.cluster_id
+  label      = each.key
+}
+```
+
+---
+
+## Best Practices
+
+### Vercel
+1. **Use Edge Config** - Fast global key-value store
+2. **Configure environment properly** - Production, preview, development
+3. **Use monorepo support** - root_directory configuration
+4. **Enable build cache** - Faster deployments
+5. **Configure domain verification** - DNS records
+
+### Heroku
+1. **Use review apps** - Pipeline-based testing
+2. **Configure formation** - Appropriate dyno sizes
+3. **Use addons** - Managed services
+4. **Enable ACM** - Automated certificates
+5. **Use private spaces** - Enterprise isolation
+
+### DigitalOcean
+1. **Use VPC** - Private networking
+2. **Enable monitoring** - Built-in metrics
+3. **Use managed databases** - Automatic backups
+4. **Configure firewalls** - Cloud firewalls
+5. **Use App Platform** - PaaS simplicity
+
+### Linode
+1. **Use StackScripts** - Automated provisioning
+2. **Enable backups** - Automatic backup service
+3. **Use LKE** - Managed Kubernetes
+4. **Configure VLANs** - Private networking
+5. **Use NodeBalancers** - Load balancing
+
+### Vultr
+1. **Use VPC** - Private networking
+2. **Enable DDoS protection** - Built-in protection
+3. **Use managed databases** - Automatic failover
+4. **Configure firewall groups** - Security rules
+5. **Use block storage** - Scalable volumes

--- a/components/skills/iac-terraform-modules-eng/references/security-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/security-providers.md
@@ -1,0 +1,637 @@
+# Security Provider Patterns
+
+## Vault Provider (hashicorp/vault)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# Option 1: Token auth
+provider "vault" {
+  address = var.vault_address
+  token   = var.vault_token
+}
+
+# Option 2: AppRole auth
+provider "vault" {
+  address = var.vault_address
+
+  auth_login {
+    path = "auth/approle/login"
+
+    parameters = {
+      role_id   = var.vault_role_id
+      secret_id = var.vault_secret_id
+    }
+  }
+}
+
+# Option 3: Kubernetes auth
+provider "vault" {
+  address = var.vault_address
+
+  auth_login {
+    path = "auth/kubernetes/login"
+
+    parameters = {
+      role = var.vault_role
+      jwt  = file("/var/run/secrets/kubernetes.io/serviceaccount/token")
+    }
+  }
+}
+```
+
+### Auth Backend Module
+```hcl
+# AppRole Auth
+resource "vault_auth_backend" "approle" {
+  type = "approle"
+  path = var.approle_path
+}
+
+resource "vault_approle_auth_backend_role" "this" {
+  for_each = var.approle_roles
+
+  backend               = vault_auth_backend.approle.path
+  role_name             = each.key
+  token_policies        = each.value.token_policies
+  token_ttl             = each.value.token_ttl
+  token_max_ttl         = each.value.token_max_ttl
+  secret_id_ttl         = each.value.secret_id_ttl
+  secret_id_num_uses    = each.value.secret_id_num_uses
+  token_num_uses        = each.value.token_num_uses
+  bind_secret_id        = each.value.bind_secret_id
+  secret_id_bound_cidrs = each.value.secret_id_bound_cidrs
+}
+
+# Kubernetes Auth
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = var.kubernetes_path
+}
+
+resource "vault_kubernetes_auth_backend_config" "this" {
+  backend            = vault_auth_backend.kubernetes.path
+  kubernetes_host    = var.kubernetes_host
+  kubernetes_ca_cert = var.kubernetes_ca_cert
+  token_reviewer_jwt = var.token_reviewer_jwt
+}
+
+resource "vault_kubernetes_auth_backend_role" "this" {
+  for_each = var.kubernetes_roles
+
+  backend                          = vault_auth_backend.kubernetes.path
+  role_name                        = each.key
+  bound_service_account_names      = each.value.service_account_names
+  bound_service_account_namespaces = each.value.service_account_namespaces
+  token_policies                   = each.value.token_policies
+  token_ttl                        = each.value.token_ttl
+  token_max_ttl                    = each.value.token_max_ttl
+  audience                         = each.value.audience
+}
+
+# OIDC Auth
+resource "vault_jwt_auth_backend" "oidc" {
+  count = var.enable_oidc ? 1 : 0
+
+  path               = "oidc"
+  type               = "oidc"
+  oidc_discovery_url = var.oidc_discovery_url
+  oidc_client_id     = var.oidc_client_id
+  oidc_client_secret = var.oidc_client_secret
+  default_role       = var.oidc_default_role
+}
+
+resource "vault_jwt_auth_backend_role" "oidc_roles" {
+  for_each = var.oidc_roles
+
+  backend        = vault_jwt_auth_backend.oidc[0].path
+  role_name      = each.key
+  role_type      = "oidc"
+  token_policies = each.value.token_policies
+
+  allowed_redirect_uris = each.value.allowed_redirect_uris
+  user_claim            = each.value.user_claim
+  groups_claim          = each.value.groups_claim
+  bound_claims          = each.value.bound_claims
+  claim_mappings        = each.value.claim_mappings
+}
+```
+
+### Secrets Engine Module
+```hcl
+# KV v2 Secrets Engine
+resource "vault_mount" "kv" {
+  for_each = var.kv_mounts
+
+  path        = each.key
+  type        = "kv"
+  options     = { version = "2" }
+  description = each.value.description
+}
+
+resource "vault_kv_secret_v2" "this" {
+  for_each = var.kv_secrets
+
+  mount               = each.value.mount
+  name                = each.value.name
+  cas                 = each.value.cas
+  delete_all_versions = each.value.delete_all_versions
+  data_json           = jsonencode(each.value.data)
+}
+
+# Database Secrets Engine
+resource "vault_mount" "database" {
+  for_each = var.database_mounts
+
+  path = each.key
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "postgres" {
+  for_each = var.postgres_connections
+
+  backend       = each.value.mount
+  name          = each.key
+  allowed_roles = each.value.allowed_roles
+
+  postgresql {
+    connection_url = each.value.connection_url
+    max_open_connections = each.value.max_open_connections
+    max_idle_connections = each.value.max_idle_connections
+    max_connection_lifetime = each.value.max_connection_lifetime
+  }
+}
+
+resource "vault_database_secret_backend_role" "this" {
+  for_each = var.database_roles
+
+  backend             = each.value.backend
+  name                = each.key
+  db_name             = each.value.db_name
+  creation_statements = each.value.creation_statements
+  revocation_statements = each.value.revocation_statements
+  default_ttl         = each.value.default_ttl
+  max_ttl             = each.value.max_ttl
+}
+
+# PKI Secrets Engine
+resource "vault_mount" "pki" {
+  for_each = var.pki_mounts
+
+  path                      = each.key
+  type                      = "pki"
+  description               = each.value.description
+  default_lease_ttl_seconds = each.value.default_lease_ttl
+  max_lease_ttl_seconds     = each.value.max_lease_ttl
+}
+
+resource "vault_pki_secret_backend_root_cert" "root" {
+  for_each = { for k, v in var.pki_mounts : k => v if v.is_root }
+
+  backend              = vault_mount.pki[each.key].path
+  type                 = "internal"
+  common_name          = each.value.common_name
+  ttl                  = each.value.ttl
+  format               = "pem"
+  private_key_format   = "der"
+  key_type             = "rsa"
+  key_bits             = 4096
+  exclude_cn_from_sans = true
+  organization         = each.value.organization
+  ou                   = each.value.ou
+}
+
+resource "vault_pki_secret_backend_role" "this" {
+  for_each = var.pki_roles
+
+  backend          = each.value.backend
+  name             = each.key
+  ttl              = each.value.ttl
+  max_ttl          = each.value.max_ttl
+  allow_ip_sans    = each.value.allow_ip_sans
+  key_type         = each.value.key_type
+  key_bits         = each.value.key_bits
+  allowed_domains  = each.value.allowed_domains
+  allow_subdomains = each.value.allow_subdomains
+  allow_glob_domains = each.value.allow_glob_domains
+  allow_any_name   = each.value.allow_any_name
+  enforce_hostnames = each.value.enforce_hostnames
+  allow_bare_domains = each.value.allow_bare_domains
+  server_flag      = each.value.server_flag
+  client_flag      = each.value.client_flag
+}
+
+# AWS Secrets Engine
+resource "vault_aws_secret_backend" "this" {
+  for_each = var.aws_backends
+
+  path       = each.key
+  access_key = each.value.access_key
+  secret_key = each.value.secret_key
+  region     = each.value.region
+
+  default_lease_ttl_seconds = each.value.default_lease_ttl
+  max_lease_ttl_seconds     = each.value.max_lease_ttl
+}
+
+resource "vault_aws_secret_backend_role" "this" {
+  for_each = var.aws_roles
+
+  backend         = each.value.backend
+  name            = each.key
+  credential_type = each.value.credential_type  # iam_user, assumed_role, federation_token
+
+  role_arns       = each.value.role_arns
+  policy_arns     = each.value.policy_arns
+  policy_document = each.value.policy_document
+  default_sts_ttl = each.value.default_sts_ttl
+  max_sts_ttl     = each.value.max_sts_ttl
+}
+
+# Transit Secrets Engine
+resource "vault_mount" "transit" {
+  count = var.enable_transit ? 1 : 0
+
+  path        = "transit"
+  type        = "transit"
+  description = "Transit secrets engine for encryption as a service"
+}
+
+resource "vault_transit_secret_backend_key" "this" {
+  for_each = var.transit_keys
+
+  backend          = vault_mount.transit[0].path
+  name             = each.key
+  type             = each.value.type  # aes256-gcm96, chacha20-poly1305, rsa-2048, etc.
+  deletion_allowed = each.value.deletion_allowed
+  exportable       = each.value.exportable
+  allow_plaintext_backup = each.value.allow_plaintext_backup
+
+  min_decryption_version = each.value.min_decryption_version
+  min_encryption_version = each.value.min_encryption_version
+
+  auto_rotate_period = each.value.auto_rotate_period
+}
+```
+
+### Policy Module
+```hcl
+resource "vault_policy" "this" {
+  for_each = var.policies
+
+  name   = each.key
+  policy = each.value.policy
+}
+
+# Example policy HCL
+locals {
+  app_policy = <<-EOT
+    # Read application secrets
+    path "secret/data/app/*" {
+      capabilities = ["read", "list"]
+    }
+
+    # Issue certificates
+    path "pki/issue/app-role" {
+      capabilities = ["create", "update"]
+    }
+
+    # Get database credentials
+    path "database/creds/app-role" {
+      capabilities = ["read"]
+    }
+
+    # Encrypt/decrypt with transit
+    path "transit/encrypt/app-key" {
+      capabilities = ["update"]
+    }
+
+    path "transit/decrypt/app-key" {
+      capabilities = ["update"]
+    }
+  EOT
+}
+```
+
+### Namespace Module (Enterprise)
+```hcl
+resource "vault_namespace" "this" {
+  for_each = var.namespaces
+
+  path = each.key
+}
+
+# Cross-namespace auth
+resource "vault_namespace" "child" {
+  for_each = var.child_namespaces
+
+  namespace = each.value.parent
+  path      = each.key
+}
+```
+
+---
+
+## TLS Provider (hashicorp/tls)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+```
+
+### Private Key Module
+```hcl
+variable "private_keys" {
+  description = "Private key configurations"
+  type = map(object({
+    algorithm   = string  # RSA, ECDSA, ED25519
+    rsa_bits    = optional(number, 4096)
+    ecdsa_curve = optional(string, "P384")  # P224, P256, P384, P521
+  }))
+}
+
+resource "tls_private_key" "this" {
+  for_each = var.private_keys
+
+  algorithm   = each.value.algorithm
+  rsa_bits    = each.value.algorithm == "RSA" ? each.value.rsa_bits : null
+  ecdsa_curve = each.value.algorithm == "ECDSA" ? each.value.ecdsa_curve : null
+}
+
+output "private_keys_pem" {
+  value     = { for k, v in tls_private_key.this : k => v.private_key_pem }
+  sensitive = true
+}
+
+output "public_keys_pem" {
+  value = { for k, v in tls_private_key.this : k => v.public_key_pem }
+}
+
+output "public_keys_openssh" {
+  value = { for k, v in tls_private_key.this : k => v.public_key_openssh }
+}
+```
+
+### Self-Signed Certificate Module
+```hcl
+variable "self_signed_certs" {
+  description = "Self-signed certificate configurations"
+  type = map(object({
+    private_key_pem = string
+    subject = object({
+      common_name         = string
+      organization        = optional(string)
+      organizational_unit = optional(string)
+      locality            = optional(string)
+      province            = optional(string)
+      country             = optional(string)
+    })
+    validity_period_hours = number
+    is_ca_certificate     = optional(bool, false)
+    allowed_uses          = list(string)
+    dns_names             = optional(list(string), [])
+    ip_addresses          = optional(list(string), [])
+  }))
+}
+
+resource "tls_self_signed_cert" "this" {
+  for_each = var.self_signed_certs
+
+  private_key_pem = each.value.private_key_pem
+
+  subject {
+    common_name         = each.value.subject.common_name
+    organization        = each.value.subject.organization
+    organizational_unit = each.value.subject.organizational_unit
+    locality            = each.value.subject.locality
+    province            = each.value.subject.province
+    country             = each.value.subject.country
+  }
+
+  validity_period_hours = each.value.validity_period_hours
+  is_ca_certificate     = each.value.is_ca_certificate
+  allowed_uses          = each.value.allowed_uses
+  dns_names             = each.value.dns_names
+  ip_addresses          = each.value.ip_addresses
+}
+
+# Common allowed_uses values:
+# - key_encipherment
+# - digital_signature
+# - server_auth
+# - client_auth
+# - cert_signing
+# - crl_signing
+# - code_signing
+# - email_protection
+# - ipsec_end_system
+# - ipsec_tunnel
+# - ipsec_user
+# - timestamping
+# - ocsp_signing
+```
+
+### Certificate Request (CSR) Module
+```hcl
+resource "tls_cert_request" "this" {
+  for_each = var.cert_requests
+
+  private_key_pem = each.value.private_key_pem
+
+  subject {
+    common_name         = each.value.subject.common_name
+    organization        = each.value.subject.organization
+    organizational_unit = each.value.subject.organizational_unit
+  }
+
+  dns_names    = each.value.dns_names
+  ip_addresses = each.value.ip_addresses
+  uris         = each.value.uris
+}
+
+output "cert_requests_pem" {
+  value = { for k, v in tls_cert_request.this : k => v.cert_request_pem }
+}
+```
+
+### Locally Signed Certificate Module
+```hcl
+resource "tls_locally_signed_cert" "this" {
+  for_each = var.locally_signed_certs
+
+  cert_request_pem   = each.value.cert_request_pem
+  ca_private_key_pem = each.value.ca_private_key_pem
+  ca_cert_pem        = each.value.ca_cert_pem
+
+  validity_period_hours = each.value.validity_period_hours
+  allowed_uses          = each.value.allowed_uses
+
+  is_ca_certificate = each.value.is_ca_certificate
+
+  set_subject_key_id = true
+}
+```
+
+### Complete PKI Example
+```hcl
+# Root CA
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "tls_self_signed_cert" "ca" {
+  private_key_pem = tls_private_key.ca.private_key_pem
+
+  subject {
+    common_name  = "Example Root CA"
+    organization = "Example Inc"
+  }
+
+  validity_period_hours = 87600  # 10 years
+  is_ca_certificate     = true
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+    "digital_signature",
+    "key_encipherment",
+  ]
+}
+
+# Server certificate
+resource "tls_private_key" "server" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "server" {
+  private_key_pem = tls_private_key.server.private_key_pem
+
+  subject {
+    common_name  = "server.example.com"
+    organization = "Example Inc"
+  }
+
+  dns_names = [
+    "server.example.com",
+    "*.server.example.com",
+    "localhost",
+  ]
+
+  ip_addresses = ["127.0.0.1"]
+}
+
+resource "tls_locally_signed_cert" "server" {
+  cert_request_pem   = tls_cert_request.server.cert_request_pem
+  ca_private_key_pem = tls_private_key.ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
+
+  validity_period_hours = 8760  # 1 year
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "server_auth",
+  ]
+}
+
+# Client certificate
+resource "tls_private_key" "client" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "client" {
+  private_key_pem = tls_private_key.client.private_key_pem
+
+  subject {
+    common_name  = "client@example.com"
+    organization = "Example Inc"
+  }
+}
+
+resource "tls_locally_signed_cert" "client" {
+  cert_request_pem   = tls_cert_request.client.cert_request_pem
+  ca_private_key_pem = tls_private_key.ca.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
+
+  validity_period_hours = 8760
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "client_auth",
+  ]
+}
+```
+
+### SSH Key Module
+```hcl
+resource "tls_private_key" "ssh" {
+  for_each = var.ssh_keys
+
+  algorithm = each.value.algorithm  # RSA, ED25519, ECDSA
+  rsa_bits  = each.value.rsa_bits
+}
+
+# Store in AWS Secrets Manager
+resource "aws_secretsmanager_secret" "ssh_key" {
+  for_each = var.ssh_keys
+
+  name = "ssh-key-${each.key}"
+}
+
+resource "aws_secretsmanager_secret_version" "ssh_key" {
+  for_each = var.ssh_keys
+
+  secret_id = aws_secretsmanager_secret.ssh_key[each.key].id
+  secret_string = jsonencode({
+    private_key = tls_private_key.ssh[each.key].private_key_openssh
+    public_key  = tls_private_key.ssh[each.key].public_key_openssh
+  })
+}
+```
+
+---
+
+## Best Practices
+
+### Vault
+1. **Use dynamic secrets** - Short-lived, automatically rotated
+2. **Enable audit logging** - All operations logged
+3. **Use namespaces** - Tenant isolation (Enterprise)
+4. **Implement least privilege policies** - Fine-grained access
+5. **Enable response wrapping** - Secure secret delivery
+6. **Use auto-unseal** - AWS KMS, Azure Key Vault, GCP KMS
+7. **Enable high availability** - Raft or Consul storage
+8. **Regular token rotation** - Limit token lifetime
+9. **Use AppRole for automation** - Machine-to-machine auth
+10. **Enable telemetry** - Monitor Vault health
+
+### TLS
+1. **Use RSA-4096 or ECDSA P-384** - Strong key sizes
+2. **Short certificate lifetimes** - 90 days max for leaf certs
+3. **Store private keys securely** - Vault, AWS Secrets Manager
+4. **Use SANs over CN** - Modern certificate practice
+5. **Implement certificate rotation** - Automated renewal
+6. **Use separate keys per service** - Limit blast radius
+7. **Enable OCSP stapling** - Certificate revocation
+8. **Use hardware security modules** - HSM for production CAs
+9. **Implement certificate pinning** - For critical services
+10. **Monitor certificate expiration** - Alerting before expiry

--- a/components/skills/iac-terraform-modules-eng/references/utility-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/utility-providers.md
@@ -1,0 +1,551 @@
+# Utility Provider Patterns
+
+## Template Provider (hashicorp/template)
+
+> **Note**: The template provider is deprecated. Use `templatefile()` function instead.
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
+  }
+}
+```
+
+### Legacy Template Data Source
+```hcl
+# Deprecated - use templatefile() instead
+data "template_file" "user_data" {
+  template = file("${path.module}/templates/user_data.sh")
+
+  vars = {
+    cluster_name = var.cluster_name
+    environment  = var.environment
+  }
+}
+```
+
+### Modern Approach: templatefile()
+```hcl
+# Preferred method - no provider needed
+locals {
+  user_data = templatefile("${path.module}/templates/user_data.sh", {
+    cluster_name = var.cluster_name
+    environment  = var.environment
+    packages     = jsonencode(var.packages)
+  })
+}
+
+# Template file: templates/user_data.sh
+# #!/bin/bash
+# CLUSTER_NAME="${cluster_name}"
+# ENVIRONMENT="${environment}"
+# PACKAGES='${packages}'
+#
+# for pkg in $(echo $PACKAGES | jq -r '.[]'); do
+#   apt-get install -y $pkg
+# done
+
+# Using with for_each
+locals {
+  rendered_configs = {
+    for name, config in var.services :
+    name => templatefile("${path.module}/templates/service.yaml", {
+      service_name = name
+      port         = config.port
+      replicas     = config.replicas
+    })
+  }
+}
+```
+
+### Template Directives
+```hcl
+# templates/config.yaml.tpl
+
+# String interpolation
+name: ${service_name}
+port: ${port}
+
+# Conditionals
+%{ if enable_ssl ~}
+ssl:
+  enabled: true
+  certificate: /etc/ssl/cert.pem
+%{ endif ~}
+
+# Loops
+replicas:
+%{ for i in range(replica_count) ~}
+  - id: replica-${i}
+    zone: ${zones[i % length(zones)]}
+%{ endfor ~}
+
+# Strips newlines with ~
+labels:
+%{ for key, value in labels ~}
+  ${key}: "${value}"
+%{ endfor ~}
+```
+
+---
+
+## Time Provider (hashicorp/time)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.11"
+    }
+  }
+}
+```
+
+### Static Time Reference
+```hcl
+# Capture timestamp at apply time
+resource "time_static" "created" {}
+
+output "creation_timestamp" {
+  value = time_static.created.rfc3339
+}
+
+# With triggers for recreation
+resource "time_static" "rotation" {
+  triggers = {
+    version = var.config_version
+  }
+}
+```
+
+### Offset Time
+```hcl
+# Calculate future/past times
+resource "time_offset" "certificate_expiry" {
+  offset_days   = 365
+  offset_hours  = 0
+  offset_months = 0
+  offset_years  = 0
+
+  # Or offset from specific time
+  base_rfc3339 = "2024-01-01T00:00:00Z"
+}
+
+output "expiry_date" {
+  value = time_offset.certificate_expiry.rfc3339
+}
+
+# Token expiration
+resource "time_offset" "token_expiry" {
+  offset_hours = 24
+
+  triggers = {
+    token_id = random_uuid.token.id
+  }
+}
+```
+
+### Rotating Time
+```hcl
+# Rotation schedule for secrets
+resource "time_rotating" "secret_rotation" {
+  rotation_days = 30
+}
+
+resource "aws_secretsmanager_secret_version" "app_secret" {
+  secret_id     = aws_secretsmanager_secret.app.id
+  secret_string = random_password.app.result
+
+  lifecycle {
+    replace_triggered_by = [time_rotating.secret_rotation.id]
+  }
+}
+
+# More rotation options
+resource "time_rotating" "daily" {
+  rotation_hours = 24
+}
+
+resource "time_rotating" "weekly" {
+  rotation_days = 7
+}
+
+resource "time_rotating" "monthly" {
+  rotation_months = 1
+}
+
+resource "time_rotating" "yearly" {
+  rotation_years = 1
+}
+
+# Rotation with specific start time
+resource "time_rotating" "certificate" {
+  rotation_days = 90
+  rfc3339       = "2024-01-01T00:00:00Z"  # Start rotation from this time
+}
+```
+
+### Sleep Resource
+```hcl
+# Add delays between resources
+resource "time_sleep" "wait_for_propagation" {
+  depends_on = [aws_route53_record.main]
+
+  create_duration  = "60s"
+  destroy_duration = "30s"
+}
+
+resource "aws_acm_certificate_validation" "cert" {
+  depends_on = [time_sleep.wait_for_propagation]
+
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
+}
+
+# Conditional delays
+resource "time_sleep" "conditional_wait" {
+  count = var.wait_enabled ? 1 : 0
+
+  create_duration = "${var.wait_seconds}s"
+}
+```
+
+---
+
+## Local Provider (hashicorp/local)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+  }
+}
+```
+
+### Local File
+```hcl
+# Write content to file
+resource "local_file" "kubeconfig" {
+  content  = data.aws_eks_cluster.cluster.kubeconfig
+  filename = "${path.module}/kubeconfig"
+
+  file_permission      = "0600"
+  directory_permission = "0755"
+}
+
+# Write sensitive content
+resource "local_sensitive_file" "private_key" {
+  content         = tls_private_key.main.private_key_pem
+  filename        = "${path.module}/private_key.pem"
+  file_permission = "0600"
+}
+
+# Write from template
+resource "local_file" "config" {
+  content = templatefile("${path.module}/templates/config.yaml.tpl", {
+    environment = var.environment
+    endpoints   = var.endpoints
+  })
+  filename = "${path.module}/generated/config.yaml"
+}
+
+# Multiple files with for_each
+resource "local_file" "configs" {
+  for_each = var.config_files
+
+  content  = each.value.content
+  filename = "${path.module}/generated/${each.key}"
+}
+```
+
+### Read File Data Source
+```hcl
+# Read file content
+data "local_file" "existing_config" {
+  filename = "${path.module}/configs/base.yaml"
+}
+
+output "config_content" {
+  value = data.local_file.existing_config.content
+}
+
+# Read sensitive file
+data "local_sensitive_file" "existing_key" {
+  filename = var.private_key_path
+}
+```
+
+### Common Use Cases
+```hcl
+# Generate kubeconfig
+resource "local_file" "kubeconfig" {
+  content = yamlencode({
+    apiVersion = "v1"
+    kind       = "Config"
+    clusters = [{
+      name = var.cluster_name
+      cluster = {
+        certificate-authority-data = base64encode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
+        server                     = data.aws_eks_cluster.cluster.endpoint
+      }
+    }]
+    contexts = [{
+      name = var.cluster_name
+      context = {
+        cluster = var.cluster_name
+        user    = var.cluster_name
+      }
+    }]
+    current-context = var.cluster_name
+    users = [{
+      name = var.cluster_name
+      user = {
+        exec = {
+          apiVersion = "client.authentication.k8s.io/v1beta1"
+          command    = "aws"
+          args       = ["eks", "get-token", "--cluster-name", var.cluster_name]
+        }
+      }
+    }]
+  })
+  filename = "${path.root}/kubeconfig-${var.cluster_name}"
+}
+
+# Generate SSH config
+resource "local_file" "ssh_config" {
+  content = join("\n", [
+    for name, instance in aws_instance.this :
+    <<-EOT
+    Host ${name}
+      HostName ${instance.public_ip}
+      User ubuntu
+      IdentityFile ~/.ssh/id_rsa
+      StrictHostKeyChecking no
+    EOT
+  ])
+  filename = "${path.root}/ssh_config"
+}
+
+# Write Ansible inventory
+resource "local_file" "ansible_inventory" {
+  content = templatefile("${path.module}/templates/inventory.ini.tpl", {
+    web_servers = { for k, v in aws_instance.web : k => v.private_ip }
+    db_servers  = { for k, v in aws_instance.db : k => v.private_ip }
+  })
+  filename = "${path.root}/inventory.ini"
+}
+```
+
+---
+
+## HTTP Provider (hashicorp/http)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.4"
+    }
+  }
+}
+```
+
+### Basic HTTP Request
+```hcl
+# Simple GET request
+data "http" "myip" {
+  url = "https://api.ipify.org?format=json"
+}
+
+output "my_public_ip" {
+  value = jsondecode(data.http.myip.response_body).ip
+}
+
+# With request headers
+data "http" "github_user" {
+  url = "https://api.github.com/users/${var.github_username}"
+
+  request_headers = {
+    Accept        = "application/vnd.github.v3+json"
+    Authorization = "Bearer ${var.github_token}"
+  }
+}
+
+# With retry
+data "http" "external_api" {
+  url = var.api_endpoint
+
+  retry {
+    attempts     = 3
+    min_delay_ms = 1000
+    max_delay_ms = 5000
+  }
+}
+```
+
+### Response Validation
+```hcl
+data "http" "health_check" {
+  url = "${var.service_url}/health"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+# Check response
+locals {
+  health_status = jsondecode(data.http.health_check.response_body)
+  is_healthy    = data.http.health_check.status_code == 200
+}
+
+# Validate expected response
+data "http" "validated_response" {
+  url = var.api_url
+
+  lifecycle {
+    postcondition {
+      condition     = self.status_code == 200
+      error_message = "API returned non-200 status: ${self.status_code}"
+    }
+
+    postcondition {
+      condition     = can(jsondecode(self.response_body))
+      error_message = "Response is not valid JSON"
+    }
+  }
+}
+```
+
+### Common Use Cases
+```hcl
+# Get AWS IP ranges
+data "http" "aws_ip_ranges" {
+  url = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+}
+
+locals {
+  aws_ip_ranges = jsondecode(data.http.aws_ip_ranges.response_body)
+
+  cloudfront_ips = [
+    for prefix in local.aws_ip_ranges.prefixes :
+    prefix.ip_prefix
+    if prefix.service == "CLOUDFRONT"
+  ]
+}
+
+# Get GitHub meta information
+data "http" "github_meta" {
+  url = "https://api.github.com/meta"
+
+  request_headers = {
+    Accept = "application/vnd.github.v3+json"
+  }
+}
+
+locals {
+  github_actions_ips = jsondecode(data.http.github_meta.response_body).actions
+}
+
+# Fetch remote configuration
+data "http" "remote_config" {
+  url = "https://raw.githubusercontent.com/org/repo/main/config.json"
+
+  request_headers = {
+    Authorization = "token ${var.github_token}"
+  }
+}
+
+locals {
+  remote_config = jsondecode(data.http.remote_config.response_body)
+}
+
+# Dynamic security group rules from external source
+data "http" "allowed_ips" {
+  url = var.allowed_ips_url
+}
+
+resource "aws_security_group_rule" "dynamic_ingress" {
+  for_each = toset(split("\n", trimspace(data.http.allowed_ips.response_body)))
+
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = [each.value]
+  security_group_id = aws_security_group.main.id
+}
+```
+
+### POST Request (Data Source Workaround)
+```hcl
+# HTTP provider only supports GET
+# For POST requests, use external provider or null_resource with local-exec
+
+# Using null_resource for POST
+resource "null_resource" "api_call" {
+  triggers = {
+    payload_hash = sha256(jsonencode(var.payload))
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      curl -X POST \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${var.api_token}" \
+        -d '${jsonencode(var.payload)}' \
+        ${var.api_url} > ${path.module}/response.json
+    EOT
+  }
+}
+
+data "local_file" "api_response" {
+  depends_on = [null_resource.api_call]
+  filename   = "${path.module}/response.json"
+}
+```
+
+---
+
+## Best Practices
+
+### Template
+1. **Use templatefile() over template provider** - Modern, no provider dependency
+2. **Use ~ for whitespace control** - Clean output formatting
+3. **Validate template syntax** - Test templates before apply
+4. **Use jsonencode() for complex data** - Proper escaping
+5. **Keep templates in separate files** - Better maintainability
+
+### Time
+1. **Use time_rotating for secrets** - Automatic rotation schedules
+2. **Use time_sleep sparingly** - Prefer proper dependencies
+3. **Use triggers for controlled recreation** - Predictable behavior
+4. **Store timestamps in state** - Consistent reference points
+5. **Use RFC3339 format** - Standard, parseable format
+
+### Local
+1. **Set restrictive permissions** - 0600 for sensitive files
+2. **Use local_sensitive_file for secrets** - Proper handling
+3. **Clean up generated files** - Use destroy-time provisioners
+4. **Use path.module/path.root** - Portable paths
+5. **Don't commit generated files** - Add to .gitignore
+
+### HTTP
+1. **Add retry configuration** - Handle transient failures
+2. **Validate responses** - Use postconditions
+3. **Cache responses if static** - Avoid repeated requests
+4. **Use authentication headers** - Secure API access
+5. **Handle errors gracefully** - Check status codes

--- a/components/skills/iac-terraform-modules-eng/references/virtualization-providers.md
+++ b/components/skills/iac-terraform-modules-eng/references/virtualization-providers.md
@@ -1,0 +1,916 @@
+# Virtualization Provider Patterns
+
+## vSphere Provider (vmware/vsphere)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    vsphere = {
+      source  = "hashicorp/vsphere"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "vsphere" {
+  user                 = var.vsphere_user
+  password             = var.vsphere_password
+  vsphere_server       = var.vsphere_server
+  allow_unverified_ssl = var.allow_unverified_ssl
+
+  # Optional REST API configuration
+  rest_session_path = "/rest"
+}
+```
+
+### Data Sources
+```hcl
+data "vsphere_datacenter" "dc" {
+  name = var.datacenter
+}
+
+data "vsphere_compute_cluster" "cluster" {
+  name          = var.cluster
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_datastore" "datastore" {
+  name          = var.datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_network" "network" {
+  name          = var.network
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_virtual_machine" "template" {
+  name          = var.template
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_resource_pool" "pool" {
+  name          = var.resource_pool
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_host" "host" {
+  name          = var.esxi_host
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_content_library" "library" {
+  name = var.content_library
+}
+
+data "vsphere_content_library_item" "template" {
+  library_id = data.vsphere_content_library.library.id
+  name       = var.library_template
+  type       = "ovf"
+}
+```
+
+### Virtual Machine Module
+```hcl
+variable "virtual_machines" {
+  description = "Virtual machine configurations"
+  type = map(object({
+    num_cpus             = number
+    memory               = number
+    guest_id             = optional(string, "ubuntu64Guest")
+    firmware             = optional(string, "efi")
+    efi_secure_boot_enabled = optional(bool, true)
+    disk_size            = number
+    thin_provisioned     = optional(bool, true)
+    eagerly_scrub        = optional(bool, false)
+    folder               = optional(string)
+    annotation           = optional(string)
+    cpu_hot_add_enabled  = optional(bool, false)
+    memory_hot_add_enabled = optional(bool, false)
+    resource_pool_id     = optional(string)
+    host_system_id       = optional(string)
+    wait_for_guest_net_timeout = optional(number, 5)
+    wait_for_guest_ip_timeout  = optional(number, 5)
+    customize = optional(object({
+      linux_options = optional(object({
+        host_name = string
+        domain    = string
+      }))
+      network_interface = optional(object({
+        ipv4_address = string
+        ipv4_netmask = number
+      }))
+      ipv4_gateway = optional(string)
+      dns_server_list = optional(list(string))
+      dns_suffix_list = optional(list(string))
+    }))
+    extra_config = optional(map(string), {})
+    tags         = optional(list(string), [])
+  }))
+}
+
+resource "vsphere_virtual_machine" "this" {
+  for_each = var.virtual_machines
+
+  name             = each.key
+  resource_pool_id = each.value.resource_pool_id != null ? each.value.resource_pool_id : data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
+  host_system_id   = each.value.host_system_id
+  folder           = each.value.folder
+  annotation       = each.value.annotation
+
+  num_cpus             = each.value.num_cpus
+  memory               = each.value.memory
+  guest_id             = each.value.guest_id
+  firmware             = each.value.firmware
+  efi_secure_boot_enabled = each.value.efi_secure_boot_enabled
+
+  cpu_hot_add_enabled    = each.value.cpu_hot_add_enabled
+  memory_hot_add_enabled = each.value.memory_hot_add_enabled
+
+  wait_for_guest_net_timeout = each.value.wait_for_guest_net_timeout
+  wait_for_guest_ip_timeout  = each.value.wait_for_guest_ip_timeout
+
+  network_interface {
+    network_id   = data.vsphere_network.network.id
+    adapter_type = "vmxnet3"
+  }
+
+  disk {
+    label            = "disk0"
+    size             = each.value.disk_size
+    thin_provisioned = each.value.thin_provisioned
+    eagerly_scrub    = each.value.eagerly_scrub
+  }
+
+  clone {
+    template_uuid = data.vsphere_virtual_machine.template.id
+
+    dynamic "customize" {
+      for_each = each.value.customize != null ? [each.value.customize] : []
+      content {
+        dynamic "linux_options" {
+          for_each = customize.value.linux_options != null ? [customize.value.linux_options] : []
+          content {
+            host_name = linux_options.value.host_name
+            domain    = linux_options.value.domain
+          }
+        }
+
+        dynamic "network_interface" {
+          for_each = customize.value.network_interface != null ? [customize.value.network_interface] : []
+          content {
+            ipv4_address = network_interface.value.ipv4_address
+            ipv4_netmask = network_interface.value.ipv4_netmask
+          }
+        }
+
+        ipv4_gateway    = customize.value.ipv4_gateway
+        dns_server_list = customize.value.dns_server_list
+        dns_suffix_list = customize.value.dns_suffix_list
+      }
+    }
+  }
+
+  extra_config = each.value.extra_config
+  tags         = each.value.tags
+
+  lifecycle {
+    ignore_changes = [
+      clone[0].template_uuid,
+      disk[0].io_share_count,
+    ]
+  }
+}
+```
+
+### VM from Content Library
+```hcl
+resource "vsphere_virtual_machine" "from_content_library" {
+  for_each = var.content_library_vms
+
+  name             = each.key
+  resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  datastore_id     = data.vsphere_datastore.datastore.id
+
+  num_cpus = each.value.num_cpus
+  memory   = each.value.memory
+  guest_id = each.value.guest_id
+
+  network_interface {
+    network_id = data.vsphere_network.network.id
+  }
+
+  disk {
+    label = "disk0"
+    size  = each.value.disk_size
+  }
+
+  clone {
+    template_uuid = data.vsphere_content_library_item.template.id
+  }
+
+  cdrom {
+    client_device = true
+  }
+}
+```
+
+### vApp Module
+```hcl
+resource "vsphere_vapp_container" "this" {
+  for_each = var.vapps
+
+  name                    = each.key
+  parent_resource_pool_id = data.vsphere_compute_cluster.cluster.resource_pool_id
+  parent_folder_id        = each.value.folder_id
+
+  cpu_share_level    = each.value.cpu_share_level
+  cpu_reservation    = each.value.cpu_reservation
+  cpu_expandable     = each.value.cpu_expandable
+  cpu_limit          = each.value.cpu_limit
+  memory_share_level = each.value.memory_share_level
+  memory_reservation = each.value.memory_reservation
+  memory_expandable  = each.value.memory_expandable
+  memory_limit       = each.value.memory_limit
+
+  tags = each.value.tags
+}
+```
+
+### Distributed Switch Module
+```hcl
+resource "vsphere_distributed_virtual_switch" "this" {
+  for_each = var.distributed_switches
+
+  name          = each.key
+  datacenter_id = data.vsphere_datacenter.dc.id
+
+  max_mtu                = each.value.max_mtu
+  link_discovery_protocol = each.value.link_discovery_protocol
+  link_discovery_operation = each.value.link_discovery_operation
+
+  uplinks         = each.value.uplinks
+  active_uplinks  = each.value.active_uplinks
+  standby_uplinks = each.value.standby_uplinks
+
+  dynamic "host" {
+    for_each = each.value.hosts
+    content {
+      host_system_id = host.value.host_system_id
+      devices        = host.value.devices
+    }
+  }
+
+  tags = each.value.tags
+}
+
+resource "vsphere_distributed_port_group" "this" {
+  for_each = var.port_groups
+
+  name                            = each.key
+  distributed_virtual_switch_uuid = vsphere_distributed_virtual_switch.this[each.value.switch_name].id
+  vlan_id                         = each.value.vlan_id
+  type                            = each.value.type  # earlyBinding, lateBinding, ephemeral
+
+  allow_forged_transmits = each.value.allow_forged_transmits
+  allow_mac_changes      = each.value.allow_mac_changes
+  allow_promiscuous      = each.value.allow_promiscuous
+}
+```
+
+---
+
+## VMware Cloud (VMC) Provider (vmware/vmc)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    vmc = {
+      source  = "vmware/vmc"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "vmc" {
+  refresh_token = var.vmc_refresh_token
+  org_id        = var.vmc_org_id
+}
+```
+
+### SDDC Module
+```hcl
+data "vmc_connected_accounts" "this" {
+  account_number = var.aws_account_number
+}
+
+data "vmc_customer_subnets" "this" {
+  connected_account_id = data.vmc_connected_accounts.this.id
+  region               = var.region
+}
+
+resource "vmc_sddc" "this" {
+  for_each = var.sddcs
+
+  sddc_name           = each.key
+  vpc_cidr            = each.value.vpc_cidr
+  num_host            = each.value.num_hosts
+  provider_type       = each.value.provider_type  # AWS, ZEROCLOUD
+  region              = each.value.region
+  vxlan_subnet        = each.value.vxlan_subnet
+  delay_account_link  = each.value.delay_account_link
+  skip_creating_vxlan = each.value.skip_creating_vxlan
+  sso_domain          = each.value.sso_domain
+  sddc_type           = each.value.sddc_type  # DEFAULT, 1NODE
+  deployment_type     = each.value.deployment_type  # SingleAZ, MultiAZ
+  size                = each.value.size  # medium, large, i3.metal, etc.
+
+  account_link_sddc_config {
+    customer_subnet_ids  = data.vmc_customer_subnets.this.ids
+    connected_account_id = data.vmc_connected_accounts.this.id
+  }
+
+  microsoft_licensing_config {
+    mssql_licensing = each.value.mssql_licensing
+    windows_licensing = each.value.windows_licensing
+  }
+
+  timeouts {
+    create = each.value.create_timeout
+    update = each.value.update_timeout
+    delete = each.value.delete_timeout
+  }
+}
+```
+
+### Cluster Module
+```hcl
+resource "vmc_cluster" "this" {
+  for_each = var.clusters
+
+  sddc_id      = each.value.sddc_id
+  num_hosts    = each.value.num_hosts
+  host_cpu_cores_count = each.value.cpu_cores
+  host_instance_type   = each.value.instance_type
+  storage_capacity     = each.value.storage_capacity
+
+  microsoft_licensing_config {
+    mssql_licensing = each.value.mssql_licensing
+    windows_licensing = each.value.windows_licensing
+  }
+}
+```
+
+### Site Recovery Module
+```hcl
+resource "vmc_site_recovery" "this" {
+  for_each = var.site_recovery_configs
+
+  sddc_id                       = each.value.sddc_id
+  srm_extension_key_suffix      = each.value.srm_suffix
+}
+
+resource "vmc_srm_node" "this" {
+  for_each = var.srm_nodes
+
+  sddc_id                  = each.value.sddc_id
+  srm_node_extension_key_suffix = each.value.node_suffix
+}
+```
+
+### Public IP Module
+```hcl
+resource "vmc_public_ip" "this" {
+  for_each = var.public_ips
+
+  nsxt_reverse_proxy_url = each.value.nsxt_url
+  display_name           = each.key
+}
+```
+
+---
+
+## Proxmox Provider (bpg/proxmox)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = "~> 0.46"
+    }
+  }
+}
+
+provider "proxmox" {
+  endpoint = var.proxmox_url
+  username = var.proxmox_username
+  password = var.proxmox_password
+
+  # Or use API token
+  # api_token = var.proxmox_api_token
+
+  insecure = var.proxmox_insecure
+
+  ssh {
+    agent    = true
+    username = var.ssh_username
+  }
+}
+```
+
+### Virtual Machine Module
+```hcl
+variable "virtual_machines" {
+  description = "Proxmox VM configurations"
+  type = map(object({
+    node_name    = string
+    vm_id        = optional(number)
+    name         = string
+    description  = optional(string)
+    tags         = optional(list(string), [])
+    clone = optional(object({
+      vm_id    = number
+      full     = optional(bool, true)
+      retries  = optional(number, 1)
+    }))
+    cpu = optional(object({
+      cores   = optional(number, 2)
+      sockets = optional(number, 1)
+      type    = optional(string, "x86-64-v2-AES")
+    }))
+    memory = optional(object({
+      dedicated = optional(number, 2048)
+      floating  = optional(number)
+    }))
+    disk = optional(list(object({
+      datastore_id = string
+      interface    = string
+      size         = number
+      file_format  = optional(string, "raw")
+      iothread     = optional(bool, true)
+      ssd          = optional(bool, true)
+      discard      = optional(string, "on")
+    })), [])
+    network_device = optional(list(object({
+      bridge     = string
+      model      = optional(string, "virtio")
+      vlan_id    = optional(number)
+      mac_address = optional(string)
+      firewall   = optional(bool, false)
+    })), [])
+    operating_system = optional(object({
+      type = string  # l26 (Linux 2.6+), win10, other
+    }))
+    agent = optional(object({
+      enabled = optional(bool, true)
+      type    = optional(string, "virtio")
+    }))
+    initialization = optional(object({
+      ip_config = optional(object({
+        ipv4 = optional(object({
+          address = string
+          gateway = optional(string)
+        }))
+        ipv6 = optional(object({
+          address = string
+          gateway = optional(string)
+        }))
+      }))
+      user_account = optional(object({
+        username = string
+        password = optional(string)
+        keys     = optional(list(string))
+      }))
+      dns = optional(object({
+        domain  = optional(string)
+        servers = optional(list(string))
+      }))
+    }))
+    started         = optional(bool, true)
+    on_boot         = optional(bool, true)
+    reboot          = optional(bool, false)
+    stop_on_destroy = optional(bool, true)
+    timeout_create  = optional(number, 600)
+    timeout_clone   = optional(number, 600)
+    timeout_migrate = optional(number, 600)
+  }))
+}
+
+resource "proxmox_virtual_environment_vm" "this" {
+  for_each = var.virtual_machines
+
+  node_name   = each.value.node_name
+  vm_id       = each.value.vm_id
+  name        = each.value.name
+  description = each.value.description
+  tags        = each.value.tags
+
+  dynamic "clone" {
+    for_each = each.value.clone != null ? [each.value.clone] : []
+    content {
+      vm_id   = clone.value.vm_id
+      full    = clone.value.full
+      retries = clone.value.retries
+    }
+  }
+
+  dynamic "cpu" {
+    for_each = each.value.cpu != null ? [each.value.cpu] : []
+    content {
+      cores   = cpu.value.cores
+      sockets = cpu.value.sockets
+      type    = cpu.value.type
+    }
+  }
+
+  dynamic "memory" {
+    for_each = each.value.memory != null ? [each.value.memory] : []
+    content {
+      dedicated = memory.value.dedicated
+      floating  = memory.value.floating
+    }
+  }
+
+  dynamic "disk" {
+    for_each = each.value.disk
+    content {
+      datastore_id = disk.value.datastore_id
+      interface    = disk.value.interface
+      size         = disk.value.size
+      file_format  = disk.value.file_format
+      iothread     = disk.value.iothread
+      ssd          = disk.value.ssd
+      discard      = disk.value.discard
+    }
+  }
+
+  dynamic "network_device" {
+    for_each = each.value.network_device
+    content {
+      bridge      = network_device.value.bridge
+      model       = network_device.value.model
+      vlan_id     = network_device.value.vlan_id
+      mac_address = network_device.value.mac_address
+      firewall    = network_device.value.firewall
+    }
+  }
+
+  dynamic "operating_system" {
+    for_each = each.value.operating_system != null ? [each.value.operating_system] : []
+    content {
+      type = operating_system.value.type
+    }
+  }
+
+  dynamic "agent" {
+    for_each = each.value.agent != null ? [each.value.agent] : []
+    content {
+      enabled = agent.value.enabled
+      type    = agent.value.type
+    }
+  }
+
+  dynamic "initialization" {
+    for_each = each.value.initialization != null ? [each.value.initialization] : []
+    content {
+      dynamic "ip_config" {
+        for_each = initialization.value.ip_config != null ? [initialization.value.ip_config] : []
+        content {
+          dynamic "ipv4" {
+            for_each = ip_config.value.ipv4 != null ? [ip_config.value.ipv4] : []
+            content {
+              address = ipv4.value.address
+              gateway = ipv4.value.gateway
+            }
+          }
+          dynamic "ipv6" {
+            for_each = ip_config.value.ipv6 != null ? [ip_config.value.ipv6] : []
+            content {
+              address = ipv6.value.address
+              gateway = ipv6.value.gateway
+            }
+          }
+        }
+      }
+      dynamic "user_account" {
+        for_each = initialization.value.user_account != null ? [initialization.value.user_account] : []
+        content {
+          username = user_account.value.username
+          password = user_account.value.password
+          keys     = user_account.value.keys
+        }
+      }
+      dynamic "dns" {
+        for_each = initialization.value.dns != null ? [initialization.value.dns] : []
+        content {
+          domain  = dns.value.domain
+          servers = dns.value.servers
+        }
+      }
+    }
+  }
+
+  started         = each.value.started
+  on_boot         = each.value.on_boot
+  reboot          = each.value.reboot
+  stop_on_destroy = each.value.stop_on_destroy
+
+  timeout_create  = each.value.timeout_create
+  timeout_clone   = each.value.timeout_clone
+  timeout_migrate = each.value.timeout_migrate
+}
+```
+
+### LXC Container Module
+```hcl
+resource "proxmox_virtual_environment_container" "this" {
+  for_each = var.containers
+
+  node_name   = each.value.node_name
+  vm_id       = each.value.vm_id
+  description = each.value.description
+  tags        = each.value.tags
+
+  initialization {
+    hostname = each.key
+
+    ip_config {
+      ipv4 {
+        address = each.value.ipv4_address
+        gateway = each.value.ipv4_gateway
+      }
+    }
+
+    user_account {
+      keys     = each.value.ssh_keys
+      password = each.value.root_password
+    }
+
+    dns {
+      domain  = each.value.dns_domain
+      servers = each.value.dns_servers
+    }
+  }
+
+  operating_system {
+    template_file_id = each.value.template_file_id
+    type             = each.value.os_type  # alpine, archlinux, centos, debian, fedora, gentoo, nixos, opensuse, ubuntu, unmanaged
+  }
+
+  cpu {
+    cores = each.value.cores
+  }
+
+  memory {
+    dedicated = each.value.memory
+    swap      = each.value.swap
+  }
+
+  disk {
+    datastore_id = each.value.datastore_id
+    size         = each.value.disk_size
+  }
+
+  network_interface {
+    name     = "eth0"
+    bridge   = each.value.bridge
+    vlan_id  = each.value.vlan_id
+    firewall = each.value.firewall
+  }
+
+  features {
+    nesting = each.value.nesting
+    fuse    = each.value.fuse
+    mount   = each.value.mount
+  }
+
+  unprivileged = each.value.unprivileged
+  started      = each.value.started
+  start_on_boot = each.value.start_on_boot
+}
+```
+
+### Storage Module
+```hcl
+resource "proxmox_virtual_environment_file" "this" {
+  for_each = var.files
+
+  node_name    = each.value.node_name
+  datastore_id = each.value.datastore_id
+  content_type = each.value.content_type  # iso, vztmpl, snippets
+
+  source_file {
+    path      = each.value.source_path
+    file_name = each.value.file_name
+    checksum  = each.value.checksum
+  }
+
+  # Or from URL
+  # source_raw {
+  #   data      = each.value.data
+  #   file_name = each.value.file_name
+  # }
+}
+
+resource "proxmox_virtual_environment_download_file" "this" {
+  for_each = var.download_files
+
+  node_name    = each.value.node_name
+  datastore_id = each.value.datastore_id
+  content_type = each.value.content_type
+  url          = each.value.url
+  file_name    = each.value.file_name
+  checksum     = each.value.checksum
+  checksum_algorithm = each.value.checksum_algorithm
+
+  overwrite         = each.value.overwrite
+  upload_timeout    = each.value.upload_timeout
+  verify            = each.value.verify
+}
+```
+
+### Cluster Module
+```hcl
+resource "proxmox_virtual_environment_cluster_options" "this" {
+  language       = var.cluster_language
+  keyboard       = var.cluster_keyboard
+  email_from     = var.cluster_email_from
+  max_workers    = var.cluster_max_workers
+  migration_type = var.cluster_migration_type  # secure, insecure
+
+  ha {
+    shutdown_policy = var.ha_shutdown_policy
+  }
+
+  bandwidth_limit {
+    default = var.bandwidth_limit_default
+    restore = var.bandwidth_limit_restore
+    migration = var.bandwidth_limit_migration
+  }
+}
+
+resource "proxmox_virtual_environment_haresource" "this" {
+  for_each = var.ha_resources
+
+  resource_id = each.value.resource_id  # vm:100, ct:101
+  state       = each.value.state  # started, stopped, enabled, disabled
+  group       = each.value.group
+  comment     = each.value.comment
+
+  max_relocate = each.value.max_relocate
+  max_restart  = each.value.max_restart
+}
+
+resource "proxmox_virtual_environment_hagroup" "this" {
+  for_each = var.ha_groups
+
+  group      = each.key
+  comment    = each.value.comment
+  nodes      = each.value.nodes
+  restricted = each.value.restricted
+  nofailback = each.value.nofailback
+}
+```
+
+---
+
+## Telmate Proxmox Provider (Alternative)
+
+### Provider Configuration
+```hcl
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "proxmox" {
+  pm_api_url      = var.proxmox_url
+  pm_user         = var.proxmox_username
+  pm_password     = var.proxmox_password
+  pm_tls_insecure = var.proxmox_insecure
+
+  pm_parallel     = 2
+  pm_timeout      = 600
+  pm_debug        = var.debug
+}
+```
+
+### VM with Telmate Provider
+```hcl
+resource "proxmox_vm_qemu" "this" {
+  for_each = var.virtual_machines
+
+  name        = each.key
+  target_node = each.value.node
+  vmid        = each.value.vmid
+  desc        = each.value.description
+
+  clone      = each.value.template
+  full_clone = each.value.full_clone
+
+  os_type   = each.value.os_type
+  qemu_os   = each.value.qemu_os
+  bios      = each.value.bios
+  boot      = each.value.boot
+  bootdisk  = each.value.bootdisk
+
+  cores   = each.value.cores
+  sockets = each.value.sockets
+  cpu     = each.value.cpu_type
+  memory  = each.value.memory
+  balloon = each.value.balloon
+
+  scsihw = each.value.scsihw
+
+  dynamic "disk" {
+    for_each = each.value.disks
+    content {
+      type     = disk.value.type
+      storage  = disk.value.storage
+      size     = disk.value.size
+      format   = disk.value.format
+      iothread = disk.value.iothread
+      ssd      = disk.value.ssd
+      discard  = disk.value.discard
+    }
+  }
+
+  dynamic "network" {
+    for_each = each.value.networks
+    content {
+      model    = network.value.model
+      bridge   = network.value.bridge
+      tag      = network.value.vlan
+      firewall = network.value.firewall
+    }
+  }
+
+  # Cloud-init configuration
+  ipconfig0   = each.value.ipconfig0
+  nameserver  = each.value.nameserver
+  searchdomain = each.value.searchdomain
+  ciuser      = each.value.ciuser
+  cipassword  = each.value.cipassword
+  sshkeys     = each.value.sshkeys
+
+  agent    = each.value.agent
+  onboot   = each.value.onboot
+  oncreate = each.value.oncreate
+
+  lifecycle {
+    ignore_changes = [
+      network,
+      disk,
+    ]
+  }
+}
+```
+
+---
+
+## Best Practices
+
+### vSphere
+1. **Use content libraries** - Centralized template management
+2. **Configure DRS** - Automated resource balancing
+3. **Use distributed switches** - Advanced networking
+4. **Enable HA** - High availability clusters
+5. **Use storage policies** - SPBM for storage placement
+6. **Configure tagging** - Resource categorization
+7. **Use vSphere with Tanzu** - Kubernetes integration
+8. **Enable vMotion** - Live migration
+9. **Configure resource pools** - Resource allocation
+10. **Monitor with vRealize** - Operations management
+
+### VMC
+1. **Plan SDDC sizing** - Right-size from start
+2. **Configure hybrid connectivity** - VPN, Direct Connect
+3. **Use linked mode** - Unified management
+4. **Enable Site Recovery** - Disaster recovery
+5. **Configure NSX** - Software-defined networking
+6. **Use HCX** - Workload migration
+7. **Enable add-ons** - Extended services
+8. **Monitor costs** - Capacity planning
+9. **Configure backup** - Data protection
+10. **Plan maintenance windows** - Scheduled updates
+
+### Proxmox
+1. **Use cloud-init** - Automated provisioning
+2. **Enable QEMU guest agent** - Better management
+3. **Configure HA** - High availability
+4. **Use Ceph storage** - Distributed storage
+5. **Enable ZFS** - Data integrity
+6. **Use LXC where appropriate** - Container efficiency
+7. **Configure backup** - Proxmox Backup Server
+8. **Use VLANs** - Network isolation
+9. **Monitor with Prometheus** - Metrics collection
+10. **Use templates** - Standardized deployments


### PR DESCRIPTION
## Summary

- Expand `iac-terraform-modules-eng` skill from 3 cloud providers to 40+ Terraform providers
- Add 10 new reference files covering CI/CD, Kubernetes, databases, networking, security, observability, platforms, and virtualization
- Update existing cloud provider reference files with comprehensive module patterns
- Improve SKILL.md with expanded description and categorized reference file listing

Closes #67

## New Reference Files

| Category | File | Providers |
|----------|------|-----------|
| CI/CD | `cicd-providers.md` | GitHub, GitLab, Buildkite |
| Kubernetes | `kubernetes-providers.md` | Kubernetes, Helm, Talos, Coder |
| Databases | `database-providers.md` | MongoDB Atlas, CockroachDB, Elastic, Pinecone, Atlas, Airbyte |
| Networking | `networking-providers.md` | Cloudflare, DNS, NS1, ZeroTier, Fastly, Akamai |
| Security | `security-providers.md` | Vault, TLS |
| Utility | `utility-providers.md` | Template, Time, Local, HTTP |
| Orchestration | `orchestration-providers.md` | Ansible AAP, Kestra, Prefect, Flagsmith |
| Observability | `observability-providers.md` | Grafana, Grafana Cloud, Adaptive Metrics |
| Platforms | `platform-providers.md` | Vercel, Heroku, DigitalOcean, Linode, Vultr |
| Virtualization | `virtualization-providers.md` | vSphere, VMC, Proxmox |

## Test plan

- [ ] Verify all reference files are properly formatted markdown
- [ ] Verify HCL code blocks have valid syntax
- [ ] Verify SKILL.md accurately lists all reference files
- [ ] Review provider version constraints are current

🤖 Generated with [Claude Code](https://claude.com/claude-code)