### PR TITLE
feat(skills): add OpenMetadata skill collection

### DIFF
--- a/components/skills/openmetadata-dev/SKILL.md
+++ b/components/skills/openmetadata-dev/SKILL.md
@@ -1,0 +1,812 @@
+---
+name: openmetadata-dev
+description: Use OpenMetadata SDK and APIs to build integrations, connectors, and automations. Use when querying metadata, creating custom properties, building ingestion pipelines, automating governance workflows, or integrating OpenMetadata with other systems.
+---
+
+# OpenMetadata Development
+
+Guide for using OpenMetadata Python/Java SDKs and REST APIs to build integrations, connectors, and automations.
+
+## When to Use This Skill
+
+- Querying and updating metadata via SDK/API
+- Building custom ingestion connectors
+- Creating and managing custom properties
+- Automating governance workflows
+- Integrating OpenMetadata with external systems
+- Managing lineage programmatically
+
+## This Skill Does NOT Cover
+
+- Implementing new language SDKs (see `openmetadata-sdk-dev`)
+- Administering OpenMetadata (bots, users, security) (see `openmetadata-ops`)
+- Deploying or operating OpenMetadata infrastructure
+
+---
+
+## SDK Setup
+
+### Python SDK Installation
+
+```bash
+pip install openmetadata-ingestion
+```
+
+### Initialize Client
+
+```python
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    OpenMetadataConnection,
+    AuthProvider,
+)
+from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
+    OpenMetadataJWTClientConfig,
+)
+
+# Configure connection
+server_config = OpenMetadataConnection(
+    hostPort="http://localhost:8585/api",
+    authProvider=AuthProvider.openmetadata,
+    securityConfig=OpenMetadataJWTClientConfig(
+        jwtToken="<your-jwt-token>",
+    ),
+)
+
+# Create client
+metadata = OpenMetadata(server_config)
+
+# Verify connection
+assert metadata.health_check()
+```
+
+### Java SDK Setup
+
+```xml
+<dependency>
+    <groupId>org.open-metadata</groupId>
+    <artifactId>openmetadata-java-client</artifactId>
+    <version>1.3.0</version>
+</dependency>
+```
+
+```java
+OpenMetadataConnection server = new OpenMetadataConnection();
+server.setHostPort("http://localhost:8585/api");
+server.setAuthProvider(AuthProvider.OPENMETADATA);
+server.setSecurityConfig(new OpenMetadataJWTClientConfig().withJwtToken("<token>"));
+
+OpenMetadata client = new OpenMetadata(server);
+```
+
+---
+
+## Querying Metadata
+
+### Get Entity by Name
+
+```python
+from metadata.generated.schema.entity.data.table import Table
+
+# Get table by fully qualified name
+table = metadata.get_by_name(
+    entity=Table,
+    fqn="prod.sales.public.orders",
+    fields=["columns", "owner", "tags"],  # Optional: include related data
+)
+
+if table:
+    print(f"Table: {table.name}")
+    print(f"Columns: {[col.name for col in table.columns]}")
+    print(f"Owner: {table.owner.name if table.owner else 'None'}")
+```
+
+### Get Entity by ID
+
+```python
+from uuid import UUID
+
+table = metadata.get_by_id(
+    entity=Table,
+    entity_id=UUID("12345678-1234-1234-1234-123456789abc"),
+    fields=["columns"],
+)
+```
+
+### List Entities with Pagination
+
+```python
+from metadata.generated.schema.entity.data.table import Table
+
+# List tables with pagination
+tables = metadata.list_entities(
+    entity=Table,
+    limit=100,
+    fields=["owner", "database"],
+)
+
+for table in tables.entities:
+    print(f"{table.fullyQualifiedName}")
+
+# Get next page
+if tables.paging.after:
+    next_page = metadata.list_entities(
+        entity=Table,
+        limit=100,
+        after=tables.paging.after,
+    )
+```
+
+### Search Entities
+
+```python
+# Search using Elasticsearch query
+results = metadata.es_search_from_fqn(
+    entity_type=Table,
+    fqn_search_string="*orders*",
+    size=50,
+)
+
+for hit in results:
+    print(hit["_source"]["fullyQualifiedName"])
+```
+
+---
+
+## Creating and Updating Entities
+
+### Create Table
+
+```python
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.entity.data.table import Column, DataType
+
+create_request = CreateTableRequest(
+    name="new_orders",
+    databaseSchema="prod.sales.public",
+    columns=[
+        Column(name="id", dataType=DataType.BIGINT),
+        Column(name="customer_id", dataType=DataType.BIGINT),
+        Column(name="total", dataType=DataType.DECIMAL),
+        Column(name="created_at", dataType=DataType.TIMESTAMP),
+    ],
+    description="Order transactions",
+)
+
+table = metadata.create_or_update(create_request)
+print(f"Created table: {table.fullyQualifiedName}")
+```
+
+### Update Entity Description
+
+```python
+from metadata.generated.schema.type.tagLabel import TagLabel
+
+# Update table description
+metadata.patch_description(
+    entity=Table,
+    source=table,
+    description="Updated description for orders table",
+)
+```
+
+### Add Tags to Entity
+
+```python
+from metadata.generated.schema.type.tagLabel import (
+    TagLabel,
+    TagSource,
+    LabelType,
+    State,
+)
+
+tag = TagLabel(
+    tagFQN="PII.Sensitive",
+    source=TagSource.Classification,
+    labelType=LabelType.Manual,
+    state=State.Confirmed,
+)
+
+metadata.patch_tag(
+    entity=Table,
+    source=table,
+    tag_label=tag,
+)
+```
+
+### Set Owner
+
+```python
+from metadata.generated.schema.type.entityReference import EntityReference
+
+# Get user reference
+user = metadata.get_by_name(entity=User, fqn="john.doe")
+
+# Set owner
+metadata.patch_owner(
+    entity=Table,
+    source=table,
+    owner=EntityReference(id=user.id, type="user"),
+)
+```
+
+---
+
+## Custom Properties
+
+### Create Custom Property Type
+
+```python
+from metadata.generated.schema.api.data.createCustomProperty import (
+    CreateCustomPropertyRequest,
+)
+from metadata.generated.schema.type.customProperty import PropertyType
+
+# Create custom property on Table entity
+metadata.create_or_update_custom_property(
+    ometa_custom_property=CreateCustomPropertyRequest(
+        name="costCenter",
+        description="Cost center for billing",
+        propertyType=PropertyType(
+            id=metadata.get_property_type("string").id,
+            type="type",
+        ),
+    ),
+    entity_type=Table,
+)
+```
+
+### Set Custom Property Value
+
+```python
+# Set custom property value using extension
+table = metadata.get_by_name(entity=Table, fqn="prod.sales.orders")
+
+# Patch extension with custom property
+metadata.patch(
+    entity=Table,
+    source=table,
+    destination=table.copy(
+        update={"extension": {"costCenter": "SALES-001"}}
+    ),
+)
+```
+
+### Read Custom Property Value
+
+```python
+table = metadata.get_by_name(entity=Table, fqn="prod.sales.orders")
+
+if table.extension:
+    cost_center = table.extension.get("costCenter")
+    print(f"Cost Center: {cost_center}")
+```
+
+### Supported Property Types
+
+| Type | Description | Example Value |
+|------|-------------|---------------|
+| `string` | Text value | `"SALES-001"` |
+| `integer` | Whole number | `42` |
+| `number` | Decimal number | `3.14` |
+| `markdown` | Rich text | `"# Header\nContent"` |
+| `enum` | Predefined values | `"option1"` |
+| `date` | Date only | `"2024-01-15"` |
+| `dateTime` | Date and time | `"2024-01-15T10:30:00Z"` |
+| `time` | Time only | `"10:30:00"` |
+| `duration` | Time duration | `"PT1H30M"` |
+| `entityReference` | Link to entity | `{"id": "uuid", "type": "user"}` |
+| `entityReferenceList` | Multiple links | `[{"id": "uuid", "type": "user"}]` |
+
+---
+
+## Lineage Management
+
+### Add Lineage Edge
+
+```python
+from metadata.generated.schema.api.lineage.addLineage import AddLineage
+from metadata.generated.schema.type.entityLineage import EntitiesEdge
+
+# Get source and target tables
+source = metadata.get_by_name(entity=Table, fqn="raw.events")
+target = metadata.get_by_name(entity=Table, fqn="analytics.user_events")
+
+# Add lineage
+metadata.add_lineage(
+    AddLineage(
+        edge=EntitiesEdge(
+            fromEntity=EntityReference(id=source.id, type="table"),
+            toEntity=EntityReference(id=target.id, type="table"),
+        ),
+    )
+)
+```
+
+### Add Column-Level Lineage
+
+```python
+from metadata.generated.schema.type.entityLineage import ColumnLineage
+
+metadata.add_lineage(
+    AddLineage(
+        edge=EntitiesEdge(
+            fromEntity=EntityReference(id=source.id, type="table"),
+            toEntity=EntityReference(id=target.id, type="table"),
+            lineageDetails=LineageDetails(
+                columnsLineage=[
+                    ColumnLineage(
+                        fromColumns=["raw.events.user_id"],
+                        toColumn="analytics.user_events.user_id",
+                    ),
+                    ColumnLineage(
+                        fromColumns=["raw.events.event_type"],
+                        toColumn="analytics.user_events.event_type",
+                    ),
+                ],
+            ),
+        ),
+    )
+)
+```
+
+### Query Lineage
+
+```python
+lineage = metadata.get_lineage_by_name(
+    entity=Table,
+    fqn="analytics.user_events",
+    up_depth=3,    # Upstream hops
+    down_depth=3,  # Downstream hops
+)
+
+print("Upstream tables:")
+for node in lineage.upstreamEdges:
+    print(f"  - {node.fromEntity.name}")
+
+print("Downstream tables:")
+for node in lineage.downstreamEdges:
+    print(f"  - {node.toEntity.name}")
+```
+
+---
+
+## Building Custom Connectors
+
+### Connector Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Workflow                                │
+├─────────────────────────────────────────────────────────────┤
+│  Source → Processor → Processor → Sink                      │
+│    ↓          ↓           ↓         ↓                        │
+│  Extract   Transform   Enrich    Load to                     │
+│  Records    Data       Data      OpenMetadata                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Source Implementation
+
+```python
+from abc import ABC, abstractmethod
+from typing import Iterable, Optional
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+class MyCustomSource(Source):
+    """Custom source for extracting metadata."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = None
+        self.metadata = None
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+    ) -> "MyCustomSource":
+        instance = cls()
+        instance.config = MySourceConfig.parse_obj(config_dict)
+        instance.metadata = metadata
+        return instance
+
+    def prepare(self):
+        """Initialize connections before extraction."""
+        self.client = MyApiClient(self.config.api_url)
+
+    def _iter(self) -> Iterable[Either]:
+        """Yield records to downstream steps."""
+        for item in self.client.list_items():
+            yield Either(right=self._convert_to_entity(item))
+
+    def _convert_to_entity(self, item) -> CreateTableRequest:
+        """Convert API response to OpenMetadata entity."""
+        return CreateTableRequest(
+            name=item["name"],
+            databaseSchema=self.config.database_schema,
+            columns=[
+                Column(name=col["name"], dataType=self._map_type(col["type"]))
+                for col in item["columns"]
+            ],
+        )
+
+    def close(self):
+        """Cleanup resources."""
+        if self.client:
+            self.client.close()
+
+    def test_connection(self) -> None:
+        """Verify connectivity to source system."""
+        self.client.health_check()
+```
+
+### Processor Implementation
+
+```python
+from metadata.ingestion.api.steps import Processor
+
+class EnrichmentProcessor(Processor):
+    """Add additional metadata to records."""
+
+    @classmethod
+    def create(cls, config_dict: dict, metadata: OpenMetadata):
+        instance = cls()
+        instance.config = EnrichmentConfig.parse_obj(config_dict)
+        instance.metadata = metadata
+        return instance
+
+    def _run(self, record: CreateTableRequest) -> Either:
+        """Process each record."""
+        # Add custom enrichment
+        record.description = self._generate_description(record)
+        record.tags = self._auto_classify(record)
+        return Either(right=record)
+
+    def close(self):
+        pass
+```
+
+### Sink Implementation
+
+```python
+from metadata.ingestion.api.steps import Sink
+
+class OpenMetadataSink(Sink):
+    """Write records to OpenMetadata."""
+
+    @classmethod
+    def create(cls, config_dict: dict, metadata: OpenMetadata):
+        instance = cls()
+        instance.metadata = metadata
+        return instance
+
+    def _run(self, record: CreateTableRequest) -> Either:
+        """Write record to OpenMetadata."""
+        try:
+            entity = self.metadata.create_or_update(record)
+            return Either(right=entity)
+        except Exception as e:
+            return Either(left=StackTraceError(str(e)))
+
+    def close(self):
+        pass
+```
+
+### Workflow Configuration
+
+```yaml
+# connector.yaml
+source:
+  type: MyCustomSource
+  serviceName: my-source
+  serviceConnection:
+    config:
+      api_url: https://api.example.com
+      database_schema: prod.my_db.public
+
+processor:
+  type: EnrichmentProcessor
+  config:
+    auto_classify: true
+
+sink:
+  type: metadata-rest
+  config: {}
+
+workflowConfig:
+  openMetadataServerConfig:
+    hostPort: http://localhost:8585/api
+    authProvider: openmetadata
+    securityConfig:
+      jwtToken: ${OM_JWT_TOKEN}
+```
+
+### Run Workflow
+
+```python
+from metadata.workflow.metadata import MetadataWorkflow
+
+config = yaml.safe_load(open("connector.yaml"))
+workflow = MetadataWorkflow.create(config)
+
+workflow.execute()
+workflow.print_status()
+workflow.stop()
+```
+
+---
+
+## Automation Patterns
+
+### Bulk Tagging
+
+```python
+def bulk_tag_tables(metadata: OpenMetadata, pattern: str, tag_fqn: str):
+    """Apply tag to all tables matching pattern."""
+    tables = metadata.es_search_from_fqn(
+        entity_type=Table,
+        fqn_search_string=pattern,
+    )
+
+    tag = TagLabel(
+        tagFQN=tag_fqn,
+        source=TagSource.Classification,
+        labelType=LabelType.Automated,
+        state=State.Confirmed,
+    )
+
+    for hit in tables:
+        table = metadata.get_by_id(
+            entity=Table,
+            entity_id=UUID(hit["_source"]["id"]),
+        )
+        metadata.patch_tag(entity=Table, source=table, tag_label=tag)
+        print(f"Tagged: {table.fullyQualifiedName}")
+
+# Tag all PII tables
+bulk_tag_tables(metadata, "*customer*", "PII.Sensitive")
+```
+
+### Auto-Assign Owners
+
+```python
+def auto_assign_owners(metadata: OpenMetadata, rules: dict):
+    """Assign owners based on schema/database patterns."""
+    for pattern, owner_fqn in rules.items():
+        owner = metadata.get_by_name(entity=User, fqn=owner_fqn)
+        owner_ref = EntityReference(id=owner.id, type="user")
+
+        tables = metadata.es_search_from_fqn(
+            entity_type=Table,
+            fqn_search_string=pattern,
+        )
+
+        for hit in tables:
+            table = metadata.get_by_id(
+                entity=Table,
+                entity_id=UUID(hit["_source"]["id"]),
+            )
+            if table.owner is None:
+                metadata.patch_owner(entity=Table, source=table, owner=owner_ref)
+                print(f"Assigned {owner_fqn} to {table.fullyQualifiedName}")
+
+# Define ownership rules
+rules = {
+    "*.sales.*": "sales-team-lead",
+    "*.analytics.*": "analytics-team-lead",
+    "*.finance.*": "finance-team-lead",
+}
+auto_assign_owners(metadata, rules)
+```
+
+### Data Quality Automation
+
+```python
+from metadata.generated.schema.tests.testCase import TestCase
+from metadata.generated.schema.tests.testDefinition import TestDefinition
+
+def add_null_check_tests(metadata: OpenMetadata, table_fqn: str):
+    """Add null check tests to all required columns."""
+    table = metadata.get_by_name(
+        entity=Table,
+        fqn=table_fqn,
+        fields=["columns"],
+    )
+
+    null_test = metadata.get_by_name(
+        entity=TestDefinition,
+        fqn="columnValuesToBeNotNull",
+    )
+
+    for column in table.columns:
+        if column.constraint == "NOT NULL":
+            test_case = TestCase(
+                name=f"{column.name}_not_null",
+                testDefinition=EntityReference(id=null_test.id, type="testDefinition"),
+                entityLink=f"<#E::table::{table_fqn}::columns::{column.name}>",
+                parameterValues=[],
+            )
+            metadata.create_or_update(test_case)
+            print(f"Added null check for {column.name}")
+```
+
+### Lineage Propagation
+
+```python
+def propagate_tags_downstream(
+    metadata: OpenMetadata,
+    source_fqn: str,
+    tag_fqn: str,
+    max_depth: int = 3,
+):
+    """Propagate tags through lineage."""
+    source = metadata.get_by_name(entity=Table, fqn=source_fqn)
+
+    lineage = metadata.get_lineage_by_name(
+        entity=Table,
+        fqn=source_fqn,
+        down_depth=max_depth,
+    )
+
+    tag = TagLabel(
+        tagFQN=tag_fqn,
+        source=TagSource.Classification,
+        labelType=LabelType.Propagated,
+        state=State.Confirmed,
+    )
+
+    for edge in lineage.downstreamEdges:
+        downstream = metadata.get_by_id(
+            entity=Table,
+            entity_id=edge.toEntity.id,
+        )
+        metadata.patch_tag(entity=Table, source=downstream, tag_label=tag)
+        print(f"Propagated {tag_fqn} to {downstream.fullyQualifiedName}")
+
+# Propagate PII tag through lineage
+propagate_tags_downstream(metadata, "raw.customers", "PII.Sensitive")
+```
+
+---
+
+## REST API Direct Usage
+
+### Authentication
+
+```bash
+# Get JWT token
+curl -X POST "http://localhost:8585/api/v1/users/login" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "admin@openmetadata.org", "password": "admin"}'
+```
+
+### Common Endpoints
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| List tables | GET | `/api/v1/tables` |
+| Get table | GET | `/api/v1/tables/{id}` |
+| Get by name | GET | `/api/v1/tables/name/{fqn}` |
+| Create/Update | PUT | `/api/v1/tables` |
+| Patch | PATCH | `/api/v1/tables/{id}` |
+| Delete | DELETE | `/api/v1/tables/{id}` |
+| Search | GET | `/api/v1/search/query?q={query}` |
+| Lineage | GET | `/api/v1/lineage/{type}/{fqn}` |
+
+### Example: Create Table via REST
+
+```bash
+curl -X PUT "http://localhost:8585/api/v1/tables" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "new_table",
+    "databaseSchema": "prod.db.schema",
+    "columns": [
+      {"name": "id", "dataType": "BIGINT"},
+      {"name": "name", "dataType": "VARCHAR"}
+    ]
+  }'
+```
+
+---
+
+## Error Handling
+
+### Common Exceptions
+
+```python
+from metadata.ingestion.ometa.client import APIError
+
+try:
+    table = metadata.get_by_name(entity=Table, fqn="nonexistent.table")
+except APIError as e:
+    if e.status_code == 404:
+        print("Table not found")
+    elif e.status_code == 403:
+        print("Permission denied")
+    else:
+        raise
+```
+
+### Retry Pattern
+
+```python
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+)
+def resilient_create(metadata: OpenMetadata, entity):
+    return metadata.create_or_update(entity)
+```
+
+---
+
+## Best Practices
+
+### Connection Management
+
+```python
+# Use context manager pattern
+class OpenMetadataSession:
+    def __init__(self, config: OpenMetadataConnection):
+        self.config = config
+        self.client = None
+
+    def __enter__(self) -> OpenMetadata:
+        self.client = OpenMetadata(self.config)
+        self.client.health_check()
+        return self.client
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Client cleanup if needed
+        pass
+
+# Usage
+with OpenMetadataSession(config) as metadata:
+    table = metadata.get_by_name(entity=Table, fqn="prod.sales.orders")
+```
+
+### Batch Operations
+
+```python
+def batch_update(metadata: OpenMetadata, entities: list, batch_size: int = 50):
+    """Update entities in batches to avoid rate limits."""
+    for i in range(0, len(entities), batch_size):
+        batch = entities[i:i + batch_size]
+        for entity in batch:
+            metadata.create_or_update(entity)
+        time.sleep(0.5)  # Rate limit protection
+```
+
+### Idempotent Operations
+
+```python
+def ensure_table_exists(metadata: OpenMetadata, create_request: CreateTableRequest):
+    """Create table if not exists, otherwise return existing."""
+    existing = metadata.get_by_name(
+        entity=Table,
+        fqn=f"{create_request.databaseSchema}.{create_request.name}",
+    )
+    if existing:
+        return existing
+    return metadata.create_or_update(create_request)
+```
+
+---
+
+## References
+
+- [OpenMetadata Python SDK](https://docs.open-metadata.org/latest/sdk/python)
+- [OpenMetadata Java SDK](https://docs.open-metadata.org/latest/sdk/java)
+- [OpenMetadata API Reference](https://docs.open-metadata.org/swagger.html)
+- [Building Connectors](https://docs.open-metadata.org/latest/sdk/python/build-connector)
+- [Data Governance Automation](https://docs.open-metadata.org/latest/how-to-guides/data-governance)
+- `openmetadata-sdk-dev` - Implementing SDKs for new languages
+- `openmetadata-ops` - Administering OpenMetadata

--- a/components/skills/openmetadata-ops/SKILL.md
+++ b/components/skills/openmetadata-ops/SKILL.md
@@ -1,0 +1,582 @@
+---
+name: openmetadata-ops
+description: Administer OpenMetadata platform including users, teams, bots, roles, policies, and security. Use when managing access control, configuring SSO, creating service accounts, setting up team hierarchies, or troubleshooting authentication issues.
+---
+
+# OpenMetadata Operations
+
+Guide for administering OpenMetadata platform: users, teams, bots, roles, policies, security configuration, and operational tasks.
+
+## When to Use This Skill
+
+- Managing users and team hierarchies
+- Creating and configuring bots (service accounts)
+- Setting up roles and policies (RBAC/ABAC)
+- Configuring SSO and authentication providers
+- Managing JWT tokens and API access
+- Troubleshooting authentication and authorization issues
+
+## This Skill Does NOT Cover
+
+- Building OpenMetadata SDKs (see `openmetadata-sdk-dev`)
+- Using SDKs/APIs to build integrations (see `openmetadata-dev`)
+- Deploying OpenMetadata infrastructure (Kubernetes, Docker)
+- Database administration for OpenMetadata backend
+
+---
+
+## Team Hierarchy
+
+### Team Types
+
+OpenMetadata uses a hierarchical team structure:
+
+```
+Organization (root)
+├── Business Unit
+│   ├── Division
+│   │   ├── Department
+│   │   │   └── Group ← Only Groups can own Data Assets
+│   │   └── Group
+│   └── Department
+│       └── Group
+└── Business Unit
+    └── Group
+```
+
+| Level | Purpose | Can Own Assets |
+|-------|---------|----------------|
+| **Organization** | Company root, auto-created | No |
+| **Business Unit** | Top-tier organizational unit | No |
+| **Division** | Mid-tier under Business Unit | No |
+| **Department** | Team under Division | No |
+| **Group** | Lowest level, contains users | **Yes** |
+
+### Create Team
+
+**Via UI:**
+1. Navigate to **Settings → Teams**
+2. Click **Add Team**
+3. Select team type (BusinessUnit, Division, Department, Group)
+4. Set parent team
+5. Add team name, display name, description
+
+**Via API:**
+```bash
+curl -X PUT "http://localhost:8585/api/v1/teams" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "data-engineering",
+    "displayName": "Data Engineering",
+    "description": "Data platform team",
+    "teamType": "Group",
+    "parents": [{"id": "parent-team-uuid", "type": "team"}]
+  }'
+```
+
+### Team Policies
+
+Assign policies to teams for inherited permissions:
+
+```bash
+curl -X PATCH "http://localhost:8585/api/v1/teams/${TEAM_ID}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json-patch+json" \
+  -d '[
+    {
+      "op": "add",
+      "path": "/policies/-",
+      "value": {"id": "policy-uuid", "type": "policy"}
+    }
+  ]'
+```
+
+---
+
+## User Management
+
+### Add User
+
+**Via UI:**
+1. Navigate to **Settings → Users**
+2. Click **Add User**
+3. Enter email, name, select teams
+4. Assign roles
+
+**Via API:**
+```bash
+curl -X PUT "http://localhost:8585/api/v1/users" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "john.doe",
+    "email": "john.doe@company.com",
+    "displayName": "John Doe",
+    "teams": [{"id": "team-uuid", "type": "team"}],
+    "roles": [{"id": "role-uuid", "type": "role"}]
+  }'
+```
+
+### Assign Role to User
+
+```bash
+curl -X PATCH "http://localhost:8585/api/v1/users/${USER_ID}" \
+  -H "Authorization: Bearer ${JWT_TOKEN}" \
+  -H "Content-Type: application/json-patch+json" \
+  -d '[
+    {
+      "op": "add",
+      "path": "/roles/-",
+      "value": {"id": "data-steward-role-uuid", "type": "role"}
+    }
+  ]'
+```
+
+### Generate User Access Token
+
+Users can generate personal access tokens:
+
+1. Go to **Profile → Access Token**
+2. Click **Generate New Token**
+3. Set expiration (optional)
+4. Copy token immediately (shown only once)
+
+---
+
+## Bots (Service Accounts)
+
+### What Are Bots?
+
+Bots are service accounts for automated processes:
+- Ingestion pipelines
+- External integrations
+- Scheduled jobs
+- CI/CD automation
+
+### Built-in Bots
+
+| Bot | Purpose | Default Role |
+|-----|---------|--------------|
+| `ingestion-bot` | Metadata ingestion pipelines | Ingestion Bot Role |
+| `automator-bot` | Automation workflows | Automator Role |
+
+### Create Custom Bot
+
+**Via UI:**
+1. Navigate to **Settings → Integrations → Bots**
+2. Click **Add Bot**
+3. Enter bot name and description
+4. Select or create role
+5. Copy generated JWT token
+
+**Via API:**
+```bash
+# Create bot
+curl -X PUT "http://localhost:8585/api/v1/bots" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ci-cd-bot",
+    "displayName": "CI/CD Bot",
+    "description": "Bot for CI/CD pipeline metadata updates",
+    "botUser": {
+      "name": "ci-cd-bot",
+      "email": "ci-cd-bot@openmetadata.org",
+      "isBot": true
+    }
+  }'
+```
+
+### Get Bot JWT Token
+
+**Via UI:**
+1. Navigate to **Settings → Integrations → Bots**
+2. Select the bot
+3. Click **Revoke & Regenerate Token** or view existing token
+
+**Via API:**
+```bash
+# Get bot details including auth mechanism
+curl "http://localhost:8585/api/v1/bots/name/ingestion-bot?fields=botUser" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
+```
+
+### Bot Token Validation
+
+Validate bot tokens at [jwt.io](https://jwt.io) or programmatically:
+
+```python
+import jwt
+
+def validate_bot_token(token: str, public_key: str) -> dict:
+    """Validate and decode bot JWT token."""
+    try:
+        payload = jwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            issuer="open-metadata.org",
+        )
+        assert payload.get("isBot") == True
+        return payload
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token expired - regenerate in UI")
+    except jwt.InvalidTokenError as e:
+        raise ValueError(f"Invalid token: {e}")
+```
+
+### Bot Token Rotation
+
+Rotate bot tokens periodically:
+
+1. Navigate to **Settings → Integrations → Bots**
+2. Select the bot
+3. Click **Revoke & Regenerate Token**
+4. Update all systems using the old token
+5. Verify ingestion pipelines are working
+
+---
+
+## Roles and Policies
+
+### Access Control Model
+
+OpenMetadata uses hybrid RBAC + ABAC:
+
+```
+Authorization Decision = f(User, Resource, Operation)
+
+Where:
+- User    = Identity + Roles + Teams
+- Resource = Entity Type + Attributes (owner, domain, tags)
+- Operation = Create, Edit, Delete, ViewAll, EditOwner, etc.
+```
+
+### Built-in Roles
+
+| Role | Description | Key Permissions |
+|------|-------------|-----------------|
+| **Admin** | Full platform access | All operations on all resources |
+| **Data Consumer** | Read-only access | ViewBasic on most entities |
+| **Data Steward** | Governance operations | Edit descriptions, tags, glossary |
+| **Ingestion Bot Role** | Pipeline operations | Create/edit services and entities |
+
+### Create Custom Role
+
+**Via UI:**
+1. Navigate to **Settings → Roles**
+2. Click **Add Role**
+3. Enter name and description
+4. Add policies to the role
+
+**Via API:**
+```bash
+curl -X PUT "http://localhost:8585/api/v1/roles" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "DataEngineer",
+    "displayName": "Data Engineer",
+    "description": "Role for data engineering team",
+    "policies": [
+      {"id": "policy-uuid-1", "type": "policy"},
+      {"id": "policy-uuid-2", "type": "policy"}
+    ]
+  }'
+```
+
+### Policy Structure
+
+Policies contain rules that define permissions:
+
+```json
+{
+  "name": "TableEditPolicy",
+  "rules": [
+    {
+      "name": "AllowEditTables",
+      "resources": ["table"],
+      "operations": ["Create", "Edit", "Delete"],
+      "effect": "allow",
+      "condition": "isOwner()"
+    }
+  ]
+}
+```
+
+### Common Policy Rules
+
+| Rule | Effect | Description |
+|------|--------|-------------|
+| `isOwner()` | Condition | User/team owns the resource |
+| `inTeam('team-name')` | Condition | User belongs to team |
+| `hasDomain('domain')` | Condition | Resource is in domain |
+| `hasTag('tag-fqn')` | Condition | Resource has specific tag |
+
+### Create Policy
+
+```bash
+curl -X PUT "http://localhost:8585/api/v1/policies" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "TeamOwnershipPolicy",
+    "displayName": "Team Ownership Policy",
+    "description": "Allow team members to edit owned resources",
+    "rules": [
+      {
+        "name": "EditOwnedResources",
+        "resources": ["table", "dashboard", "pipeline"],
+        "operations": ["Edit", "EditDescription", "EditTags"],
+        "effect": "allow",
+        "condition": "isOwner()"
+      }
+    ]
+  }'
+```
+
+### Operations Reference
+
+| Operation | Description |
+|-----------|-------------|
+| `Create` | Create new entities |
+| `Delete` | Delete entities |
+| `ViewAll` | View all entity fields including sensitive data |
+| `ViewBasic` | View basic fields (name, description, tags) |
+| `Edit` | Edit entity properties |
+| `EditDescription` | Edit description only |
+| `EditTags` | Edit tags and classifications |
+| `EditOwner` | Change entity owner |
+| `EditLineage` | Modify lineage edges |
+| `EditCustomFields` | Modify custom properties |
+
+---
+
+## Authentication Configuration
+
+### Supported Providers
+
+| Provider | Type | Notes |
+|----------|------|-------|
+| OpenMetadata (built-in) | JWT | Development only |
+| Google | OIDC | Google Workspace SSO |
+| Okta | OIDC | Okta SSO |
+| Azure AD | OIDC | Microsoft Entra ID |
+| Auth0 | OIDC | Auth0 SSO |
+| AWS Cognito | OIDC | AWS Cognito User Pools |
+| OneLogin | OIDC | OneLogin SSO |
+| Keycloak | OIDC | Self-hosted OIDC |
+| Custom OIDC | OIDC | Any OIDC-compliant provider |
+
+> **Note**: OpenMetadata does not support multiple auth providers simultaneously.
+
+### Configure SSO (Example: Okta)
+
+**1. Create Okta Application:**
+- Sign in to Okta Admin Console
+- Navigate to **Applications → Create App Integration**
+- Select **OIDC - OpenID Connect** and **Web Application**
+- Set redirect URI: `http://localhost:8585/callback`
+
+**2. Configure OpenMetadata:**
+
+```yaml
+# openmetadata.yaml
+authenticationConfiguration:
+  provider: okta
+  publicKeyUrls:
+    - https://your-domain.okta.com/oauth2/default/v1/keys
+  authority: https://your-domain.okta.com/oauth2/default
+  clientId: <your-client-id>
+  callbackUrl: http://localhost:8585/callback
+```
+
+**3. Configure Frontend:**
+
+```yaml
+# openmetadata.yaml (continued)
+authorizerConfiguration:
+  className: org.openmetadata.service.security.DefaultAuthorizer
+  containerRequestFilter: org.openmetadata.service.security.JwtFilter
+  adminPrincipals:
+    - admin@company.com
+  principalDomain: company.com
+```
+
+### LDAP/Active Directory
+
+For LDAP integration, use an OIDC proxy like Keycloak:
+
+1. Deploy Keycloak
+2. Configure LDAP User Federation in Keycloak
+3. Configure OpenMetadata to use Keycloak as OIDC provider
+
+---
+
+## Custom Properties Administration
+
+### Create Custom Property Type
+
+**Via UI:**
+1. Navigate to **Settings → Custom Properties**
+2. Select entity type (Table, Dashboard, etc.)
+3. Click **Add Property**
+4. Configure name, type, description
+
+**Via API:**
+```bash
+curl -X PUT "http://localhost:8585/api/v1/metadata/types/name/table/customProperties" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "dataClassification",
+    "description": "Data classification level",
+    "propertyType": {
+      "id": "enum-type-uuid",
+      "type": "type"
+    },
+    "customPropertyConfig": {
+      "config": {
+        "values": ["Public", "Internal", "Confidential", "Restricted"]
+      }
+    }
+  }'
+```
+
+### List Custom Properties
+
+```bash
+curl "http://localhost:8585/api/v1/metadata/types/name/table?fields=customProperties" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
+```
+
+---
+
+## Troubleshooting
+
+### Authentication Issues
+
+**Problem: 401 Unauthorized**
+
+1. Check JWT token validity:
+   ```bash
+   # Decode token at jwt.io or:
+   echo $JWT_TOKEN | cut -d. -f2 | base64 -d | jq .
+   ```
+
+2. Verify token expiration (`exp` claim)
+
+3. Check issuer matches configuration
+
+**Problem: Bot ingestion failing**
+
+1. Verify bot has `Ingestion Bot Role`:
+   ```bash
+   curl "http://localhost:8585/api/v1/bots/name/ingestion-bot?fields=botUser" \
+     -H "Authorization: Bearer ${ADMIN_TOKEN}"
+   ```
+
+2. Check role policies weren't modified
+
+3. Regenerate bot token if expired
+
+### Authorization Issues
+
+**Problem: 403 Forbidden**
+
+1. Check user's roles:
+   ```bash
+   curl "http://localhost:8585/api/v1/users/name/john.doe?fields=roles,teams" \
+     -H "Authorization: Bearer ${ADMIN_TOKEN}"
+   ```
+
+2. Verify role has required policy
+
+3. Check policy conditions (isOwner, inTeam, etc.)
+
+**Problem: User can't see entities**
+
+1. Verify `ViewBasic` or `ViewAll` permission
+2. Check team hierarchy - user must be in a Group
+3. Verify entity isn't soft-deleted
+
+### Common Fixes
+
+| Issue | Solution |
+|-------|----------|
+| Token expired | Regenerate token in UI |
+| Missing permissions | Add policy to role |
+| User not in team | Add user to Group-type team |
+| Bot not working | Check role assignment, regenerate token |
+| SSO login failing | Verify redirect URI, check OIDC config |
+
+---
+
+## Operational Tasks
+
+### Backup Considerations
+
+Critical data to back up:
+- Database (MySQL/PostgreSQL)
+- Elasticsearch indices
+- JWT signing keys
+- Configuration files
+
+### Audit Logging
+
+OpenMetadata tracks changes via:
+- Entity version history
+- Change events in Elasticsearch
+- API audit logs
+
+Query audit events:
+```bash
+curl "http://localhost:8585/api/v1/events?entityType=table&timestamp=1704067200000" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}"
+```
+
+### Health Checks
+
+```bash
+# API health
+curl "http://localhost:8585/api/v1/system/health"
+
+# Elasticsearch health
+curl "http://localhost:8585/api/v1/search/health"
+```
+
+---
+
+## Best Practices
+
+### Security
+
+1. **Never use built-in auth in production** - always configure SSO
+2. **Rotate bot tokens** periodically (every 90 days recommended)
+3. **Use least-privilege roles** - create specific policies per team
+4. **Audit admin access** regularly
+
+### Team Structure
+
+1. **Use Groups for ownership** - only Groups can own assets
+2. **Mirror org structure** - Business Unit → Division → Department → Group
+3. **Assign domain owners** - use domains for cross-team governance
+
+### Bot Management
+
+1. **Create purpose-specific bots** - don't reuse ingestion-bot
+2. **Document bot purposes** in descriptions
+3. **Monitor bot token usage** in audit logs
+4. **Disable unused bots** rather than deleting
+
+---
+
+## References
+
+- [OpenMetadata Security Guide](https://docs.open-metadata.org/latest/deployment/security)
+- [Roles and Policies](https://docs.open-metadata.org/latest/how-to-guides/admin-guide-roles-policies)
+- [Team Management](https://docs.open-metadata.org/latest/how-to-guides/admin-guide/teams-and-users)
+- [SSO Configuration](https://docs.open-metadata.org/latest/deployment/security)
+- `openmetadata-dev` - Using SDKs/APIs for integrations
+- `openmetadata-sdk-dev` - Implementing SDKs for new languages

--- a/components/skills/openmetadata-sdk-dev/SKILL.md
+++ b/components/skills/openmetadata-sdk-dev/SKILL.md
@@ -1,0 +1,1152 @@
+---
+name: openmetadata-sdk-dev
+description: Implement OpenMetadata API as SDKs for new languages or extend existing SDKs. Use when building OpenMetadata clients, adding language support, implementing authentication providers, or extending SDK capabilities with new entity types.
+---
+
+# OpenMetadata SDK Development
+
+Guide for implementing OpenMetadata API as SDKs for new languages or extending existing Python/Java SDKs with new features.
+
+> **Note**: This skill extends patterns from `meta-sdk-patterns-eng`.
+> See that skill for foundational SDK patterns (architecture, error handling,
+> configuration, testing strategies, packaging).
+
+## When to Use This Skill
+
+- Implementing OpenMetadata SDK for a new language
+- Extending existing Python or Java SDK with new features
+- Adding new entity type support to an SDK
+- Implementing authentication providers
+- Generating entity models from OpenMetadata JSON Schemas
+
+## This Skill Does NOT Cover
+
+- Using the existing Python/Java SDK to interact with OpenMetadata
+- Deploying or operating OpenMetadata
+- Writing ingestion pipelines or connectors
+- See OpenMetadata user documentation for those topics
+
+---
+
+## OpenMetadata SDK Architecture
+
+### Core Components
+
+Every OpenMetadata SDK implements these components:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OpenMetadata Client                       │
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+│  │ Connection  │  │    Auth     │  │   API Clients       │  │
+│  │   Config    │  │  Provider   │  │  (Tables, Dashes..) │  │
+│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │              Entity Models (Generated)                  ││
+│  │   Table, Database, Dashboard, Pipeline, MlModel, etc.   ││
+│  └─────────────────────────────────────────────────────────┘│
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │              HTTP Client / Transport Layer              ││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Pattern: Gateway with Typed API Clients
+
+OpenMetadata SDKs use a gateway pattern where the main client builds typed API clients:
+
+```python
+# Python Pattern
+class OpenMetadata:
+    def __init__(self, config: OpenMetadataConnection):
+        self._config = config
+        self._client = self._build_client()
+
+    def get_by_name(self, entity: Type[T], fqn: str) -> Optional[T]:
+        """Generic method using TypeVar for type safety."""
+        ...
+
+    def create_or_update(self, data: CreateEntity) -> Entity:
+        """Handles both create and update operations."""
+        ...
+```
+
+```java
+// Java Pattern
+public class OpenMetadata {
+    private final OpenMetadataConnection config;
+
+    public <T> T buildClient(Class<T> apiClass) {
+        // Build typed API client
+        return clientBuilder.build(apiClass);
+    }
+}
+
+// Usage
+TablesApi tablesApi = openMetadata.buildClient(TablesApi.class);
+DashboardsApi dashboardApi = openMetadata.buildClient(DashboardsApi.class);
+```
+
+---
+
+## Connection Configuration
+
+### Configuration Object
+
+```python
+# Python
+from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    OpenMetadataConnection,
+    AuthProvider,
+)
+
+server_config = OpenMetadataConnection(
+    hostPort="http://localhost:8585/api",
+    authProvider=AuthProvider.openmetadata,
+    securityConfig=OpenMetadataJWTClientConfig(jwtToken="<token>"),
+    verifySSL="validate",  # or "ignore", "no-ssl"
+    sslConfig=ValidateSslClientConfig(caCertificate="/path/to/cert"),
+)
+```
+
+```java
+// Java
+OpenMetadataConnection server = new OpenMetadataConnection();
+server.setHostPort("http://localhost:8585/api");
+server.setApiVersion("v1");
+server.setAuthProvider(OpenMetadataConnection.AuthProvider.OPENMETADATA);
+server.setSecurityConfig(jwtClientConfig);
+```
+
+### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `hostPort` | Yes | Base URL including `/api` |
+| `authProvider` | Yes | Authentication provider type |
+| `securityConfig` | Yes | Provider-specific auth config |
+| `apiVersion` | No | API version (default: `v1`) |
+| `verifySSL` | No | SSL verification mode |
+| `sslConfig` | No | Custom SSL certificates |
+
+---
+
+## Authentication Providers
+
+### Provider Architecture
+
+Implement pluggable authentication with a provider interface:
+
+```python
+# Python
+class AuthenticationProvider(ABC):
+    @abstractmethod
+    def get_access_token(self) -> str:
+        """Return valid access token."""
+        pass
+
+class OpenMetadataJWTProvider(AuthenticationProvider):
+    def __init__(self, config: OpenMetadataJWTClientConfig):
+        self._token = config.jwtToken
+
+    def get_access_token(self) -> str:
+        return self._token
+
+class OktaProvider(AuthenticationProvider):
+    def __init__(self, config: OktaClientConfig):
+        self._client_id = config.clientId
+        self._org_url = config.orgURL
+        self._scopes = config.scopes
+
+    def get_access_token(self) -> str:
+        # OAuth2 token exchange
+        ...
+```
+
+```java
+// Java
+public interface AuthenticationProvider {
+    String getAccessToken();
+}
+
+public class NoOpAuthenticationProvider implements AuthenticationProvider {
+    @Override
+    public String getAccessToken() {
+        return "";
+    }
+}
+
+public class GoogleAuthenticationProvider implements AuthenticationProvider {
+    private final GoogleSSOClientConfig config;
+
+    @Override
+    public String getAccessToken() {
+        // OAuth2 flow with Google
+        ...
+    }
+}
+```
+
+### Supported Providers
+
+| Provider | Config Class | Auth Flow |
+|----------|--------------|-----------|
+| `openmetadata` | `OpenMetadataJWTClientConfig` | Static JWT token |
+| `google` | `GoogleSSOClientConfig` | OAuth2 OIDC |
+| `okta` | `OktaClientConfig` | OAuth2 OIDC |
+| `auth0` | `Auth0ClientConfig` | OAuth2 OIDC |
+| `azure` | `AzureClientConfig` | OAuth2 OIDC |
+| `custom-oidc` | `CustomOIDCClientConfig` | OAuth2 OIDC |
+| `no-auth` | None | No authentication |
+
+### Implementing New Provider
+
+1. Define configuration schema (JSON Schema)
+2. Generate config class from schema
+3. Implement `AuthenticationProvider` interface
+4. Register in provider factory
+5. Add to `AuthProvider` enum
+
+### Bot Token Internals
+
+OpenMetadata Bots are service accounts that provide JWT tokens for SDK authentication. When implementing SDK auth:
+
+#### Bot Token Structure
+
+Bot tokens are JWTs with specific claims:
+
+```json
+{
+  "sub": "ingestion-bot",
+  "iss": "open-metadata.org",
+  "iat": 1234567890,
+  "exp": 1234567890,
+  "email": "ingestion-bot@openmetadata.org",
+  "isBot": true
+}
+```
+
+#### SDK Token Validation
+
+When implementing auth provider, validate bot tokens:
+
+```python
+# Python
+import jwt
+from typing import Optional
+
+class BotTokenValidator:
+    def __init__(self, public_key: str, issuer: str = "open-metadata.org"):
+        self._public_key = public_key
+        self._issuer = issuer
+
+    def validate(self, token: str) -> Optional[dict]:
+        try:
+            payload = jwt.decode(
+                token,
+                self._public_key,
+                algorithms=["RS256"],
+                issuer=self._issuer,
+            )
+            if not payload.get("isBot", False):
+                raise ValueError("Token is not a bot token")
+            return payload
+        except jwt.ExpiredSignatureError:
+            raise AuthenticationError("Bot token expired")
+        except jwt.InvalidTokenError as e:
+            raise AuthenticationError(f"Invalid bot token: {e}")
+```
+
+```rust
+// Rust
+use jsonwebtoken::{decode, DecodingKey, Validation, Algorithm};
+
+#[derive(Debug, Deserialize)]
+struct BotClaims {
+    sub: String,
+    iss: String,
+    exp: u64,
+    is_bot: bool,
+}
+
+impl BotTokenValidator {
+    pub fn validate(&self, token: &str) -> Result<BotClaims, AuthError> {
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_issuer(&["open-metadata.org"]);
+
+        let token_data = decode::<BotClaims>(
+            token,
+            &DecodingKey::from_rsa_pem(self.public_key.as_bytes())?,
+            &validation,
+        )?;
+
+        if !token_data.claims.is_bot {
+            return Err(AuthError::NotBotToken);
+        }
+
+        Ok(token_data.claims)
+    }
+}
+```
+
+#### Token Refresh Handling
+
+Bot tokens have expiration. SDKs should handle refresh:
+
+```python
+class BotAuthProvider(AuthenticationProvider):
+    def __init__(self, config: BotConfig):
+        self._config = config
+        self._cached_token: Optional[str] = None
+        self._expires_at: Optional[datetime] = None
+
+    def get_access_token(self) -> str:
+        if self._is_token_valid():
+            return self._cached_token
+
+        # Refresh token from OpenMetadata API
+        self._cached_token = self._refresh_token()
+        self._expires_at = self._parse_expiry(self._cached_token)
+        return self._cached_token
+
+    def _is_token_valid(self) -> bool:
+        if not self._cached_token or not self._expires_at:
+            return False
+        # Refresh 5 minutes before expiry
+        return datetime.utcnow() < (self._expires_at - timedelta(minutes=5))
+```
+
+---
+
+## Entity Models
+
+### Schema-Driven Generation
+
+OpenMetadata entities are defined as JSON Schemas and models are generated:
+
+```
+json-schemas/
+├── entity/
+│   ├── data/
+│   │   ├── table.json
+│   │   ├── database.json
+│   │   └── dashboard.json
+│   ├── services/
+│   │   └── databaseService.json
+│   └── teams/
+│       └── user.json
+└── api/
+    ├── data/
+    │   ├── createTable.json
+    │   └── createDatabase.json
+    └── services/
+        └── createDatabaseService.json
+```
+
+### Entity vs API Models
+
+OpenMetadata separates entity definitions from API request models:
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| **Entity** | Response/read models | `Table`, `Database`, `Dashboard` |
+| **Create** | POST request body | `CreateTable`, `CreateDatabase` |
+| **Update** | PATCH request body | Partial entity fields |
+
+```python
+# Entity model (response)
+class Table(BaseModel):
+    id: UUID
+    name: str
+    fullyQualifiedName: str
+    columns: List[Column]
+    database: EntityReference
+    ...
+
+# API model (request)
+class CreateTable(BaseModel):
+    name: str
+    columns: List[Column]
+    databaseSchema: FullyQualifiedEntityName
+    ...
+```
+
+### Entity Hierarchy
+
+```
+DatabaseService
+    └── Database
+        └── DatabaseSchema
+            └── Table
+                └── Column
+
+DashboardService
+    └── Dashboard
+        └── Chart
+
+PipelineService
+    └── Pipeline
+        └── Task
+
+MessagingService
+    └── Topic
+```
+
+### Entity References
+
+Link entities using references:
+
+```python
+# By fully qualified name
+table = CreateTable(
+    name="orders",
+    databaseSchema="prod.sales.public",  # FQN string
+    columns=[...],
+)
+
+# By EntityReference
+table.owner = EntityReference(
+    id=user_uuid,
+    type="user",
+)
+```
+
+### Custom Property Model Handling
+
+OpenMetadata supports user-defined custom properties on entities. SDKs must handle these dynamic fields.
+
+#### Schema Definition
+
+Custom properties are defined per entity type:
+
+```json
+{
+  "name": "customField",
+  "propertyType": {
+    "id": "uuid",
+    "type": "type",
+    "name": "string"
+  },
+  "description": "Custom field description"
+}
+```
+
+#### SDK Model Strategy
+
+**Option 1: Extension Dictionary (Recommended)**
+
+Keep generated models clean, store custom properties separately:
+
+```python
+# Python
+class Table(BaseModel):
+    id: UUID
+    name: str
+    columns: List[Column]
+    # ... standard fields
+
+    extension: Optional[Dict[str, Any]] = None  # Custom properties
+
+    def get_custom_property(self, name: str) -> Any:
+        if self.extension is None:
+            return None
+        return self.extension.get(name)
+
+    def set_custom_property(self, name: str, value: Any) -> None:
+        if self.extension is None:
+            self.extension = {}
+        self.extension[name] = value
+```
+
+```typescript
+// TypeScript
+interface Table {
+    id: string;
+    name: string;
+    columns: Column[];
+    // ... standard fields
+
+    extension?: Record<string, unknown>;  // Custom properties
+}
+
+function getCustomProperty<T>(entity: Table, name: string): T | undefined {
+    return entity.extension?.[name] as T | undefined;
+}
+```
+
+```rust
+// Rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Table {
+    pub id: Uuid,
+    pub name: String,
+    pub columns: Vec<Column>,
+    // ... standard fields
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl Table {
+    pub fn get_custom_property<T: DeserializeOwned>(&self, name: &str) -> Option<T> {
+        self.extension
+            .as_ref()?
+            .get(name)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+}
+```
+
+**Option 2: Dynamic Model Generation**
+
+Generate models at runtime based on custom property definitions:
+
+```python
+# Python - dynamic model creation
+from pydantic import create_model
+
+def build_table_model(custom_properties: List[CustomProperty]) -> Type[BaseModel]:
+    """Build Table model with custom properties as typed fields."""
+    extra_fields = {}
+    for prop in custom_properties:
+        field_type = PROPERTY_TYPE_MAP.get(prop.propertyType.name, Any)
+        extra_fields[prop.name] = (Optional[field_type], None)
+
+    return create_model(
+        'TableWithCustomProperties',
+        __base__=Table,
+        **extra_fields,
+    )
+```
+
+#### Type Mapping for Custom Properties
+
+| OpenMetadata Type | Python | TypeScript | Rust | Go |
+|-------------------|--------|------------|------|-----|
+| `string` | `str` | `string` | `String` | `string` |
+| `integer` | `int` | `number` | `i64` | `int64` |
+| `number` | `float` | `number` | `f64` | `float64` |
+| `markdown` | `str` | `string` | `String` | `string` |
+| `enum` | `Enum` | `string` | `enum` | `string` |
+| `date` | `date` | `string` | `NaiveDate` | `time.Time` |
+| `dateTime` | `datetime` | `string` | `DateTime<Utc>` | `time.Time` |
+| `time` | `time` | `string` | `NaiveTime` | `time.Time` |
+| `duration` | `timedelta` | `string` | `Duration` | `time.Duration` |
+| `entityReference` | `EntityReference` | `EntityReference` | `EntityReference` | `EntityReference` |
+| `entityReferenceList` | `List[EntityReference]` | `EntityReference[]` | `Vec<EntityReference>` | `[]EntityReference` |
+
+#### Serialization Considerations
+
+Custom properties use the `extension` field in API payloads:
+
+```json
+{
+  "id": "uuid",
+  "name": "orders",
+  "columns": [...],
+  "extension": {
+    "customField1": "value",
+    "customField2": 123,
+    "customEntityRef": {
+      "id": "uuid",
+      "type": "user",
+      "name": "john"
+    }
+  }
+}
+```
+
+SDKs should:
+1. Preserve unknown fields during round-trip (deserialize → serialize)
+2. Validate custom property types if schema is available
+3. Handle missing custom properties gracefully (return `None`/`null`/`Option::None`)
+
+---
+
+## API Client Implementation
+
+### Standard CRUD Operations
+
+Every entity API should implement:
+
+```python
+class EntityAPI(Generic[T, CreateT]):
+    def create_or_update(self, entity: CreateT) -> T:
+        """POST /api/v1/{entities}"""
+        ...
+
+    def get_by_id(self, entity_id: UUID) -> Optional[T]:
+        """GET /api/v1/{entities}/{id}"""
+        ...
+
+    def get_by_name(self, fqn: str, fields: List[str] = None) -> Optional[T]:
+        """GET /api/v1/{entities}/name/{fqn}"""
+        ...
+
+    def list(self, limit: int = 10, fields: List[str] = None) -> ResultList[T]:
+        """GET /api/v1/{entities}"""
+        ...
+
+    def delete(
+        self,
+        entity_id: UUID,
+        recursive: bool = False,
+        hard_delete: bool = False,
+    ) -> None:
+        """DELETE /api/v1/{entities}/{id}"""
+        ...
+```
+
+### API Endpoints Pattern
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| List | GET | `/api/v1/{entities}` |
+| Get by ID | GET | `/api/v1/{entities}/{id}` |
+| Get by Name | GET | `/api/v1/{entities}/name/{fqn}` |
+| Create/Update | PUT | `/api/v1/{entities}` |
+| Patch | PATCH | `/api/v1/{entities}/{id}` |
+| Delete | DELETE | `/api/v1/{entities}/{id}` |
+
+### Query Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `fields` | Include optional fields | `?fields=columns,owner` |
+| `limit` | Pagination limit | `?limit=100` |
+| `before`/`after` | Cursor pagination | `?after={cursor}` |
+| `include` | Include deleted | `?include=deleted` |
+
+---
+
+## Mixins for Special Behaviors
+
+### Lineage Mixin
+
+```python
+class LineageMixin:
+    def add_lineage(self, edge: AddLineage) -> None:
+        """PUT /api/v1/lineage"""
+        ...
+
+    def get_lineage(
+        self,
+        entity_type: str,
+        entity_id: UUID,
+        up_depth: int = 1,
+        down_depth: int = 1,
+    ) -> EntityLineage:
+        """GET /api/v1/lineage/{type}/{id}"""
+        ...
+```
+
+### Tag Mixin
+
+```python
+class TagMixin:
+    def add_tag(self, entity_id: UUID, tag_fqn: str) -> None:
+        """PATCH /api/v1/{entities}/{id}"""
+        ...
+
+    def remove_tag(self, entity_id: UUID, tag_fqn: str) -> None:
+        ...
+```
+
+### Owner Mixin
+
+```python
+class OwnerMixin:
+    def set_owner(self, entity_id: UUID, owner: EntityReference) -> None:
+        ...
+```
+
+### Composing Mixins
+
+```python
+class OpenMetadata(LineageMixin, TagMixin, OwnerMixin):
+    """Main client composes all mixins."""
+
+    def __init__(self, config: OpenMetadataConnection):
+        self._config = config
+        self._client = self._build_http_client()
+```
+
+---
+
+## Error Handling
+
+### Exception Hierarchy
+
+```python
+class OpenMetadataException(Exception):
+    """Base exception for all SDK errors."""
+    pass
+
+class AuthenticationError(OpenMetadataException):
+    """Authentication failed."""
+    pass
+
+class EntityNotFoundError(OpenMetadataException):
+    """Entity does not exist."""
+    pass
+
+class ValidationError(OpenMetadataException):
+    """Request validation failed."""
+    pass
+
+class ConflictError(OpenMetadataException):
+    """Entity already exists or version conflict."""
+    pass
+
+class RateLimitError(OpenMetadataException):
+    """Rate limit exceeded."""
+    retry_after: int
+```
+
+### HTTP Status Mapping
+
+| Status | Exception | Action |
+|--------|-----------|--------|
+| 401 | `AuthenticationError` | Re-authenticate |
+| 403 | `AuthorizationError` | Check permissions |
+| 404 | `EntityNotFoundError` | Return None or raise |
+| 409 | `ConflictError` | Handle version conflict |
+| 422 | `ValidationError` | Fix request payload |
+| 429 | `RateLimitError` | Retry with backoff |
+| 5xx | `ServerError` | Retry with backoff |
+
+### Return None vs Raise
+
+```python
+def get_by_name(self, entity: Type[T], fqn: str) -> Optional[T]:
+    """Return None for 404, raise for other errors."""
+    try:
+        response = self._client.get(f"/api/v1/{entity.path}/name/{fqn}")
+        return entity.parse_obj(response.json())
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            return None
+        raise self._map_exception(e)
+```
+
+---
+
+## Implementing a New Language SDK
+
+### Step 1: Project Setup
+
+```bash
+# Directory structure
+openmetadata-sdk-{lang}/
+├── src/
+│   ├── client/
+│   │   ├── openmetadata.{ext}
+│   │   └── connection.{ext}
+│   ├── auth/
+│   │   ├── provider.{ext}
+│   │   └── jwt.{ext}
+│   ├── api/
+│   │   ├── tables.{ext}
+│   │   ├── databases.{ext}
+│   │   └── ...
+│   ├── models/
+│   │   └── generated/      # From JSON schemas
+│   └── mixins/
+│       ├── lineage.{ext}
+│       └── tags.{ext}
+├── tests/
+├── examples/
+└── README.md
+```
+
+### Step 2: Model Generation
+
+Use JSON Schema to generate models:
+
+```bash
+# Python: datamodel-codegen
+datamodel-codegen \
+    --input json-schemas/ \
+    --output src/models/generated/ \
+    --output-model-type pydantic_v2.BaseModel
+
+# TypeScript: json-schema-to-typescript
+npx json-schema-to-typescript \
+    json-schemas/**/*.json \
+    --out src/models/
+
+# Rust: schemafy or typify
+cargo run --bin generate-models -- \
+    --schema-dir json-schemas/ \
+    --out-dir src/models/
+```
+
+### Step 3: Implement Core Client
+
+```rust
+// Rust Example
+pub struct OpenMetadata {
+    config: OpenMetadataConnection,
+    client: reqwest::Client,
+    auth: Box<dyn AuthenticationProvider>,
+}
+
+impl OpenMetadata {
+    pub fn new(config: OpenMetadataConnection) -> Result<Self, Error> {
+        let auth = Self::build_auth_provider(&config)?;
+        let client = Self::build_http_client(&config)?;
+
+        Ok(Self { config, client, auth })
+    }
+
+    pub fn health_check(&self) -> Result<(), Error> {
+        let response = self.client
+            .get(format!("{}/health-check", self.config.host_port))
+            .send()?;
+
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::HealthCheckFailed)
+        }
+    }
+
+    pub fn tables(&self) -> TablesApi {
+        TablesApi::new(&self.client, &self.auth)
+    }
+}
+```
+
+### Step 4: Implement Entity APIs
+
+```typescript
+// TypeScript Example
+export class TablesApi {
+    constructor(
+        private client: HttpClient,
+        private auth: AuthenticationProvider,
+    ) {}
+
+    async getByName(fqn: string, fields?: string[]): Promise<Table | null> {
+        const params = fields ? { fields: fields.join(',') } : {};
+        try {
+            const response = await this.client.get(
+                `/api/v1/tables/name/${encodeURIComponent(fqn)}`,
+                { params },
+            );
+            return response.data as Table;
+        } catch (e) {
+            if (e.response?.status === 404) return null;
+            throw this.mapError(e);
+        }
+    }
+
+    async createOrUpdate(table: CreateTable): Promise<Table> {
+        const response = await this.client.put('/api/v1/tables', table);
+        return response.data as Table;
+    }
+
+    async delete(
+        id: string,
+        options: { recursive?: boolean; hardDelete?: boolean } = {},
+    ): Promise<void> {
+        await this.client.delete(`/api/v1/tables/${id}`, {
+            params: {
+                recursive: options.recursive ?? false,
+                hardDelete: options.hardDelete ?? false,
+            },
+        });
+    }
+}
+```
+
+### Step 5: Add Authentication Providers
+
+```go
+// Go Example
+type AuthenticationProvider interface {
+    GetAccessToken() (string, error)
+}
+
+type JWTProvider struct {
+    token string
+}
+
+func (p *JWTProvider) GetAccessToken() (string, error) {
+    return p.token, nil
+}
+
+type OktaProvider struct {
+    clientID    string
+    orgURL      string
+    privateKey  string
+    scopes      []string
+    cachedToken string
+    expiresAt   time.Time
+}
+
+func (p *OktaProvider) GetAccessToken() (string, error) {
+    if time.Now().Before(p.expiresAt) {
+        return p.cachedToken, nil
+    }
+    // Refresh token via OAuth2
+    token, expiry, err := p.refreshToken()
+    if err != nil {
+        return "", err
+    }
+    p.cachedToken = token
+    p.expiresAt = expiry
+    return token, nil
+}
+```
+
+### Step 6: Implement Mixins
+
+```kotlin
+// Kotlin Example
+interface LineageMixin {
+    val client: HttpClient
+
+    suspend fun addLineage(edge: AddLineage) {
+        client.put("/api/v1/lineage", edge)
+    }
+
+    suspend fun getLineage(
+        entityType: String,
+        entityId: UUID,
+        upDepth: Int = 1,
+        downDepth: Int = 1,
+    ): EntityLineage {
+        return client.get(
+            "/api/v1/lineage/$entityType/$entityId",
+            mapOf("upDepth" to upDepth, "downDepth" to downDepth),
+        )
+    }
+}
+
+class OpenMetadata(
+    private val config: OpenMetadataConnection,
+) : LineageMixin, TagMixin {
+    override val client = buildHttpClient()
+    // ...
+}
+```
+
+---
+
+## Extending Existing SDKs
+
+### Adding New Entity Type
+
+1. **Add JSON Schema**:
+   ```json
+   // json-schemas/entity/data/newEntity.json
+   {
+     "$schema": "http://json-schema.org/draft-07/schema#",
+     "title": "NewEntity",
+     "type": "object",
+     "properties": {
+       "id": { "type": "string", "format": "uuid" },
+       "name": { "type": "string" },
+       ...
+     }
+   }
+   ```
+
+2. **Generate Models**:
+   ```bash
+   make generate-models
+   ```
+
+3. **Add API Client**:
+   ```python
+   class NewEntityAPI:
+       ENTITY_PATH = "newEntities"
+
+       def get_by_name(self, fqn: str) -> Optional[NewEntity]:
+           ...
+   ```
+
+4. **Register in Main Client**:
+   ```python
+   class OpenMetadata:
+       def new_entities(self) -> NewEntityAPI:
+           return NewEntityAPI(self._client)
+   ```
+
+### Adding New Mixin
+
+1. **Define Interface**:
+   ```python
+   class CustomBehaviorMixin:
+       def custom_operation(self, entity_id: UUID) -> Result:
+           ...
+   ```
+
+2. **Add to Main Client**:
+   ```python
+   class OpenMetadata(LineageMixin, TagMixin, CustomBehaviorMixin):
+       ...
+   ```
+
+### Adding New Auth Provider
+
+1. **Define Config Schema**:
+   ```json
+   {
+     "title": "NewProviderConfig",
+     "properties": {
+       "apiKey": { "type": "string" },
+       "endpoint": { "type": "string" }
+     }
+   }
+   ```
+
+2. **Implement Provider**:
+   ```python
+   class NewProvider(AuthenticationProvider):
+       def __init__(self, config: NewProviderConfig):
+           self._api_key = config.apiKey
+           self._endpoint = config.endpoint
+
+       def get_access_token(self) -> str:
+           # Custom auth flow
+           ...
+   ```
+
+3. **Register in Factory**:
+   ```python
+   AUTH_PROVIDERS = {
+       AuthProvider.openmetadata: OpenMetadataJWTProvider,
+       AuthProvider.google: GoogleProvider,
+       AuthProvider.new_provider: NewProvider,  # Add here
+   }
+   ```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+```python
+def test_table_get_by_name():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "http://localhost:8585/api/v1/tables/name/db.schema.table",
+            json={"id": "123", "name": "table", ...},
+            status=200,
+        )
+
+        client = OpenMetadata(test_config)
+        table = client.get_by_name(Table, "db.schema.table")
+
+        assert table.name == "table"
+
+def test_table_get_by_name_not_found():
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            responses.GET,
+            "http://localhost:8585/api/v1/tables/name/missing",
+            status=404,
+        )
+
+        client = OpenMetadata(test_config)
+        table = client.get_by_name(Table, "missing")
+
+        assert table is None
+```
+
+### Integration Tests
+
+```python
+@pytest.fixture
+def openmetadata():
+    """Connect to test OpenMetadata instance."""
+    config = OpenMetadataConnection(
+        hostPort=os.getenv("OM_HOST", "http://localhost:8585/api"),
+        authProvider=AuthProvider.openmetadata,
+        securityConfig=OpenMetadataJWTClientConfig(
+            jwtToken=os.getenv("OM_TOKEN"),
+        ),
+    )
+    client = OpenMetadata(config)
+    client.health_check()
+    return client
+
+def test_create_and_get_table(openmetadata):
+    create = CreateTable(
+        name=f"test_table_{uuid4().hex[:8]}",
+        databaseSchema="default.default",
+        columns=[
+            Column(name="id", dataType=DataType.INT),
+            Column(name="name", dataType=DataType.STRING),
+        ],
+    )
+
+    table = openmetadata.create_or_update(create)
+    assert table.id is not None
+
+    fetched = openmetadata.get_by_name(Table, table.fullyQualifiedName)
+    assert fetched.name == create.name
+
+    # Cleanup
+    openmetadata.delete(Table, table.id, hard_delete=True)
+```
+
+---
+
+## SDK Implementation Checklist
+
+### Core Components
+- [ ] Connection configuration with all auth providers
+- [ ] HTTP client with retry, timeout, and error handling
+- [ ] Authentication provider interface and implementations
+- [ ] Model generation from JSON Schemas
+- [ ] Health check endpoint
+
+### Entity APIs
+- [ ] Tables API
+- [ ] Databases API
+- [ ] Database Schemas API
+- [ ] Database Services API
+- [ ] Dashboard API
+- [ ] Dashboard Services API
+- [ ] Pipeline API
+- [ ] Pipeline Services API
+- [ ] Topic API
+- [ ] Messaging Services API
+- [ ] ML Model API
+- [ ] ML Model Services API
+- [ ] User/Team APIs
+- [ ] Tag/Classification APIs
+
+### Mixins
+- [ ] Lineage operations
+- [ ] Tag operations
+- [ ] Owner operations
+- [ ] Custom properties operations
+
+### Quality
+- [ ] Type safety throughout
+- [ ] Comprehensive error handling
+- [ ] Unit test coverage > 80%
+- [ ] Integration test suite
+- [ ] API documentation
+- [ ] Usage examples
+
+---
+
+## References
+
+- [OpenMetadata SDK Documentation](https://docs.open-metadata.org/latest/sdk)
+- [OpenMetadata Python SDK](https://docs.open-metadata.org/latest/sdk/python)
+- [OpenMetadata Java SDK](https://docs.open-metadata.org/latest/sdk/java)
+- [OpenMetadata API (Swagger)](https://docs.open-metadata.org/swagger.html)
+- [OpenMetadata JSON Schemas](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-spec/src/main/resources/json/schema)
+- [OpenMetadata GitHub](https://github.com/open-metadata/OpenMetadata)
+- `meta-sdk-patterns-eng` - Foundational SDK patterns


### PR DESCRIPTION
## Summary

Add comprehensive OpenMetadata skill collection with three complementary skills:

- **`openmetadata-sdk-dev`** (1,152 lines): Implementing SDKs for new languages
- **`openmetadata-dev`** (812 lines): Using SDKs/APIs for integrations  
- **`openmetadata-ops`** (582 lines): Administering the platform

Closes #92

### Added

**openmetadata-sdk-dev**:
- SDK architecture patterns (gateway, typed API clients)
- Bot JWT token structure, validation, and refresh handling
- Custom property model handling (extension dict vs dynamic generation)
- Authentication provider implementation patterns
- Entity model generation from JSON schemas
- Multi-language examples (Python, Java, TypeScript, Rust, Go, Kotlin)

**openmetadata-dev**:
- SDK setup and client initialization
- Querying metadata (by name, ID, search, pagination)
- Creating and updating entities
- Custom property creation and usage via API
- Lineage management (add edges, column-level, query)
- Building custom ingestion connectors (Source, Processor, Sink)
- Automation patterns (bulk tagging, auto-assign owners, lineage propagation)

**openmetadata-ops**:
- Team hierarchy structure (Organization → Business Unit → Division → Department → Group)
- User management and role assignment
- Bot (service account) creation, token management, rotation
- Roles and policies (RBAC/ABAC hybrid model)
- SSO configuration (Okta, Azure AD, Google, Auth0, etc.)
- Troubleshooting authentication and authorization issues

## Test plan

- [ ] Verify each skill has valid frontmatter
- [ ] Review cross-references between skills are accurate
- [ ] Check code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)