### PR TITLE
fix(skills): link openfeature-sdk-dev to meta-sdk-patterns-eng

### DIFF
--- a/components/skills/openfeature-sdk-dev/SKILL.md
+++ b/components/skills/openfeature-sdk-dev/SKILL.md
@@ -5,6 +5,10 @@ description: Develop OpenFeature SDK implementations from the specification. Use
 
 # OpenFeature SDK Development
 
+> **Note**: This skill extends patterns from `meta-sdk-patterns-eng`.
+> See that skill for foundational SDK patterns (architecture, error handling,
+> configuration, testing strategies, packaging).
+
 Guide for implementing OpenFeature SDKs from the specification. This skill covers building SDK implementations, not using existing SDKs (see `openfeature-eng` for usage).
 
 ## When to Use This Skill


### PR DESCRIPTION
## Summary

- Add reference note linking `openfeature-sdk-dev` to `meta-sdk-patterns-eng`
- Add dedicated **Server SDK Implementation** section
- Add dedicated **Client SDK Implementation** section
- Establishes skill inheritance pattern for SDK development skills

## Changes

### Meta Reference
Added note to `openfeature-sdk-dev`:

```markdown
> **Note**: This skill extends patterns from `meta-sdk-patterns-eng`.
> See that skill for foundational SDK patterns (architecture, error handling,
> configuration, testing strategies, packaging).
```

### Server SDK Implementation (new section)
- Dynamic-context paradigm patterns
- Architecture diagram
- Thread safety considerations
- Connection pooling examples (Go)
- Request-scoped context propagation (Python)
- Server SDK checklist (7 items)

### Client SDK Implementation (new section)
- Static-context paradigm patterns  
- Architecture diagram
- Context reconciliation flow
- Client-specific events (RECONCILING, CONTEXT_CHANGED)
- Platform-specific patterns:
  - iOS (Swift lifecycle)
  - Android (Kotlin ViewModel)
  - Browser (visibility, online/offline)
  - Edge/Embedded (Rust resource-constrained)
- Offline support patterns
- Client SDK checklist (10 items)

## Stats
- **Before**: 940 lines
- **After**: 1345 lines (+405 lines)

## Related

- Depends on #89 (`meta-sdk-patterns-eng`)
- Updates #87 (`openfeature-sdk-dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)