### PR TITLE
feat(skills): add openmetadata-user and openmetadata-dq skills

### DIFF
--- a/components/skills/openmetadata-dev/SKILL.md
+++ b/components/skills/openmetadata-dev/SKILL.md
@@ -801,6 +801,106 @@ def ensure_table_exists(metadata: OpenMetadata, create_request: CreateTableReque
 
 ---
 
+## MCP Server Integration
+
+OpenMetadata provides a Model Context Protocol (MCP) server that enables AI assistants (like Claude and ChatGPT) to interact with your metadata catalog using natural language.
+
+### What is MCP?
+
+MCP (Model Context Protocol) is an open standard that allows AI systems to interact with external tools and data sources in a uniform, secure way. OpenMetadata's MCP server exposes its metadata knowledge graph to AI tools.
+
+### Use Cases
+
+- Natural language queries about data assets
+- "What tables contain customer data?"
+- "Who owns the orders table?"
+- "Show me the lineage for the sales dashboard"
+- AI-powered data discovery
+- Conversational data governance
+
+### Setting Up MCP
+
+#### 1. Install MCP Application
+
+1. Navigate to **Settings → Applications → Marketplace**
+2. Find the **MCP** application
+3. Click **Install**
+4. Configure the application settings
+
+#### 2. Generate Personal Access Token
+
+1. Go to **Profile → Access Token**
+2. Click **Generate New Token**
+3. Set appropriate expiration
+4. Copy token (shown only once)
+
+#### 3. Configure MCP Client
+
+**For Claude Desktop:**
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "openmetadata": {
+      "url": "http://localhost:8585/api/v1/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+**For API Integration:**
+
+```python
+import requests
+
+MCP_ENDPOINT = "http://localhost:8585/api/v1/mcp"
+TOKEN = "<your-token>"
+
+def query_mcp(prompt: str) -> dict:
+    """Send natural language query to OpenMetadata MCP."""
+    response = requests.post(
+        f"{MCP_ENDPOINT}/query",
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Content-Type": "application/json",
+        },
+        json={"prompt": prompt},
+    )
+    return response.json()
+
+# Example queries
+result = query_mcp("What tables are in the sales database?")
+result = query_mcp("Show me the owner of the customers table")
+result = query_mcp("What is the lineage for the revenue dashboard?")
+```
+
+### Available MCP Tools
+
+The MCP server exposes tools for:
+
+| Tool | Description |
+|------|-------------|
+| **search_assets** | Search for data assets by keyword |
+| **get_asset_details** | Get detailed metadata for an asset |
+| **get_lineage** | Retrieve lineage for an entity |
+| **get_owner** | Find asset ownership |
+| **list_tables** | List tables in a database |
+| **get_schema** | Get table schema details |
+
+### Security Considerations
+
+1. **Use dedicated tokens** - Don't share personal tokens
+2. **Set appropriate permissions** - MCP uses token's permissions
+3. **Rotate tokens regularly** - Follow security policies
+4. **Audit usage** - Monitor MCP queries in logs
+
+---
+
 ## References
 
 - [OpenMetadata Python SDK](https://docs.open-metadata.org/latest/sdk/python)
@@ -808,5 +908,8 @@ def ensure_table_exists(metadata: OpenMetadata, create_request: CreateTableReque
 - [OpenMetadata API Reference](https://docs.open-metadata.org/swagger.html)
 - [Building Connectors](https://docs.open-metadata.org/latest/sdk/python/build-connector)
 - [Data Governance Automation](https://docs.open-metadata.org/latest/how-to-guides/data-governance)
+- [MCP Server Guide](https://docs.open-metadata.org/latest/how-to-guides/mcp)
 - `openmetadata-sdk-dev` - Implementing SDKs for new languages
 - `openmetadata-ops` - Administering OpenMetadata
+- `openmetadata-user` - UI navigation and discovery
+- `openmetadata-dq` - Data quality and observability

--- a/components/skills/openmetadata-dq/SKILL.md
+++ b/components/skills/openmetadata-dq/SKILL.md
@@ -1,0 +1,703 @@
+---
+name: openmetadata-dq
+description: Configure and manage data quality tests, profiling, alerts, and incidents in OpenMetadata. Use when setting up quality tests, configuring profiler workflows, creating observability alerts, or triaging data quality incidents.
+---
+
+# OpenMetadata Data Quality & Observability
+
+Guide for configuring data quality tests, profiling, alerts, and incident management in OpenMetadata.
+
+## When to Use This Skill
+
+- Creating and managing data quality tests
+- Configuring data profiler workflows
+- Setting up observability alerts
+- Triaging and resolving data incidents
+- Exploring lineage for impact analysis
+- Running quality tests programmatically
+
+## This Skill Does NOT Cover
+
+- General data discovery and UI navigation (see `openmetadata-user`)
+- Using SDKs for non-quality tasks (see `openmetadata-dev`)
+- Administering users and policies (see `openmetadata-ops`)
+- Contributing quality features to core (see `openmetadata-sdk-dev`)
+
+---
+
+## Data Quality Overview
+
+OpenMetadata provides comprehensive data quality capabilities:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                 Data Quality Framework                       │
+├─────────────────────────────────────────────────────────────┤
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
+│  │   Profiler  │  │   Tests     │  │   Incident Manager  │  │
+│  │  (Metrics)  │→ │ (Assertions)│→ │   (Resolution)      │  │
+│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+│         ↓                ↓                    ↓              │
+│  ┌─────────────────────────────────────────────────────────┐│
+│  │                 Alerts & Notifications                  ││
+│  └─────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Profiler
+
+### What the Profiler Does
+
+The profiler captures descriptive statistics to:
+- Understand data shape and distribution
+- Validate assumptions (nulls, duplicates, ranges)
+- Detect anomalies over time
+- Power data quality tests
+
+### Profiler Metrics
+
+#### Table-Level Metrics
+
+| Metric | Description |
+|--------|-------------|
+| **Row Count** | Total rows in table |
+| **Column Count** | Number of columns |
+| **Size Bytes** | Table size in bytes |
+| **Create DateTime** | When table was created |
+
+#### Column-Level Metrics
+
+| Metric | Description |
+|--------|-------------|
+| **Null Count** | Number of null values |
+| **Null Ratio** | Percentage of nulls |
+| **Unique Count** | Distinct values |
+| **Unique Ratio** | Percentage unique |
+| **Duplicate Count** | Non-unique values |
+| **Min/Max** | Range for numeric/date |
+| **Mean/Median** | Central tendency |
+| **Std Dev** | Value distribution spread |
+| **Histogram** | Value distribution buckets |
+
+### Configuring Profiler Workflow
+
+#### Via UI
+
+1. Navigate to **Settings → Services → Database Services**
+2. Select your database service
+3. Click **Ingestion → Add Ingestion**
+4. Select **Profiler** as ingestion type
+5. Configure:
+   - Schedule (cron expression)
+   - Sample size percentage
+   - Tables to include/exclude
+   - Metrics to compute
+
+#### Via YAML
+
+```yaml
+source:
+  type: profiler
+  serviceName: my-database
+  sourceConfig:
+    config:
+      type: Profiler
+      generateSampleData: true
+      profileSampleType: PERCENTAGE
+      profileSample: 50  # Sample 50% of rows
+      tableFilterPattern:
+        includes:
+          - "prod.*"
+        excludes:
+          - ".*_staging"
+      columnFilterPattern:
+        includes:
+          - ".*"
+
+processor:
+  type: orm-profiler
+  config: {}
+
+sink:
+  type: metadata-rest
+  config: {}
+
+workflowConfig:
+  openMetadataServerConfig:
+    hostPort: http://localhost:8585/api
+    authProvider: openmetadata
+    securityConfig:
+      jwtToken: ${OM_JWT_TOKEN}
+```
+
+### Sample Configuration Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `profileSampleType` | PERCENTAGE or ROWS | PERCENTAGE |
+| `profileSample` | Sample size | 50 |
+| `generateSampleData` | Store sample rows | true |
+| `sampleDataCount` | Rows to store | 50 |
+| `threadCount` | Parallel threads | 5 |
+| `timeoutSeconds` | Per-table timeout | 43200 |
+
+### Viewing Profiler Results
+
+1. Navigate to table's **Profiler** tab
+2. View **Table Profile**:
+   - Row count over time
+   - Size trends
+3. View **Column Profile**:
+   - Null percentages
+   - Unique values
+   - Distribution histograms
+
+---
+
+## Data Quality Tests
+
+### Test Categories
+
+#### Table-Level Tests
+
+| Test | Description |
+|------|-------------|
+| **tableRowCountToBeBetween** | Row count within range |
+| **tableRowCountToEqual** | Row count equals value |
+| **tableColumnCountToBeBetween** | Column count within range |
+| **tableColumnCountToEqual** | Column count equals value |
+| **tableRowInsertedCountToBeBetween** | New rows within range |
+| **tableCustomSQLQuery** | Custom SQL returns expected result |
+
+#### Column-Level Tests
+
+| Test | Description |
+|------|-------------|
+| **columnValuesToBeNotNull** | No null values |
+| **columnValuesToBeUnique** | All values unique |
+| **columnValuesToBeBetween** | Values within range |
+| **columnValuesToMatchRegex** | Values match pattern |
+| **columnValuesToBeInSet** | Values in allowed list |
+| **columnValueLengthsToBeBetween** | String lengths in range |
+| **columnValuesMissingCount** | Missing values below threshold |
+| **columnValueMaxToBeBetween** | Max value in range |
+| **columnValueMinToBeBetween** | Min value in range |
+| **columnValueMeanToBeBetween** | Mean in range |
+| **columnValueMedianToBeBetween** | Median in range |
+| **columnValueStdDevToBeBetween** | Std dev in range |
+| **columnValuesLengthsToMatch** | Exact string length |
+
+### Creating Tests via UI
+
+1. Navigate to table's **Data Quality** tab
+2. Click **+ Add Test**
+3. Select test type (Table or Column level)
+4. Choose test definition
+5. Configure parameters:
+   - Column (for column tests)
+   - Thresholds/values
+   - Description
+6. Save test
+
+### Creating Tests via YAML
+
+```yaml
+source:
+  type: TestSuite
+  serviceName: my-database
+  sourceConfig:
+    config:
+      type: TestSuite
+      entityFullyQualifiedName: my-database.schema.table
+
+processor:
+  type: orm-test-runner
+  config:
+    testCases:
+      - name: orders_row_count_check
+        testDefinitionName: tableRowCountToBeBetween
+        parameterValues:
+          - name: minValue
+            value: 1000
+          - name: maxValue
+            value: 1000000
+
+      - name: customer_id_not_null
+        testDefinitionName: columnValuesToBeNotNull
+        columnName: customer_id
+
+      - name: status_in_valid_set
+        testDefinitionName: columnValuesToBeInSet
+        columnName: status
+        parameterValues:
+          - name: allowedValues
+            value: "['pending', 'completed', 'cancelled']"
+
+sink:
+  type: metadata-rest
+  config: {}
+
+workflowConfig:
+  openMetadataServerConfig:
+    hostPort: http://localhost:8585/api
+    authProvider: openmetadata
+    securityConfig:
+      jwtToken: ${OM_JWT_TOKEN}
+```
+
+### Test Suites
+
+Group related tests into test suites:
+
+```yaml
+testSuites:
+  - name: orders_table_suite
+    description: Quality tests for orders table
+    testCases:
+      - orders_row_count_check
+      - customer_id_not_null
+      - status_in_valid_set
+```
+
+### Custom SQL Tests
+
+Write custom validation queries:
+
+```yaml
+- name: custom_business_rule
+  testDefinitionName: tableCustomSQLQuery
+  parameterValues:
+    - name: sqlExpression
+      value: "SELECT COUNT(*) FROM orders WHERE total < 0"
+    - name: strategy
+      value: "COUNT"
+    - name: threshold
+      value: 0
+```
+
+**Strategy Options:**
+- `COUNT` - Result should equal threshold
+- `ROWS` - Should return no rows
+- `VALUE` - Single value comparison
+
+### Dimensional Testing
+
+Test data quality by business dimensions:
+
+```yaml
+- name: quality_by_region
+  testDefinitionName: columnValuesToBeBetween
+  columnName: revenue
+  parameterValues:
+    - name: minValue
+      value: 0
+    - name: partitionColumnName
+      value: region
+    - name: partitionValues
+      value: "['US', 'EU', 'APAC']"
+```
+
+---
+
+## Running Tests Programmatically
+
+### Python SDK
+
+```python
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.generated.schema.tests.testCase import TestCase
+from metadata.generated.schema.tests.testDefinition import TestDefinition
+from metadata.generated.schema.type.entityReference import EntityReference
+
+# Initialize client
+metadata = OpenMetadata(server_config)
+
+# Get test definition
+null_test = metadata.get_by_name(
+    entity=TestDefinition,
+    fqn="columnValuesToBeNotNull",
+)
+
+# Create test case
+test_case = TestCase(
+    name="customer_id_not_null",
+    testDefinition=EntityReference(
+        id=null_test.id,
+        type="testDefinition",
+    ),
+    entityLink="<#E::table::my-db.schema.orders::columns::customer_id>",
+    parameterValues=[],
+)
+
+created = metadata.create_or_update(test_case)
+print(f"Created test: {created.name}")
+```
+
+### Run from ETL Pipeline
+
+```python
+from metadata.workflow.data_quality import TestSuiteWorkflow
+
+config = {
+    "source": {
+        "type": "TestSuite",
+        "serviceName": "my-database",
+        "sourceConfig": {
+            "config": {
+                "type": "TestSuite",
+                "entityFullyQualifiedName": "my-database.schema.orders"
+            }
+        }
+    },
+    # ... rest of config
+}
+
+workflow = TestSuiteWorkflow.create(config)
+workflow.execute()
+workflow.print_status()
+```
+
+---
+
+## Alerts and Notifications
+
+### Alert Types
+
+| Trigger | Description |
+|---------|-------------|
+| **Test Failure** | When data quality test fails |
+| **Pipeline Failure** | When ingestion pipeline fails |
+| **Schema Change** | When table schema changes |
+| **Ownership Change** | When asset owner changes |
+| **New Asset** | When new asset is created |
+
+### Creating Alerts
+
+1. Navigate to **Settings → Notifications**
+2. Click **+ Add Alert**
+3. Configure:
+   - Alert name and description
+   - Trigger type
+   - Filter conditions
+   - Notification destinations
+
+### Notification Destinations
+
+| Destination | Setup Required |
+|-------------|----------------|
+| **Email** | SMTP configuration |
+| **Slack** | Webhook URL |
+| **Microsoft Teams** | Webhook URL |
+| **Webhook** | Custom endpoint URL |
+
+### Alert Filters
+
+Filter which events trigger alerts:
+
+```yaml
+filters:
+  - field: entityType
+    condition: equals
+    value: table
+  - field: testResult
+    condition: equals
+    value: Failed
+  - field: tier
+    condition: in
+    values: [Tier1, Tier2]
+```
+
+### Slack Integration
+
+```yaml
+destinations:
+  - type: Slack
+    config:
+      webhookUrl: https://hooks.slack.com/services/XXX/YYY/ZZZ
+      channel: "#data-quality-alerts"
+```
+
+---
+
+## Incident Manager
+
+### Incident Lifecycle
+
+```
+Test Failure
+    ↓
+New Incident Created
+    ↓
+Acknowledged (ack)
+    ↓
+Assigned to Owner
+    ↓
+Investigation
+    ↓
+Root Cause Documented
+    ↓
+Resolved (with reason)
+```
+
+### Incident States
+
+| State | Description |
+|-------|-------------|
+| **New** | Incident just created |
+| **Ack** | Acknowledged, under review |
+| **Assigned** | Assigned to specific person/team |
+| **Resolved** | Issue fixed, incident closed |
+
+### Managing Incidents
+
+#### Acknowledge
+
+1. Navigate to **Incident Manager**
+2. Find new incident
+3. Click **Ack** to acknowledge
+4. Incident moves to acknowledged state
+
+#### Assign
+
+1. Select acknowledged incident
+2. Click **Assign**
+3. Search for user or team
+4. Add assignment notes
+5. Task created for assignee
+
+#### Document Root Cause
+
+1. Open incident details
+2. Click **Root Cause**
+3. Document:
+   - What went wrong
+   - Why it happened
+   - How it was discovered
+4. Save for future reference
+
+#### Resolve
+
+1. Open incident
+2. Click **Resolve**
+3. Select resolution reason:
+   - **Fixed** - Issue corrected
+   - **False Positive** - Test was wrong
+   - **Duplicate** - Same as another incident
+   - **Won't Fix** - Accepted as-is
+4. Add resolution comments
+5. Confirm resolution
+
+### Resolution Workflow
+
+```
+1. Failure Notification → System alerts on test failure
+2. Acknowledgment → Team member confirms awareness
+3. Assignment → Routes to knowledgeable person
+4. Status Updates → Assigned team communicates progress
+5. Resolution → All stakeholders notified of fix
+```
+
+### Historical Analysis
+
+Past incidents serve as a troubleshooting handbook:
+- Review similar scenarios
+- Access previous resolutions
+- Learn from patterns
+- Improve test coverage
+
+---
+
+## Lineage for Impact Analysis
+
+### Lineage in Data Quality Context
+
+Use lineage to understand:
+- Which downstream tables are affected by issues
+- Which upstream sources might be the root cause
+- Impact radius of data quality problems
+
+### Exploring Lineage
+
+1. Navigate to table's **Lineage** tab
+2. View upstream sources (data origins)
+3. View downstream targets (data consumers)
+4. Click nodes for quality status
+
+### Lineage Configuration
+
+| Setting | Range | Purpose |
+|---------|-------|---------|
+| Upstream Depth | 1-3 | How far back to trace |
+| Downstream Depth | 1-3 | How far forward to trace |
+| Nodes per Layer | 5-50 | Max nodes displayed |
+
+### Lineage Layers
+
+| Layer | Quality Use Case |
+|-------|------------------|
+| **Column** | Track field transformations |
+| **Observability** | See test results on each node |
+| **Service** | Cross-system impact analysis |
+
+### Observability Layer
+
+Enabling the observability layer shows:
+- Test pass/fail status on each node
+- Failing tests propagate visual indicators
+- Quick identification of problem sources
+
+---
+
+## Profiler and Test Scheduling
+
+### Cron Expressions
+
+| Expression | Schedule |
+|------------|----------|
+| `0 0 * * *` | Daily at midnight |
+| `0 */6 * * *` | Every 6 hours |
+| `0 0 * * 0` | Weekly on Sunday |
+| `0 0 1 * *` | Monthly on 1st |
+| `*/30 * * * *` | Every 30 minutes |
+
+### Recommended Schedules
+
+| Workload Type | Profiler | Tests |
+|---------------|----------|-------|
+| **Batch (Daily)** | Daily after load | Daily after load |
+| **Streaming** | Every 6 hours | Every hour |
+| **Critical** | Hourly | Every 15 minutes |
+| **Archive** | Weekly | Weekly |
+
+### Managing Schedules
+
+1. Navigate to **Settings → Services → [Service]**
+2. Go to **Ingestion** tab
+3. View/edit scheduled workflows:
+   - Metadata ingestion
+   - Profiler
+   - Test suites
+
+---
+
+## Best Practices
+
+### Test Coverage
+
+1. **Start with critical tables** - Tier1 assets first
+2. **Cover basics first**:
+   - Null checks on required columns
+   - Uniqueness on primary keys
+   - Range checks on numeric fields
+3. **Add business rules** - Custom SQL for domain logic
+4. **Test incrementally** - New rows, not full table
+
+### Profiler Configuration
+
+1. **Sample appropriately** - 10-50% usually sufficient
+2. **Exclude large columns** - Skip LOBs and JSON
+3. **Schedule off-peak** - Avoid production impact
+4. **Timeout appropriately** - Set realistic limits
+
+### Alert Management
+
+1. **Avoid alert fatigue** - Start with critical tests
+2. **Route appropriately** - Right team for right issues
+3. **Include context** - Link to asset and test details
+4. **Set severity levels** - Not all failures are equal
+
+### Incident Response
+
+1. **Acknowledge quickly** - Show awareness
+2. **Document thoroughly** - Future you will thank you
+3. **Communicate status** - Keep stakeholders informed
+4. **Learn from incidents** - Improve tests and processes
+
+---
+
+## Troubleshooting
+
+### Profiler Not Running
+
+| Symptom | Check |
+|---------|-------|
+| No metrics | Verify ingestion is scheduled |
+| Missing columns | Check column filter patterns |
+| Slow execution | Reduce sample size |
+| Timeouts | Increase timeout or reduce scope |
+
+### Tests Failing Unexpectedly
+
+| Symptom | Check |
+|---------|-------|
+| False positives | Review test thresholds |
+| Intermittent failures | Check for race conditions |
+| All tests failing | Verify database connectivity |
+| No test results | Check test suite is scheduled |
+
+### Alerts Not Sending
+
+| Symptom | Check |
+|---------|-------|
+| No emails | Verify SMTP configuration |
+| No Slack messages | Check webhook URL |
+| Wrong recipients | Review alert filters |
+| Too many alerts | Tighten filter conditions |
+
+---
+
+## Integration with CI/CD
+
+### GitHub Actions Example
+
+```yaml
+name: Data Quality Check
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  quality-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install openmetadata-ingestion
+
+      - name: Run quality tests
+        env:
+          OM_HOST: ${{ secrets.OM_HOST }}
+          OM_TOKEN: ${{ secrets.OM_TOKEN }}
+        run: |
+          metadata_openmetadata test-suite run \
+            --config quality-tests.yaml
+
+      - name: Check results
+        run: |
+          # Fail pipeline if critical tests failed
+          metadata_openmetadata test-suite status \
+            --suite critical-tests \
+            --fail-on-failure
+```
+
+---
+
+## References
+
+- [Data Quality Guide](https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability)
+- [Profiler Configuration](https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/profiler)
+- [Test Definitions](https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/quality)
+- [Incident Manager](https://docs.open-metadata.org/latest/how-to-guides/data-quality-observability/incident-manager)
+- [Data Lineage](https://docs.open-metadata.org/latest/how-to-guides/data-lineage)
+- `openmetadata-dev` - SDK for programmatic quality tests
+- `openmetadata-user` - UI navigation and discovery
+- `openmetadata-ops` - Platform administration

--- a/components/skills/openmetadata-user/SKILL.md
+++ b/components/skills/openmetadata-user/SKILL.md
@@ -1,0 +1,625 @@
+---
+name: openmetadata-user
+description: Use OpenMetadata UI for data discovery, governance, and collaboration. Use when searching for data assets, managing descriptions and ownership, creating glossary terms, setting up data contracts, or tracking data insights and KPIs.
+---
+
+# OpenMetadata User Guide
+
+Guide for data producers and consumers using OpenMetadata UI for discovery, documentation, governance, and collaboration.
+
+## When to Use This Skill
+
+- Searching and discovering data assets
+- Adding descriptions and documentation
+- Managing ownership and tagging
+- Creating and using glossary terms
+- Setting up data contracts
+- Tracking data insights and KPIs
+- Navigating lineage visualizations
+- Understanding version history
+
+## This Skill Does NOT Cover
+
+- Using SDKs/APIs programmatically (see `openmetadata-dev`)
+- Administering users, roles, and policies (see `openmetadata-ops`)
+- Data quality test creation and profiling (see `openmetadata-dq`)
+- Contributing to OpenMetadata core (see `openmetadata-sdk-dev`)
+
+---
+
+## Data Discovery
+
+### Search Features
+
+Access search from any page via **Ctrl+K** (Windows) or **Cmd+K** (macOS).
+
+**Searchable Asset Types:**
+- Tables, Topics, Dashboards
+- Pipelines, ML Models, Containers
+- Glossaries, Tags
+
+**Search Behavior:**
+- Matches asset names and descriptions
+- Searches nested elements (column names, chart names)
+- Powers both quick search and advanced search
+
+### Quick Filters
+
+| Filter | Purpose |
+|--------|---------|
+| **Owner/Team** | Find assets by responsible party |
+| **Tags** | Filter by classification |
+| **Tier** | Filter by business importance |
+| **Service** | Filter by data source |
+| **Database/Schema** | Database-specific refinement |
+| **Deleted** | Include soft-deleted assets |
+
+### Sort Options
+
+| Sort By | Description |
+|---------|-------------|
+| **Relevance** | Best match to search terms |
+| **Last Updated** | Most recently modified |
+| **Weekly Usage** | Most frequently accessed |
+
+### Advanced Search
+
+Use boolean operators and faceted queries:
+
+```
+name:orders AND owner:data-team AND tier:Tier1
+```
+
+**Supported Operators:**
+- `AND`, `OR`, `NOT`
+- Field-specific queries: `name:`, `owner:`, `tag:`
+- Wildcards: `*orders*`
+
+---
+
+## Previewing Assets
+
+Click any asset from search results to open the preview panel.
+
+### Basic Information
+
+All assets display:
+- Source system
+- Name and description
+- Owner (user or team)
+- Tier and usage metrics
+
+### Type-Specific Preview
+
+| Asset Type | Preview Shows |
+|------------|---------------|
+| **Tables** | Table type, query count, columns |
+| **Topics** | Partitions, replication factor, retention, schema type |
+| **ML Models** | Algorithm, target, server, dashboard |
+| **Glossary Terms** | Reviewers, synonyms, children |
+| **Dashboards** | URL, charts |
+| **Pipelines** | URL, tasks |
+
+### Additional Sections
+
+- **Data Quality**: Tests passed/aborted/failed
+- **Tags**: All associated classifications
+- **Schema**: Column names, types, descriptions
+
+---
+
+## Asset Detail Page
+
+### Top Information Bar
+
+- Source, Owner, Tier, Type, Usage
+- Description (editable)
+
+### Action Icons (Top Right)
+
+| Icon | Function |
+|------|----------|
+| Circle with number | Open tasks count |
+| Clock | Version history |
+| Star | Follow/unfollow asset |
+| Share | Copy asset link |
+| ⋮ Menu | Announcements, rename, delete |
+
+### Tabs by Asset Type
+
+| Tab | Available For | Content |
+|-----|---------------|---------|
+| **Schema** | Tables, Topics, Containers | Columns, types, tags, frequently joined |
+| **Activity Feeds** | All | Tasks, mentions, conversations |
+| **Sample Data** | Tables, Topics | Ingested sample rows |
+| **Queries** | Tables | SQL queries with execution times |
+| **Data Observability** | Tables | Profiler metrics, quality tests |
+| **Lineage** | All | Upstream/downstream visualization |
+| **Custom Properties** | All | Organization-specific metadata |
+| **Details** | Dashboards, ML Models | Charts, hyperparameters |
+| **Executions** | Pipelines | Run history with status |
+
+---
+
+## Adding Descriptions
+
+### Edit Description
+
+1. Navigate to asset from Explore page
+2. Click pencil icon to enter edit mode
+3. Use toolbar for formatting
+4. Preview changes before saving
+
+### Markdown Formatting
+
+Use the toolbar for:
+- Headers (H1-H6)
+- **Bold**, *italics*, ~~strikethrough~~
+- Bulleted and numbered lists
+- Hyperlinks
+- Code blocks and inline code
+- Block quotes
+
+> **Note**: Legacy markdown syntax is not supported. Use the toolbar.
+
+### Request Description
+
+When you don't have edit permissions:
+1. Click "Request Description"
+2. Provide suggested text
+3. Owner receives notification
+4. Track request in Activity Feeds
+
+### Column Descriptions
+
+Tables support column-level documentation:
+1. Navigate to Schema tab
+2. Click column description field
+3. Add context about the column's purpose
+
+---
+
+## Ownership and Following
+
+### Assign Owner
+
+1. Click owner field on asset page
+2. Search for user or team
+3. Select to assign ownership
+
+**Owner Types:**
+- **User**: Individual person
+- **Team**: Group (only Group-type teams can own assets)
+
+### Change Owner
+
+1. Click existing owner
+2. Search for new owner
+3. Confirm change
+
+### Follow Assets
+
+Click the star icon to follow an asset:
+- Receive notifications on changes
+- Track in your activity feed
+- Quick access from your profile
+
+---
+
+## Tags and Classification
+
+### Tag Types
+
+| Type | Description |
+|------|-------------|
+| **Classification Tags** | User-defined categories |
+| **System Tags** | Built-in platform tags |
+| **Mutually Exclusive** | Only one can apply at a time |
+| **Tiers** | Business importance levels |
+
+### Adding Tags
+
+1. Navigate to asset
+2. Click "+ Add Tag" in tags section
+3. Search and select tags
+4. Tags apply immediately
+
+### Tiers
+
+Standard tier levels:
+
+| Tier | Description |
+|------|-------------|
+| **Tier1** | Critical business data |
+| **Tier2** | Important operational data |
+| **Tier3** | Standard business data |
+| **Tier4** | Low-priority/experimental data |
+| **Tier5** | Deprecated or archive data |
+
+### Auto-Classification (PII)
+
+OpenMetadata can automatically detect PII:
+- Scans column names and sample data
+- Suggests or auto-applies PII tags
+- Configurable confidence thresholds
+
+---
+
+## Business Glossary
+
+### Glossary Structure
+
+```
+Glossary
+├── Parent Term
+│   ├── Child Term
+│   └── Child Term
+└── Parent Term
+    └── Child Term
+```
+
+**Fully Qualified Name Format:** `glossary.parentTerm.childTerm`
+
+### Creating Glossary Terms
+
+1. Navigate to **Govern → Glossary**
+2. Click **+ Add Term**
+3. Fill in:
+   - Name and display name
+   - Description
+   - Synonyms
+   - Related terms
+   - Tags
+4. Optionally assign reviewers
+
+### Term Enrichment
+
+| Field | Purpose |
+|-------|---------|
+| **Synonyms** | Alternative names |
+| **Related Terms** | Connected concepts |
+| **References** | External documentation links |
+| **Reviewers** | Approval workflow |
+
+### Applying Glossary Terms
+
+1. Navigate to data asset
+2. Click "+ Add Glossary Term"
+3. Search and select term
+4. Term links asset to business concept
+
+### Approval Workflows
+
+For governed glossaries:
+1. Create or modify term
+2. Term enters "Draft" state
+3. Reviewers receive notification
+4. Approve or request changes
+5. Term becomes "Approved"
+
+---
+
+## Data Contracts
+
+Data contracts establish formal agreements between data producers and consumers.
+
+### Contract Components
+
+| Section | Purpose |
+|---------|---------|
+| **Contract Details** | Name, owner, description |
+| **Terms of Service** | Usage guidelines, policies |
+| **Schema** | Columns included in contract |
+| **Security** | Classifications, access policies |
+| **Semantics** | Business rules for attributes |
+| **Quality Tests** | Data quality validations |
+| **SLA** | Service level expectations |
+
+### Creating a Contract
+
+1. Navigate to table's detail page
+2. Click **Contract → + Add Contract**
+3. Configure each section:
+
+**Terms of Service:**
+- Click "+ New Node" to add terms
+- Define acceptable usage
+- Specify data handling policies
+
+**Schema Selection:**
+- Select specific columns or all columns
+- Define expected types and constraints
+
+**Security Configuration:**
+- Assign classification labels (PII, Confidential)
+- Define data consumers via policies
+- Set row-level filters
+
+**Semantics (Business Rules):**
+- Service requirements
+- Ownership requirements
+- Tag and domain requirements
+
+**Quality Tests:**
+- Add data quality tests
+- Define pass/fail thresholds
+
+### SLA Configuration
+
+| Field | Description |
+|-------|-------------|
+| **Refresh Frequency** | How often data updates |
+| **Maximum Latency** | Acceptable delay |
+| **Availability Time** | When data should be available |
+| **Retention Period** | How long data is kept |
+| **Refresh Timestamp Column** | Column indicating last update |
+
+### Running Contracts
+
+1. Complete contract configuration
+2. Click **Run Now**
+3. View results in contract details
+4. Track execution history over time
+
+---
+
+## Data Insights
+
+### Data Insights Dashboard
+
+Navigate to **Insights** to access:
+- Platform-wide metrics
+- Data quality trends
+- Ownership coverage
+- Documentation progress
+
+### Key Performance Indicators (KPIs)
+
+#### Supported KPIs
+
+| KPI | Measures |
+|-----|----------|
+| **Completed Description** | % of assets with descriptions |
+| **Completed Ownership** | % of assets with owners |
+
+#### Creating KPIs
+
+1. Navigate to **Insights → Add KPI**
+2. Choose chart type
+3. Set display name
+4. Select metric type (percentage or absolute)
+5. Define target and deadline
+6. Add description
+
+#### Tracking Progress
+
+KPIs display:
+- Current coverage percentage
+- Days remaining to goal
+- Daily progress line graph
+- Trajectory toward completion
+
+### Tiering Analysis
+
+View distribution of assets across tiers:
+- Identify critical data (Tier1)
+- Find untiered assets
+- Track tiering coverage over time
+
+### Reports
+
+**Available Reports:**
+- Description coverage by service
+- Ownership coverage by team
+- Tier distribution
+- Data quality trends
+
+**Email Distribution:**
+- Schedule weekly/monthly reports
+- Configure recipients
+- Include specific metrics
+
+---
+
+## Lineage Visualization
+
+### Lineage View Elements
+
+| Element | Description |
+|---------|-------------|
+| **Source Node** | Parent table (left side) |
+| **Target Node** | Destination table (right side) |
+| **Edge** | Arrow showing data flow |
+
+### Navigation
+
+1. Navigate to asset's **Lineage** tab
+2. View upstream (sources) and downstream (targets)
+3. Click nodes to see asset details
+4. Click edges to see transformation SQL
+
+### Configuration Options
+
+Access **Lineage Config** to set:
+- Upstream depth (1-3 levels)
+- Downstream depth (1-3 levels)
+- Nodes per layer
+
+### Lineage Layers
+
+| Layer | Shows |
+|-------|-------|
+| **Column** | Field-level transformations |
+| **Observability** | Data quality test results |
+| **Service** | Cross-platform flows |
+| **Domain** | Business category organization |
+| **Data Product** | Curated outputs |
+
+### Node Details
+
+Clicking a node shows:
+- Owner and tier
+- Data quality metrics
+- Associated tags
+- Schema preview
+- Query count (for tables)
+
+---
+
+## Version History
+
+### Version Numbering
+
+OpenMetadata uses **major.minor** versioning:
+
+| Change Type | Version Increment | Example |
+|-------------|-------------------|---------|
+| **Minor** (backward compatible) | +0.1 | 0.1 → 0.2 |
+| **Major** (breaking change) | +1.0 | 0.2 → 1.2 |
+
+### Minor Changes (Backward Compatible)
+
+- Description updates
+- Tag additions/removals
+- Ownership changes
+- Custom property updates
+
+### Major Changes (Breaking)
+
+- Column deletions
+- Column type changes
+- Schema restructuring
+
+### Viewing History
+
+1. Click clock icon on asset page
+2. View list of versions
+3. See who made changes
+4. Compare versions
+5. Review change details
+
+### Governance Benefits
+
+- Debug issues by reviewing recent changes
+- Track who modified what and when
+- Identify metadata changes causing problems
+- Support compliance and audit requirements
+
+---
+
+## Announcements
+
+### Creating Announcements
+
+1. Click ⋮ menu on asset page
+2. Select **Announcements**
+3. Click **+ Add Announcement**
+4. Fill in:
+   - Title
+   - Start and end date
+   - Description
+
+### Announcement Visibility
+
+- Appears on asset detail page
+- Shows in activity feeds
+- Visible to all asset followers
+- Time-bounded display
+
+### Use Cases
+
+- Planned maintenance windows
+- Schema migration notices
+- Deprecation warnings
+- Feature announcements
+
+---
+
+## Collaboration Features
+
+### Activity Feeds
+
+View all activity on assets:
+- Description changes
+- Tag updates
+- Ownership changes
+- Task creation
+- Conversations
+
+### Tasks
+
+Create tasks for:
+- Description requests
+- Tag requests
+- Ownership changes
+- Data quality issues
+
+### Conversations
+
+Start threaded discussions:
+1. Click activity feeds tab
+2. Add comment or reply
+3. @mention users for notifications
+4. Resolve completed discussions
+
+### Following
+
+Track assets you care about:
+- Click star to follow
+- Receive change notifications
+- View in your profile
+
+---
+
+## Best Practices
+
+### Documentation
+
+1. **Be specific** - Describe what the data represents
+2. **Include examples** - Show sample values when helpful
+3. **Note caveats** - Document known issues or limitations
+4. **Keep updated** - Review descriptions quarterly
+
+### Tagging
+
+1. **Use standard tags** - Follow organizational taxonomy
+2. **Apply tiers** - Indicate business importance
+3. **Tag consistently** - Same data, same tags
+4. **Don't over-tag** - Keep tags meaningful
+
+### Ownership
+
+1. **Assign owners early** - During ingestion if possible
+2. **Use teams** - Better than individual users
+3. **Review regularly** - Update when people change roles
+4. **Document expectations** - What ownership means
+
+### Glossary
+
+1. **Start small** - Core terms first
+2. **Get buy-in** - Involve business stakeholders
+3. **Use approval workflows** - For governed terms
+4. **Link to assets** - Make terms discoverable
+
+---
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| **Ctrl/Cmd + K** | Open search |
+| **Escape** | Close modals |
+| **Enter** | Confirm selection |
+
+---
+
+## References
+
+- [Data Discovery Guide](https://docs.open-metadata.org/latest/how-to-guides/data-discovery)
+- [Data Governance](https://docs.open-metadata.org/latest/how-to-guides/data-governance)
+- [Data Contracts](https://docs.open-metadata.org/latest/how-to-guides/data-contracts)
+- [Data Insights](https://docs.open-metadata.org/latest/how-to-guides/data-insights)
+- [Guide for Data Users](https://docs.open-metadata.org/latest/how-to-guides/guide-for-data-users)
+- `openmetadata-dev` - Using SDKs/APIs programmatically
+- `openmetadata-ops` - Administering OpenMetadata
+- `openmetadata-dq` - Data quality and observability


### PR DESCRIPTION
## Summary

- Add `openmetadata-user` skill for data discovery, governance, and collaboration UI workflows
- Add `openmetadata-dq` skill for data quality, profiling, alerts, and incident management
- Add MCP server integration section to `openmetadata-dev`

Closes #96

## Changes

### openmetadata-user (new)
- Data discovery (search, filters, previews, advanced search)
- Asset detail pages and tabs
- Descriptions and documentation
- Ownership and following
- Tags and classification
- Business glossary
- Data contracts
- Data insights and KPIs
- Lineage visualization
- Version history
- Announcements and collaboration

### openmetadata-dq (new)
- Data profiler configuration
- Quality test types (table and column level)
- Test suites and scheduling
- Programmatic testing via Python SDK
- Alerts and notifications
- Incident manager workflow
- Lineage for impact analysis
- CI/CD integration example

### openmetadata-dev (updated)
- Added MCP server integration section
- Setup instructions for Claude Desktop and API
- Available MCP tools reference
- Security considerations

## Test plan

- [ ] Verify skills load correctly in Claude Code
- [ ] Review content accuracy against OpenMetadata documentation
- [ ] Confirm cross-references between skills are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)