### PR TITLE
feat(skills): add references/ docs to meta-convert-dev

### DIFF
--- a/components/skills/meta-convert-dev/SKILL.md
+++ b/components/skills/meta-convert-dev/SKILL.md
@@ -1,0 +1,1240 @@
+---
+name: meta-convert-dev
+description: Create language conversion skills for translating code from language A to language B. Use when building 'convert-X-Y' skills, designing type mappings between languages, establishing idiom translation patterns, or defining conversion methodologies. Provides foundational patterns that specific conversion skills extend.
+---
+
+# Language Conversion Skill Development
+
+Foundational patterns for creating one-way language conversion skills. This meta-skill guides the creation of `convert-X-Y` skills (e.g., `convert-typescript-rust`, `convert-python-golang`) that assist in translating/refactoring code from a source language to a target language.
+
+## When to Use This Skill
+
+- Creating a new `convert-X-Y` skill for language translation
+- Designing type system mappings between languages
+- Establishing idiom translation strategies
+- Defining conversion workflows and validation approaches
+- Building tooling recommendations for transpilation
+
+## This Skill Does NOT Cover
+
+- Actual code conversion (use specific `convert-X-Y` skills)
+- Language tutorials (see `lang-*-dev` skills)
+- Bidirectional translation (each direction is a separate skill)
+- Runtime interop/FFI (see language-specific interop skills)
+
+---
+
+## Existing Conversion Skills
+
+For concrete, language-pair-specific examples, see these skills:
+
+| Skill | Description |
+|-------|-------------|
+| `convert-typescript-rust` | TypeScript → Rust (GC → ownership, exceptions → Result) |
+| `convert-typescript-python` | TypeScript → Python (static → dynamic typing) |
+| `convert-typescript-golang` | TypeScript → Go (OOP → simplicity, Promise → goroutine) |
+| `convert-golang-rust` | Go → Rust (GC → ownership, interface → trait) |
+| `convert-python-rust` | Python → Rust (dynamic → static, GC → ownership) |
+
+**Note:** This list may not be complete. Search `components/skills/convert-*` for all available conversion skills.
+
+When this meta-skill shows illustrative examples below, they demonstrate patterns conceptually. For production-ready, comprehensive examples with full context, refer to the specific `convert-X-Y` skills.
+
+---
+
+## Conversion Skill Naming Convention
+
+```
+convert-<source>-<target>
+```
+
+| Component | Description | Example |
+|-----------|-------------|---------|
+| `convert` | Fixed prefix | `convert-` |
+| `<source>` | Source language (lowercase) | `typescript`, `python`, `golang` |
+| `<target>` | Target language (lowercase) | `rust`, `python`, `golang` |
+
+**Examples:**
+- `convert-typescript-rust` - TypeScript → Rust
+- `convert-python-golang` - Python → Go
+- `convert-golang-rust` - Go → Rust
+
+**Note:** Each skill is ONE-WAY. `convert-A-B` and `convert-B-A` are separate skills with different patterns.
+
+---
+
+## Conversion Skill Structure
+
+Every `convert-X-Y` skill should follow this structure:
+
+```markdown
+# Convert <Source> to <Target>
+
+## Overview
+Brief description of the conversion, common use cases, and what to expect.
+
+## When to Use
+- Scenarios where this conversion makes sense
+- Benefits of the target language for this use case
+
+## When NOT to Use
+- Scenarios where conversion is not recommended
+- Better alternatives
+
+## Type System Mapping
+Complete mapping table from source types to target types.
+
+## Idiom Translation
+Source patterns and their idiomatic target equivalents.
+
+## Error Handling
+How to convert error handling patterns.
+
+## Concurrency Patterns
+How async/threading models translate.
+
+## Memory & Ownership
+If applicable, how memory models differ and translate.
+
+## Testing Strategy
+How to verify functional equivalence.
+
+## Tooling
+Available tools, transpilers, and validation helpers.
+
+## Common Pitfalls
+Mistakes to avoid during conversion.
+
+## Examples
+Concrete before/after conversion examples.
+```
+
+---
+
+## Core Conversion Methodology
+
+### The APTV Workflow
+
+Every conversion follows: **Analyze → Plan → Transform → Validate**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    CONVERSION WORKFLOW                       │
+├─────────────────────────────────────────────────────────────┤
+│  1. ANALYZE    │  Understand source code structure          │
+│                │  • Parse and identify components            │
+│                │  • Map dependencies                         │
+│                │  • Identify language-specific patterns      │
+├─────────────────────────────────────────────────────────────┤
+│  2. PLAN       │  Design the target architecture            │
+│                │  • Create type mapping table                │
+│                │  • Identify idiom translations              │
+│                │  • Plan module/package structure            │
+├─────────────────────────────────────────────────────────────┤
+│  3. TRANSFORM  │  Convert code systematically               │
+│                │  • Types and interfaces first               │
+│                │  • Core logic second                        │
+│                │  • Adopt target idioms (don't transliterate)│
+├─────────────────────────────────────────────────────────────┤
+│  4. VALIDATE   │  Verify functional equivalence             │
+│                │  • Run original tests against new code      │
+│                │  • Property-based testing for edge cases    │
+│                │  • Performance comparison if relevant       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Analyze Phase
+
+Before writing any target code:
+
+1. **Parse the source** - Understand structure, not just syntax
+2. **Identify components**:
+   - Types/interfaces/classes
+   - Functions/methods
+   - Module boundaries
+   - External dependencies
+3. **Note language-specific features**:
+   - Generics usage
+   - Error handling patterns
+   - Async patterns
+   - Memory management approach
+
+### Plan Phase
+
+Create explicit mappings before transforming:
+
+```markdown
+## Type Mapping Table
+
+| Source (TypeScript) | Target (Rust) | Notes |
+|---------------------|---------------|-------|
+| `string` | `String` / `&str` | Owned vs borrowed |
+| `number` | `i32` / `f64` | Specify precision |
+| `boolean` | `bool` | Direct |
+| `T[]` | `Vec<T>` | Owned collection |
+| `T \| null` | `Option<T>` | Nullable handling |
+| `Promise<T>` | `Future<Output=T>` | Async handling |
+| `interface X` | `trait X` / `struct X` | Depends on usage |
+```
+
+### Transform Phase
+
+**Golden Rule: Adopt target idioms, don't write "Source code in Target syntax"**
+
+```typescript
+// Source: TypeScript
+function findUser(id: string): User | null {
+  const user = users.find(u => u.id === id);
+  return user || null;
+}
+```
+
+```rust
+// BAD: Transliterated (TypeScript in Rust clothing)
+fn find_user(id: String) -> Option<User> {
+    let user = users.iter().find(|u| u.id == id);
+    match user {
+        Some(u) => Some(u.clone()),
+        None => None,
+    }
+}
+
+// GOOD: Idiomatic Rust
+fn find_user(id: &str) -> Option<&User> {
+    users.iter().find(|u| u.id == id)
+}
+```
+
+### Validate Phase
+
+1. **Functional equivalence**: Same inputs → same outputs
+2. **Edge case coverage**: Property-based tests
+3. **Error behavior**: Same error conditions trigger appropriately
+4. **Performance baseline**: Comparable or better performance
+
+---
+
+## Type System Mapping Strategies
+
+### Primitive Type Mappings
+
+Create a complete primitive mapping table for each language pair:
+
+```markdown
+## Primitive Mappings: TypeScript → Rust
+
+| TypeScript | Rust | Notes |
+|------------|------|-------|
+| `string` | `String` | Owned, heap-allocated |
+| `string` | `&str` | Borrowed, for parameters |
+| `number` | `i32` | Default integer |
+| `number` | `i64` | Large integers |
+| `number` | `f64` | Floating point |
+| `boolean` | `bool` | Direct mapping |
+| `null` | - | Use Option<T> |
+| `undefined` | - | Use Option<T> |
+| `any` | - | Avoid; use generics or enums |
+| `unknown` | - | Use generics with trait bounds |
+| `never` | `!` | Never type (unstable) |
+| `void` | `()` | Unit type |
+```
+
+### Composite Type Mappings
+
+```markdown
+## Composite Mappings: TypeScript → Rust
+
+| TypeScript | Rust | Notes |
+|------------|------|-------|
+| `T[]` | `Vec<T>` | Owned, growable |
+| `readonly T[]` | `&[T]` | Borrowed slice |
+| `[T, U]` | `(T, U)` | Tuple |
+| `Record<K, V>` | `HashMap<K, V>` | Owned map |
+| `Map<K, V>` | `HashMap<K, V>` | Same |
+| `Set<T>` | `HashSet<T>` | Unique values |
+| `T \| U` | `enum { A(T), B(U) }` | Tagged union |
+| `T & U` | `struct { ...T, ...U }` | Combine fields |
+```
+
+### Interface/Class to Struct/Trait
+
+```markdown
+## Structural Mappings
+
+| TypeScript Pattern | Rust Pattern | When to Use |
+|--------------------|--------------|-------------|
+| `interface X { ... }` | `struct X { ... }` | Data-only types |
+| `interface X { method(): T }` | `trait X { fn method(&self) -> T }` | Behavior contracts |
+| `class X implements Y` | `struct X` + `impl Y for X` | Implementation |
+| `class X extends Y` | Composition over inheritance | Rust avoids inheritance |
+| `abstract class X` | `trait X` | Abstract contracts |
+```
+
+### Generic Type Mappings
+
+```markdown
+## Generics: TypeScript → Rust
+
+| TypeScript | Rust | Notes |
+|------------|------|-------|
+| `<T>` | `<T>` | Unconstrained generic |
+| `<T extends U>` | `<T: U>` | Trait bound |
+| `<T extends A & B>` | `<T: A + B>` | Multiple bounds |
+| `<T = Default>` | `<T = Default>` | Default type |
+| `<T extends keyof U>` | Custom trait | No direct equivalent |
+```
+
+---
+
+## Idiom Translation Patterns
+
+> **Note:** The examples below are illustrative snippets showing the *concept* of idiom translation. For complete, production-ready examples with full error handling and edge cases, see specific `convert-X-Y` skills like `convert-typescript-rust` or `convert-python-rust`.
+
+### Translation Philosophy
+
+| Approach | When to Use | Example |
+|----------|-------------|---------|
+| **Literal** | Simple operations, primitives | `x + y` → `x + y` |
+| **Semantic** | Same concept, different syntax | `arr.map()` → `.iter().map()` |
+| **Idiomatic** | Different paradigm | Class hierarchy → Trait + Structs |
+| **Redesign** | No equivalent | Prototype chain → Explicit composition |
+
+### Common Idiom Translations
+
+#### Null Handling
+
+```typescript
+// TypeScript: null coalescing
+const name = user?.name ?? "Anonymous";
+```
+
+```rust
+// Rust: Option combinators
+let name = user.as_ref()
+    .map(|u| u.name.as_str())
+    .unwrap_or("Anonymous");
+```
+
+```go
+// Go: explicit nil check
+var name string
+if user != nil && user.Name != "" {
+    name = user.Name
+} else {
+    name = "Anonymous"
+}
+```
+
+```python
+# Python: or operator (careful with falsy values)
+name = (user and user.name) or "Anonymous"
+
+# Safer Python
+name = user.name if user and user.name else "Anonymous"
+```
+
+#### Collection Operations
+
+```typescript
+// TypeScript: chained methods
+const result = items
+  .filter(x => x.active)
+  .map(x => x.value)
+  .reduce((a, b) => a + b, 0);
+```
+
+```rust
+// Rust: iterator adaptors
+let result: i32 = items.iter()
+    .filter(|x| x.active)
+    .map(|x| x.value)
+    .sum();
+```
+
+```go
+// Go: explicit loops (pre-generics style)
+var result int
+for _, x := range items {
+    if x.Active {
+        result += x.Value
+    }
+}
+```
+
+```python
+# Python: generator expressions
+result = sum(x.value for x in items if x.active)
+```
+
+---
+
+## Error Handling Translation
+
+> **Note:** These examples show error handling translation concepts. For comprehensive error hierarchy translations and real-world patterns, see `convert-typescript-rust`, `convert-python-rust`, or `convert-golang-rust`.
+
+### Error Model Comparison
+
+| Language | Primary Model | Error Type | Propagation |
+|----------|--------------|------------|-------------|
+| TypeScript | Exceptions | `Error` class | `throw` / `try-catch` |
+| Python | Exceptions | `Exception` hierarchy | `raise` / `try-except` |
+| Go | Error returns | `error` interface | Multiple return values |
+| Rust | Result type | `Result<T, E>` | `?` operator |
+
+### Exception → Result Type
+
+```typescript
+// TypeScript: throws exception
+function parseConfig(path: string): Config {
+  const content = fs.readFileSync(path, 'utf-8');
+  try {
+    return JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Failed to parse config: ${e.message}`);
+  }
+}
+```
+
+```rust
+// Rust: returns Result
+fn parse_config(path: &Path) -> Result<Config, ConfigError> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| ConfigError::ReadFailed(e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| ConfigError::ParseFailed(e))
+}
+```
+
+### Exception → Error Return
+
+```typescript
+// TypeScript: throws
+function divide(a: number, b: number): number {
+  if (b === 0) throw new Error("division by zero");
+  return a / b;
+}
+```
+
+```go
+// Go: error return
+func divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+```
+
+### Error Hierarchy Translation
+
+```typescript
+// TypeScript: class hierarchy
+class AppError extends Error {
+  constructor(message: string, public code: string) {
+    super(message);
+  }
+}
+class NotFoundError extends AppError {
+  constructor(resource: string) {
+    super(`${resource} not found`, "NOT_FOUND");
+  }
+}
+```
+
+```rust
+// Rust: enum variants
+#[derive(Debug, thiserror::Error)]
+enum AppError {
+    #[error("{resource} not found")]
+    NotFound { resource: String },
+
+    #[error("validation failed: {message}")]
+    Validation { message: String },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+```
+
+---
+
+## Concurrency Model Translation
+
+> **Note:** For complete async translation patterns including cancellation, streams, and parallel execution, see the specific conversion skills.
+
+### Model Comparison
+
+| Language | Async Model | Threading | Channels |
+|----------|-------------|-----------|----------|
+| TypeScript | `async/await`, Promises | Web Workers (limited) | - |
+| Python | `async/await`, asyncio | Threading, multiprocessing | Queue |
+| Go | Goroutines | Built-in | `chan` (first-class) |
+| Rust | `async/await`, Futures | std::thread | mpsc, crossbeam |
+
+### Promise/Future Translation
+
+```typescript
+// TypeScript: Promise-based
+async function fetchUser(id: string): Promise<User> {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+}
+```
+
+```rust
+// Rust: Future-based (with tokio)
+async fn fetch_user(id: &str) -> Result<User, reqwest::Error> {
+    let user = reqwest::get(format!("/users/{}", id))
+        .await?
+        .json::<User>()
+        .await?;
+    Ok(user)
+}
+```
+
+```go
+// Go: goroutine with channel
+func fetchUser(id string) <-chan UserResult {
+    ch := make(chan UserResult, 1)
+    go func() {
+        resp, err := http.Get(fmt.Sprintf("/users/%s", id))
+        if err != nil {
+            ch <- UserResult{Err: err}
+            return
+        }
+        defer resp.Body.Close()
+        var user User
+        json.NewDecoder(resp.Body).Decode(&user)
+        ch <- UserResult{User: user}
+    }()
+    return ch
+}
+```
+
+### Parallel Execution
+
+```typescript
+// TypeScript: Promise.all
+const [users, orders] = await Promise.all([
+  fetchUsers(),
+  fetchOrders()
+]);
+```
+
+```rust
+// Rust: tokio::join!
+let (users, orders) = tokio::join!(
+    fetch_users(),
+    fetch_orders()
+);
+```
+
+```go
+// Go: goroutines with WaitGroup
+var wg sync.WaitGroup
+var users []User
+var orders []Order
+
+wg.Add(2)
+go func() { defer wg.Done(); users = fetchUsers() }()
+go func() { defer wg.Done(); orders = fetchOrders() }()
+wg.Wait()
+```
+
+---
+
+## Memory & Ownership Translation
+
+> **Note:** For detailed ownership patterns when converting from GC languages, see `convert-typescript-rust`, `convert-python-rust`, or `convert-golang-rust`.
+
+### Memory Model Comparison
+
+| Language | Memory Model | Cleanup | Ownership |
+|----------|--------------|---------|-----------|
+| TypeScript | GC (V8) | Automatic | Shared references |
+| Python | GC (ref counting + cycle) | Automatic | Shared references |
+| Go | GC (concurrent) | Automatic | Shared references |
+| Rust | Ownership + Borrowing | Deterministic (RAII) | Explicit ownership |
+
+### GC → Ownership (e.g., TypeScript → Rust)
+
+```typescript
+// TypeScript: freely share references
+class Cache {
+  private data: Map<string, User> = new Map();
+
+  get(id: string): User | undefined {
+    return this.data.get(id);  // Returns reference
+  }
+
+  set(id: string, user: User): void {
+    this.data.set(id, user);  // Stores reference
+  }
+}
+```
+
+```rust
+// Rust: explicit ownership decisions
+struct Cache {
+    data: HashMap<String, User>,
+}
+
+impl Cache {
+    // Return borrowed reference (doesn't transfer ownership)
+    fn get(&self, id: &str) -> Option<&User> {
+        self.data.get(id)
+    }
+
+    // Take ownership of user (caller gives up ownership)
+    fn set(&mut self, id: String, user: User) {
+        self.data.insert(id, user);
+    }
+
+    // Alternative: clone if shared ownership needed
+    fn get_owned(&self, id: &str) -> Option<User> {
+        self.data.get(id).cloned()
+    }
+}
+```
+
+### Ownership Decision Tree
+
+```
+When converting GC → Ownership:
+
+1. Is this data shared across components?
+   ├─ YES → Consider Arc<T> or Rc<T>
+   └─ NO → Single owner, use moves
+
+2. Is this data mutated by multiple parts?
+   ├─ YES → Arc<Mutex<T>> or channels
+   └─ NO → Immutable borrows (&T)
+
+3. Does this data outlive its creator?
+   ├─ YES → Return owned value or 'static
+   └─ NO → Return borrowed reference
+```
+
+---
+
+## Testing Strategy for Conversions
+
+### Verification Approach
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    TESTING PYRAMID                          │
+├─────────────────────────────────────────────────────────────┤
+│                    ┌───────────────┐                        │
+│                    │  Integration  │  Same API behavior      │
+│                    └───────────────┘                        │
+│               ┌─────────────────────────┐                   │
+│               │    Property-Based       │  Invariants hold   │
+│               └─────────────────────────┘                   │
+│          ┌───────────────────────────────────┐              │
+│          │           Unit Tests              │  Logic match   │
+│          └───────────────────────────────────┘              │
+│     ┌─────────────────────────────────────────────┐         │
+│     │        Input/Output Comparison              │         │
+│     └─────────────────────────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 1. Port Existing Tests
+
+```typescript
+// Original TypeScript test
+describe('Calculator', () => {
+  it('should add numbers', () => {
+    expect(add(2, 3)).toBe(5);
+  });
+
+  it('should handle negative numbers', () => {
+    expect(add(-1, 1)).toBe(0);
+  });
+});
+```
+
+```rust
+// Converted Rust test
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_add_numbers() {
+        assert_eq!(add(2, 3), 5);
+    }
+
+    #[test]
+    fn should_handle_negative_numbers() {
+        assert_eq!(add(-1, 1), 0);
+    }
+}
+```
+
+### 2. Property-Based Testing
+
+Test that invariants hold across random inputs:
+
+```rust
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn add_is_commutative(a: i32, b: i32) {
+        prop_assert_eq!(add(a, b), add(b, a));
+    }
+
+    #[test]
+    fn add_has_identity(a: i32) {
+        prop_assert_eq!(add(a, 0), a);
+    }
+}
+```
+
+### 3. Golden Testing
+
+Compare outputs between original and converted code:
+
+```python
+# Generate test cases from original implementation
+import json
+
+test_cases = []
+for input_data in generate_inputs():
+    output = original_function(input_data)
+    test_cases.append({
+        "input": input_data,
+        "expected": output
+    })
+
+with open("golden_tests.json", "w") as f:
+    json.dump(test_cases, f)
+```
+
+```rust
+// Verify converted implementation matches golden outputs
+#[test]
+fn golden_tests() {
+    let test_cases: Vec<TestCase> =
+        serde_json::from_str(include_str!("golden_tests.json")).unwrap();
+
+    for case in test_cases {
+        let actual = converted_function(&case.input);
+        assert_eq!(actual, case.expected, "Failed for input: {:?}", case.input);
+    }
+}
+```
+
+---
+
+## Tooling Recommendations
+
+### AST Analysis Tools
+
+| Language | Tool | Purpose |
+|----------|------|---------|
+| TypeScript | `ts-morph`, `typescript` compiler API | Parse and analyze TS/JS |
+| Python | `ast` module, `libcst` | Parse Python code |
+| Go | `go/ast`, `go/parser` | Parse Go code |
+| Rust | `syn`, `proc-macro2` | Parse Rust code |
+
+### Transpilers & Converters
+
+| Conversion | Tool | Notes |
+|------------|------|-------|
+| JS/TS → Rust | - | Manual (no mature tool) |
+| Python → Rust | `py2rs` (limited) | Experimental |
+| Go → Rust | - | Manual |
+| TypeScript → Go | - | Manual |
+| C → Rust | `c2rust` | Produces unsafe Rust |
+
+### Validation Tools
+
+1. **Differential Testing**: Run both versions with same inputs
+2. **Coverage Comparison**: Ensure test coverage is equivalent
+3. **Benchmark Comparison**: Compare performance characteristics
+4. **Static Analysis**: Run linters on converted code
+
+---
+
+## Common Pitfalls
+
+### 1. Transliteration Instead of Translation
+
+```
+❌ Writing "TypeScript in Rust syntax"
+✓ Writing idiomatic Rust that achieves the same goal
+```
+
+### 2. Ignoring Target Language Strengths
+
+```
+❌ Porting class hierarchies to Rust (fighting the borrow checker)
+✓ Using Rust's enums and traits to achieve polymorphism
+```
+
+### 3. One-to-One Function Mapping
+
+```
+❌ Every source function becomes one target function
+✓ Restructure to fit target language patterns (may split or merge)
+```
+
+### 4. Preserving Source Inefficiencies
+
+```
+❌ Port the inefficient algorithm just because it worked
+✓ Identify and optimize for target language characteristics
+```
+
+### 5. Ignoring Ecosystem Conventions
+
+```
+❌ Using camelCase in Python (because source was TypeScript)
+✓ Using snake_case (Python convention)
+```
+
+---
+
+## Advanced Ownership & Borrowing Patterns
+
+When converting from GC languages to ownership-based languages (especially Rust), deeper understanding of borrowing patterns is essential.
+
+### Borrowing Pattern Decision Matrix
+
+| Source Pattern | Rust Pattern | When to Use |
+|----------------|--------------|-------------|
+| Pass by reference | `&T` | Read-only access, no mutation needed |
+| Mutable reference | `&mut T` | Single mutator, temporary access |
+| Shared ownership | `Rc<T>` / `Arc<T>` | Multiple owners, single-threaded / multi-threaded |
+| Interior mutability | `RefCell<T>` / `Mutex<T>` | Shared + mutable, single / multi-threaded |
+| Optional ownership | `Option<Box<T>>` | Nullable owned values |
+
+### Lifetime Patterns
+
+```rust
+// Pattern 1: Struct borrowing from owner
+struct Parser<'a> {
+    source: &'a str,  // Borrows source, doesn't own it
+}
+
+// Pattern 2: Self-referential alternatives
+// Instead of self-referential structs, use indices:
+struct TokenStream {
+    source: String,
+    tokens: Vec<(usize, usize)>,  // (start, end) indices into source
+}
+
+// Pattern 3: Owned vs Borrowed parameters
+// Prefer borrowed for read-only, owned for consumed
+fn process_borrowed(data: &[u8]) -> Result<()> { ... }
+fn consume_owned(data: Vec<u8>) -> Result<Output> { ... }
+```
+
+### Clone vs Borrow Decision Tree
+
+```
+Is the data expensive to clone?
+├─ YES → Use borrowing with lifetimes
+│        ├─ Single owner? → &T / &mut T
+│        └─ Multiple owners? → Arc<T>
+└─ NO → Clone freely (Copy types, small structs)
+        └─ Consider #[derive(Clone)] for value semantics
+```
+
+### Shared State Patterns
+
+```typescript
+// TypeScript: Shared mutable state is easy
+class SharedCounter {
+  private count = 0;
+  increment() { this.count++; }
+  get() { return this.count; }
+}
+// Multiple references can call increment()
+```
+
+```rust
+// Rust: Explicit about sharing and mutation
+use std::sync::{Arc, Mutex};
+
+struct SharedCounter {
+    count: Arc<Mutex<i32>>,
+}
+
+impl SharedCounter {
+    fn increment(&self) {
+        let mut guard = self.count.lock().unwrap();
+        *guard += 1;
+    }
+
+    fn get(&self) -> i32 {
+        *self.count.lock().unwrap()
+    }
+}
+// Arc allows sharing, Mutex allows mutation
+```
+
+---
+
+## Async Pattern Translation (Deep Dive)
+
+### Runtime Comparison
+
+| Aspect | JS/TS | Python | Go | Rust |
+|--------|-------|--------|-----|------|
+| Runtime | V8 event loop | asyncio event loop | Go scheduler | tokio/async-std |
+| Default | Single-threaded | Single-threaded | Multi-threaded | Multi-threaded |
+| Blocking | Never block! | Never block! | Goroutines can block | Use spawn_blocking |
+| Cancellation | AbortController | asyncio.CancelledError | Context | Drop / select! |
+
+### Cancellation Patterns
+
+```typescript
+// TypeScript: AbortController
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+```
+
+```rust
+// Rust: tokio::select! for cancellation
+use tokio::time::{timeout, Duration};
+
+async fn fetch_with_timeout(url: &str, ms: u64) -> Result<Response, Error> {
+    timeout(Duration::from_millis(ms), reqwest::get(url))
+        .await
+        .map_err(|_| Error::Timeout)?
+        .map_err(Error::Request)
+}
+
+// Or with explicit select:
+tokio::select! {
+    result = fetch(url) => result,
+    _ = tokio::time::sleep(duration) => Err(Error::Timeout),
+}
+```
+
+```go
+// Go: Context for cancellation
+func fetchWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+
+    req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+    return http.DefaultClient.Do(req)
+}
+```
+
+### Stream/Iterator Translation
+
+```typescript
+// TypeScript: AsyncIterable
+async function* fetchPages(baseUrl: string): AsyncIterable<Page> {
+  let page = 1;
+  while (true) {
+    const data = await fetch(`${baseUrl}?page=${page}`);
+    if (!data.ok) break;
+    yield await data.json();
+    page++;
+  }
+}
+
+for await (const page of fetchPages(url)) {
+  process(page);
+}
+```
+
+```rust
+// Rust: Stream (futures crate or tokio_stream)
+use futures::stream::{self, Stream, StreamExt};
+
+fn fetch_pages(base_url: &str) -> impl Stream<Item = Page> {
+    stream::unfold(1, move |page| async move {
+        let url = format!("{}?page={}", base_url, page);
+        match reqwest::get(&url).await {
+            Ok(resp) if resp.status().is_success() => {
+                let data: Page = resp.json().await.ok()?;
+                Some((data, page + 1))
+            }
+            _ => None,
+        }
+    })
+}
+
+// Consuming
+let mut pages = fetch_pages(url);
+while let Some(page) = pages.next().await {
+    process(page);
+}
+```
+
+---
+
+## Dependency Management Translation
+
+### Package Ecosystem Mapping
+
+| Source | Target | Equivalent Ecosystem |
+|--------|--------|---------------------|
+| npm (TypeScript) | Cargo (Rust) | Direct mapping |
+| pip (Python) | Cargo (Rust) | Direct mapping |
+| go mod (Go) | Cargo (Rust) | Direct mapping |
+| npm (TypeScript) | pip (Python) | Direct mapping |
+| npm (TypeScript) | go mod (Go) | Direct mapping |
+
+### Common Dependency Translations
+
+| Category | TypeScript (npm) | Python (pip) | Go | Rust (Cargo) |
+|----------|-----------------|--------------|-----|--------------|
+| HTTP Client | axios, fetch | requests, httpx | net/http | reqwest |
+| JSON | built-in | json (stdlib) | encoding/json | serde_json |
+| Async Runtime | built-in | asyncio | built-in | tokio, async-std |
+| CLI Parsing | commander, yargs | argparse, click | flag, cobra | clap |
+| Logging | winston, pino | logging, loguru | log, zap | tracing, log |
+| Testing | jest, vitest | pytest | testing | built-in + cargo test |
+| Date/Time | date-fns, luxon | datetime, arrow | time | chrono |
+| Regex | built-in | re | regexp | regex |
+| Env Config | dotenv | python-dotenv | os.Getenv, godotenv | dotenvy |
+| Database | prisma, typeorm | sqlalchemy | gorm, sqlx | diesel, sqlx |
+| Validation | zod, joi | pydantic | validator | validator |
+| Serialization | class-transformer | dataclasses, attrs | encoding/* | serde |
+
+### Dependency Version Strategy
+
+When converting, choose dependency versions strategically:
+
+```toml
+# Rust Cargo.toml - prefer recent stable versions
+[dependencies]
+tokio = { version = "1", features = ["full"] }  # Major version pin
+serde = { version = "1.0", features = ["derive"] }
+reqwest = { version = "0.11", features = ["json"] }  # Pre-1.0, minor matters
+```
+
+```python
+# Python pyproject.toml - allow compatible updates
+[project]
+dependencies = [
+    "httpx>=0.25,<1.0",  # Pre-1.0, be conservative
+    "pydantic>=2.0,<3.0",  # Major version constraint
+]
+```
+
+---
+
+## Performance Considerations
+
+### Performance Impact Matrix
+
+| Conversion | Performance Impact | Why |
+|------------|-------------------|-----|
+| GC → Ownership | Usually faster | No GC pauses, predictable cleanup |
+| Dynamic → Static typing | Usually faster | No runtime type checks |
+| Interpreted → Compiled | Much faster | Direct machine code |
+| Async → Sync | Context-dependent | May lose concurrency benefits |
+| Class hierarchy → Enums | Often faster | Better cache locality |
+
+### Common Performance Pitfalls
+
+#### 1. Unnecessary Cloning
+
+```rust
+// ❌ Cloning when borrowing would work
+fn process(items: Vec<Item>) {
+    for item in items.clone() {  // Unnecessary clone
+        handle(&item);
+    }
+}
+
+// ✓ Borrow instead
+fn process(items: &[Item]) {
+    for item in items {
+        handle(item);
+    }
+}
+```
+
+#### 2. String Allocation Overhead
+
+```rust
+// ❌ Many small allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result = result + part;  // Reallocates each time
+    }
+    result
+}
+
+// ✓ Pre-allocate or use join
+fn build_message(parts: &[&str]) -> String {
+    parts.join("")  // Single allocation
+}
+```
+
+#### 3. Dynamic Dispatch Overhead
+
+```rust
+// ❌ Trait objects when static dispatch is possible
+fn process(handler: &dyn Handler) { ... }
+
+// ✓ Generics for static dispatch (when possible)
+fn process<H: Handler>(handler: &H) { ... }
+```
+
+#### 4. Inefficient Collection Choice
+
+| Need | Wrong Choice | Right Choice |
+|------|-------------|--------------|
+| Fast lookup by key | `Vec` + linear search | `HashMap` |
+| Ordered iteration | `HashMap` | `BTreeMap` or `Vec` |
+| Unique values | `Vec` + contains check | `HashSet` |
+| Stack behavior | `VecDeque` | `Vec` (push/pop) |
+| Queue behavior | `Vec` | `VecDeque` |
+
+### Benchmarking After Conversion
+
+Always benchmark converted code:
+
+```rust
+// Rust: criterion for benchmarks
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_conversion(c: &mut Criterion) {
+    c.bench_function("converted_function", |b| {
+        b.iter(|| converted_function(black_box(input)))
+    });
+}
+
+criterion_group!(benches, benchmark_conversion);
+criterion_main!(benches);
+```
+
+---
+
+## Language-Specific Gotchas
+
+### Python → Rust
+
+| Python Behavior | Rust Reality | Mitigation |
+|-----------------|--------------|------------|
+| Arbitrary precision integers | Fixed-size (i32, i64, i128) | Use `num-bigint` if needed |
+| Everything is an object | Primitives are stack-allocated | Embrace value semantics |
+| Duck typing | Strict static types | Use generics and traits |
+| `None` is everywhere | `Option<T>` is explicit | Map None → None, value → Some(value) |
+| Exceptions unwind the stack | Panics are for bugs, Results for errors | Use Result<T, E> everywhere |
+| GIL limits threading | True parallelism | Use rayon for data parallelism |
+
+### TypeScript → Rust
+
+| TypeScript Behavior | Rust Reality | Mitigation |
+|--------------------|--------------|------------|
+| `any` escape hatch | No equivalent | Use enums or generics |
+| Optional properties | All fields required | Use `Option<T>` for optional |
+| Structural typing | Nominal typing | Define explicit types |
+| Prototype inheritance | No inheritance | Use composition and traits |
+| `undefined` vs `null` | Only `None` | Both map to `Option<T>` |
+| Mutable by default | Immutable by default | Use `let mut` explicitly |
+
+### Go → Rust
+
+| Go Behavior | Rust Reality | Mitigation |
+|-------------|--------------|------------|
+| `nil` for zero values | No implicit nil | Use `Default` trait or Option |
+| Interface satisfaction implicit | Explicit impl blocks | impl Trait for Type |
+| Goroutines lightweight | async tasks or threads | Use tokio::spawn or rayon |
+| Error as return value | Result<T, E> | Similar pattern, more type-safe |
+| No generics (pre-1.18) | Full generics | Take advantage of them |
+| Defer for cleanup | RAII (Drop trait) | Resources clean up automatically |
+
+---
+
+## Skill Template
+
+When creating a new `convert-X-Y` skill, use this template:
+
+```markdown
+---
+name: convert-<source>-<target>
+description: Convert <Source> code to <Target>. Use when migrating <Source> projects to <Target>, translating <Source> patterns to idiomatic <Target>, or refactoring <Source> codebases into <Target>. Extends meta-convert-dev with <Source>-to-<Target> specific patterns.
+---
+
+# Convert <Source> to <Target>
+
+Convert <Source> code to idiomatic <Target>. This skill extends `meta-convert-dev` with <Source>-to-<Target> specific type mappings, idiom translations, and tooling.
+
+## This Skill Extends
+
+- `meta-convert-dev` - Foundational conversion patterns (APTV workflow, testing strategies)
+
+## This Skill Adds
+
+- **Type mappings**: <Source> types → <Target> types
+- **Idiom translations**: <Source> patterns → idiomatic <Target>
+- **Error handling**: <Source> exceptions/errors → <Target> approach
+- **Async patterns**: <Source> async → <Target> async
+- **Tooling**: <Source>-to-<Target> specific tools
+
+## Quick Reference
+
+| <Source> | <Target> | Notes |
+|----------|----------|-------|
+| `<type1>` | `<type1>` | ... |
+| `<type2>` | `<type2>` | ... |
+
+## [Continue with detailed sections...]
+```
+
+---
+
+## Reference Documentation
+
+This skill includes detailed reference documents for common conversion topics:
+
+| Document | Purpose |
+|----------|---------|
+| [`references/migration-strategies.md`](references/migration-strategies.md) | Incremental vs full rewrite decision framework |
+| [`references/naming-conventions.md`](references/naming-conventions.md) | Case style and naming translation tables |
+| [`references/build-system-mapping.md`](references/build-system-mapping.md) | Package manifest and dependency translation |
+| [`references/module-system-comparison.md`](references/module-system-comparison.md) | Import/export and visibility patterns |
+| [`references/performance-considerations.md`](references/performance-considerations.md) | Optimization and profiling guidance |
+
+---
+
+## References
+
+### Skills That Extend This Meta-Skill
+
+These skills provide concrete, language-pair-specific implementations:
+
+- `convert-typescript-rust` - TypeScript → Rust conversion
+- `convert-typescript-python` - TypeScript → Python conversion
+- `convert-typescript-golang` - TypeScript → Go conversion
+- `convert-golang-rust` - Go → Rust conversion
+- `convert-python-rust` - Python → Rust conversion
+
+### Related Meta-Skills
+
+- `meta-library-dev` - Library development patterns
+
+### Language Skills
+
+For language-specific fundamentals (not conversion):
+
+- `lang-typescript-dev` - TypeScript development patterns
+- `lang-python-dev` - Python development patterns
+- `lang-golang-dev` - Go development patterns
+- `lang-rust-dev` - Rust development patterns
+
+### Commands
+
+- `/create-lang-conversion-skill <source> <target>` - Create a new conversion skill using this meta-skill as foundation

--- a/components/skills/meta-convert-dev/references/build-system-mapping.md
+++ b/components/skills/meta-convert-dev/references/build-system-mapping.md
@@ -1,0 +1,362 @@
+# Build System Mapping
+
+Translation guide for build configuration and dependency management between languages.
+
+## Configuration File Mapping
+
+| Purpose | TypeScript/JS | Python | Rust | Go |
+|---------|---------------|--------|------|-----|
+| Package manifest | `package.json` | `pyproject.toml` | `Cargo.toml` | `go.mod` |
+| Lock file | `package-lock.json` / `yarn.lock` | `poetry.lock` / `uv.lock` | `Cargo.lock` | `go.sum` |
+| Build config | `tsconfig.json` | `pyproject.toml` | `Cargo.toml` | N/A (go build) |
+| Workspace | `package.json` (workspaces) | `pyproject.toml` | `Cargo.toml` (workspace) | `go.work` |
+| Env config | `.env` | `.env` | `.env` | `.env` |
+| Ignore file | `.gitignore`, `.npmignore` | `.gitignore` | `.gitignore` | `.gitignore` |
+
+---
+
+## Package Manifest Translation
+
+### Basic Structure
+
+**TypeScript (package.json)**
+```json
+{
+  "name": "my-project",
+  "version": "1.0.0",
+  "description": "Project description",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "axios": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}
+```
+
+**Python (pyproject.toml)**
+```toml
+[project]
+name = "my-project"
+version = "1.0.0"
+description = "Project description"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.25.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "mypy>=1.0.0",
+]
+
+[project.scripts]
+my-cli = "my_project:main"
+```
+
+**Rust (Cargo.toml)**
+```toml
+[package]
+name = "my-project"
+version = "1.0.0"
+description = "Project description"
+edition = "2021"
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+
+[dev-dependencies]
+tokio-test = "0.4"
+
+[[bin]]
+name = "my-cli"
+path = "src/main.rs"
+```
+
+**Go (go.mod)**
+```go
+module github.com/user/my-project
+
+go 1.21
+
+require (
+    github.com/go-resty/resty/v2 v2.10.0
+)
+
+require (
+    // indirect dependencies
+)
+```
+
+---
+
+## Dependency Specification
+
+### Version Syntax
+
+| Meaning | npm | Python (PEP 440) | Cargo | Go |
+|---------|-----|------------------|-------|-----|
+| Exact | `1.2.3` | `==1.2.3` | `=1.2.3` | `v1.2.3` |
+| Compatible | `^1.2.3` | `~=1.2.3` | `1.2.3` (default) | N/A (uses MVS) |
+| Minor updates | `~1.2.3` | `>=1.2.3,<1.3.0` | `~1.2.3` | N/A |
+| Range | `>=1.0.0 <2.0.0` | `>=1.0.0,<2.0.0` | `>=1.0.0, <2.0.0` | N/A |
+| Wildcard | `1.2.*` | `1.2.*` | `1.2.*` | N/A |
+| Any | `*` | `*` | `*` | `latest` |
+
+### Dependency Types
+
+| Type | npm | Python | Cargo | Go |
+|------|-----|--------|-------|-----|
+| Runtime | `dependencies` | `dependencies` | `[dependencies]` | `require` |
+| Development | `devDependencies` | `[project.optional-dependencies].dev` | `[dev-dependencies]` | N/A (use `//go:build` tags) |
+| Build-time | `devDependencies` | `[build-system].requires` | `[build-dependencies]` | N/A |
+| Optional | `optionalDependencies` | `[project.optional-dependencies]` | `[dependencies.x] optional = true` | N/A |
+| Peer | `peerDependencies` | N/A | N/A | N/A |
+
+---
+
+## Scripts / Tasks
+
+### TypeScript/JS → Other Languages
+
+| npm script | Python | Rust | Go |
+|------------|--------|------|-----|
+| `npm run build` | `python -m build` | `cargo build` | `go build` |
+| `npm run test` | `pytest` | `cargo test` | `go test ./...` |
+| `npm run lint` | `ruff check .` | `cargo clippy` | `golangci-lint run` |
+| `npm run fmt` | `ruff format .` | `cargo fmt` | `go fmt ./...` |
+| `npm start` | `python -m my_pkg` | `cargo run` | `go run .` |
+| `npm run dev` | N/A (use reload) | `cargo watch -x run` | `air` or `gow` |
+
+### Task Runners
+
+| Purpose | TypeScript/JS | Python | Rust | Go |
+|---------|---------------|--------|------|-----|
+| Task runner | npm scripts, just | just, make, invoke | cargo-make, just | make, just, mage |
+| Watch mode | nodemon, tsx | watchdog | cargo-watch | air, gow |
+| Monorepo | turborepo, nx | hatch, pdm | cargo workspace | go.work |
+
+---
+
+## Workspace / Monorepo
+
+### TypeScript (package.json workspaces)
+```json
+{
+  "workspaces": [
+    "packages/*"
+  ]
+}
+```
+
+### Python (pyproject.toml with hatch/pdm)
+```toml
+# Using hatch
+[tool.hatch.envs.default]
+dependencies = [
+  "./packages/core",
+  "./packages/cli"
+]
+```
+
+### Rust (Cargo.toml workspace)
+```toml
+[workspace]
+members = [
+    "crates/core",
+    "crates/cli"
+]
+
+[workspace.dependencies]
+serde = "1.0"
+tokio = { version = "1", features = ["full"] }
+```
+
+### Go (go.work)
+```go
+go 1.21
+
+use (
+    ./packages/core
+    ./packages/cli
+)
+```
+
+---
+
+## Binary / Entry Points
+
+### TypeScript
+```json
+{
+  "bin": {
+    "my-cli": "./dist/cli.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
+}
+```
+
+### Python
+```toml
+[project.scripts]
+my-cli = "my_package.cli:main"
+
+[project.gui-scripts]
+my-gui = "my_package.gui:main"
+```
+
+### Rust
+```toml
+[[bin]]
+name = "my-cli"
+path = "src/bin/cli.rs"
+
+[lib]
+name = "my_lib"
+path = "src/lib.rs"
+```
+
+### Go
+```go
+// main.go in cmd/my-cli/
+package main
+
+func main() {
+    // Entry point
+}
+```
+
+---
+
+## Features / Optional Dependencies
+
+### TypeScript
+```json
+{
+  "optionalDependencies": {
+    "fsevents": "^2.0.0"
+  }
+}
+```
+
+### Python
+```toml
+[project.optional-dependencies]
+postgres = ["psycopg2>=2.9"]
+mysql = ["mysqlclient>=2.0"]
+all = ["psycopg2>=2.9", "mysqlclient>=2.0"]
+```
+
+### Rust
+```toml
+[features]
+default = ["json"]
+json = ["serde_json"]
+postgres = ["sqlx/postgres"]
+mysql = ["sqlx/mysql"]
+full = ["json", "postgres", "mysql"]
+
+[dependencies]
+serde_json = { version = "1.0", optional = true }
+sqlx = { version = "0.7", optional = true }
+```
+
+### Go
+```go
+// Use build tags
+//go:build postgres
+
+package db
+
+import _ "github.com/lib/pq"
+```
+
+---
+
+## Environment / Config
+
+### Environment Variables
+
+| Purpose | TypeScript | Python | Rust | Go |
+|---------|------------|--------|------|-----|
+| Load .env | `dotenv` | `python-dotenv` | `dotenvy` | `godotenv` |
+| Typed config | `zod` + env | `pydantic-settings` | `config` crate | `env`, `kelseyhightower/envconfig` |
+
+### Example Translations
+
+**TypeScript**
+```typescript
+import { z } from 'zod';
+import 'dotenv/config';
+
+const Config = z.object({
+  PORT: z.coerce.number().default(3000),
+  DATABASE_URL: z.string(),
+});
+
+export const config = Config.parse(process.env);
+```
+
+**Python**
+```python
+from pydantic_settings import BaseSettings
+
+class Config(BaseSettings):
+    port: int = 3000
+    database_url: str
+
+    class Config:
+        env_file = ".env"
+
+config = Config()
+```
+
+**Rust**
+```rust
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Config {
+    #[serde(default = "default_port")]
+    pub port: u16,
+    pub database_url: String,
+}
+
+fn default_port() -> u16 { 3000 }
+
+pub fn load() -> Config {
+    dotenvy::dotenv().ok();
+    envy::from_env().expect("Failed to load config")
+}
+```
+
+**Go**
+```go
+type Config struct {
+    Port        int    `envconfig:"PORT" default:"3000"`
+    DatabaseURL string `envconfig:"DATABASE_URL" required:"true"`
+}
+
+func Load() (*Config, error) {
+    godotenv.Load()
+    var cfg Config
+    err := envconfig.Process("", &cfg)
+    return &cfg, err
+}
+```
+
+---
+
+## Related
+
+- `meta-convert-dev` - Core conversion patterns
+- `references/module-system-comparison.md` - Module systems
+- Language-specific `lang-*-dev` skills

--- a/components/skills/meta-convert-dev/references/migration-strategies.md
+++ b/components/skills/meta-convert-dev/references/migration-strategies.md
@@ -1,0 +1,222 @@
+# Migration Strategies
+
+Decision framework for choosing between incremental and full rewrite approaches.
+
+## Strategy Comparison
+
+| Strategy | When to Use | Risk Level | Timeline |
+|----------|-------------|------------|----------|
+| **Full Rewrite** | Small codebase, greenfield opportunity | High | Faster start, uncertain end |
+| **Incremental** | Production system, risk-averse | Low | Slower start, predictable end |
+| **Strangler Fig** | Large monolith, gradual replacement | Medium | Moderate timeline |
+| **Parallel Run** | Critical systems, correctness required | Low | Longer (2x development) |
+
+---
+
+## Full Rewrite
+
+### When to Choose
+
+- Codebase < 10,000 lines
+- No active users depending on current system
+- Technical debt makes incremental changes costly
+- Target language offers significant advantages
+- Team has capacity for focused rewrite sprint
+
+### Risks
+
+- "Second system effect" - tendency to over-engineer
+- Feature parity gaps discovered late
+- Timeline estimation is difficult
+- Team burnout on long rewrites
+
+### Process
+
+```
+1. Document all features and behaviors (exhaustively)
+2. Create comprehensive test suite for original
+3. Implement core functionality first
+4. Port tests to target language
+5. Achieve feature parity
+6. Parallel testing phase
+7. Cutover
+```
+
+---
+
+## Incremental Migration
+
+### When to Choose
+
+- Production system with active users
+- Large codebase (> 50,000 lines)
+- Cannot afford downtime or feature freeze
+- Team needs to learn target language gradually
+- Business requires continuous feature delivery
+
+### Patterns
+
+#### 1. Module-by-Module
+
+```
+Original System          Target System
+┌─────────────────┐     ┌─────────────────┐
+│ Module A (src)  │ ──► │ Module A (tgt)  │
+├─────────────────┤     ├─────────────────┤
+│ Module B (src)  │     │ Module B (src)  │ ← Still original
+├─────────────────┤     ├─────────────────┤
+│ Module C (src)  │     │ Module C (src)  │ ← Still original
+└─────────────────┘     └─────────────────┘
+```
+
+#### 2. Layer-by-Layer
+
+```
+┌─────────────────┐     ┌─────────────────┐
+│   UI Layer      │     │   UI Layer      │ ← Convert last
+├─────────────────┤     ├─────────────────┤
+│ Business Logic  │ ──► │ Business Logic  │ ← Convert second
+├─────────────────┤     ├─────────────────┤
+│   Data Layer    │     │   Data Layer    │ ← Convert first
+└─────────────────┘     └─────────────────┘
+```
+
+#### 3. Feature-by-Feature
+
+Convert one feature end-to-end, including all layers:
+
+```
+Feature A: [UI] → [Logic] → [Data]  ← Fully converted
+Feature B: [UI] → [Logic] → [Data]  ← Still original
+Feature C: [UI] → [Logic] → [Data]  ← Still original
+```
+
+### Interop Requirements
+
+For incremental migration, you need a bridge between languages:
+
+| Source → Target | Interop Options |
+|-----------------|-----------------|
+| TypeScript → Rust | WASM, NAPI, HTTP API |
+| Python → Rust | PyO3, CFFI, HTTP API |
+| Go → Rust | CGO + C ABI, gRPC, HTTP API |
+| TypeScript → Python | HTTP API, message queue |
+| TypeScript → Go | HTTP API, gRPC |
+
+---
+
+## Strangler Fig Pattern
+
+Named after strangler fig trees that grow around host trees.
+
+### When to Choose
+
+- Large monolithic system
+- Need to replace without disruption
+- Can route traffic between old and new
+- System has clear request/response boundaries
+
+### Process
+
+```
+                    ┌──────────────────┐
+                    │    Router/Proxy   │
+                    └────────┬─────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              ▼              ▼              ▼
+    ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+    │ New Service │  │ Old Monolith│  │ Old Monolith│
+    │  (Target)   │  │  Feature B  │  │  Feature C  │
+    └─────────────┘  └─────────────┘  └─────────────┘
+
+1. Start with edge features
+2. Route traffic to new implementation
+3. Gradually expand coverage
+4. Decommission old code as features migrate
+```
+
+### Success Criteria
+
+- [ ] Clear routing layer in place
+- [ ] Feature flags for traffic splitting
+- [ ] Monitoring on both implementations
+- [ ] Rollback capability
+
+---
+
+## Parallel Run
+
+### When to Choose
+
+- Financial systems, correctness-critical
+- Need mathematical proof of equivalence
+- Regulatory requirements for validation
+- Cannot afford any regression
+
+### Process
+
+```
+┌─────────────────┐
+│     Input       │
+└────────┬────────┘
+         │
+    ┌────┴────┐
+    ▼         ▼
+┌───────┐ ┌───────┐
+│ Old   │ │ New   │
+│System │ │System │
+└───┬───┘ └───┬───┘
+    │         │
+    └────┬────┘
+         ▼
+┌─────────────────┐
+│   Comparator    │ ← Detect differences
+└─────────────────┘
+```
+
+### Comparison Strategies
+
+1. **Shadow mode**: New system processes but results are discarded
+2. **Diff mode**: Both results stored and compared offline
+3. **Canary mode**: Small percentage of traffic uses new result
+4. **Full parallel**: Both run, old result used, new result logged
+
+---
+
+## Decision Matrix
+
+| Factor | Full Rewrite | Incremental | Strangler Fig | Parallel |
+|--------|--------------|-------------|---------------|----------|
+| Codebase size | Small | Any | Large | Any |
+| Risk tolerance | High | Low | Medium | Very Low |
+| Feature freeze OK? | Yes | No | No | No |
+| Interop complexity | None | High | Medium | Low |
+| Team size | Small | Any | Medium+ | Large |
+| Timeline certainty | Low | High | Medium | High |
+
+---
+
+## Anti-Patterns
+
+### 1. The "Big Bang"
+Attempting to rewrite everything at once without incremental delivery.
+
+### 2. Scope Creep
+Adding features during migration instead of achieving parity first.
+
+### 3. No Rollback Plan
+Migrating without ability to revert to original system.
+
+### 4. Skipping Tests
+Migrating without comprehensive test coverage of original behavior.
+
+### 5. Ignoring Interop Costs
+Underestimating the complexity of running two systems simultaneously.
+
+---
+
+## Related
+
+- `meta-convert-dev` - Core conversion patterns
+- `convert-*` skills - Language-specific migrations

--- a/components/skills/meta-convert-dev/references/module-system-comparison.md
+++ b/components/skills/meta-convert-dev/references/module-system-comparison.md
@@ -1,0 +1,438 @@
+# Module System Comparison
+
+Reference for translating module/package systems between languages.
+
+## Quick Comparison
+
+| Aspect | TypeScript/JS | Python | Rust | Go |
+|--------|---------------|--------|------|-----|
+| Unit of code | File (module) | File (module) | File (module) | Package (directory) |
+| Namespace | ES Modules | Packages | Crates/Modules | Packages |
+| Visibility | `export` | `_prefix` convention | `pub` | PascalCase |
+| Import style | Named/default | Named | Named (use) | Package-level |
+| Circular deps | Allowed (carefully) | Allowed (carefully) | Not allowed | Not allowed |
+
+---
+
+## TypeScript / JavaScript
+
+### Module Declaration
+
+```typescript
+// Named exports (preferred)
+export function doSomething() { }
+export const VALUE = 42;
+export interface User { }
+export class Service { }
+
+// Default export
+export default class MainClass { }
+
+// Re-export
+export { something } from './other';
+export * from './utils';
+export { foo as bar } from './foo';
+```
+
+### Import Patterns
+
+```typescript
+// Named imports
+import { doSomething, VALUE } from './module';
+
+// Default import
+import MainClass from './module';
+
+// Namespace import
+import * as utils from './utils';
+
+// Side effect import
+import './polyfills';
+
+// Dynamic import
+const module = await import('./lazy');
+```
+
+### Module Resolution
+
+```
+project/
+├── package.json
+├── src/
+│   ├── index.ts        # Entry point
+│   ├── utils/
+│   │   ├── index.ts    # utils barrel
+│   │   └── helpers.ts
+│   └── services/
+│       └── api.ts
+```
+
+---
+
+## Python
+
+### Module Declaration
+
+```python
+# my_module.py
+
+# Public by convention (no underscore)
+def public_function():
+    pass
+
+PUBLIC_CONSTANT = 42
+
+class PublicClass:
+    pass
+
+# Private by convention (single underscore)
+def _private_function():
+    pass
+
+_PRIVATE_CONSTANT = "internal"
+
+# Name-mangled (double underscore in classes)
+class MyClass:
+    def __private_method(self):
+        pass
+```
+
+### Package Structure
+
+```python
+# __init__.py - Package initialization
+from .module import public_function
+from .subpackage import SubClass
+
+__all__ = ['public_function', 'SubClass']  # Controls `from pkg import *`
+```
+
+### Import Patterns
+
+```python
+# Absolute imports (preferred)
+from mypackage.module import function
+from mypackage import module
+
+# Relative imports (within package)
+from . import sibling_module
+from .sibling import function
+from ..parent import something
+
+# Namespace import
+import mypackage.module as mod
+
+# Conditional import
+try:
+    import fast_module as impl
+except ImportError:
+    import slow_module as impl
+```
+
+### Module Resolution
+
+```
+mypackage/
+├── __init__.py         # Package marker
+├── module.py
+├── subpackage/
+│   ├── __init__.py
+│   └── submodule.py
+└── py.typed            # PEP 561 marker for typing
+```
+
+---
+
+## Rust
+
+### Module Declaration
+
+```rust
+// lib.rs or main.rs
+
+// Declare submodules
+mod utils;           // Load from utils.rs or utils/mod.rs
+mod services;        // Load from services.rs or services/mod.rs
+pub mod public_mod;  // Public module
+
+// Inline module
+mod inline {
+    pub fn helper() { }
+}
+
+// Re-export (common pattern)
+pub use utils::helper_function;
+pub use services::Service;
+```
+
+### Visibility
+
+```rust
+// Private (default)
+fn private_function() { }
+struct PrivateStruct { }
+
+// Public
+pub fn public_function() { }
+pub struct PublicStruct {
+    pub public_field: i32,
+    private_field: String,  // Field still private
+}
+
+// Crate-public (visible within crate only)
+pub(crate) fn crate_function() { }
+
+// Super-public (visible to parent module)
+pub(super) fn parent_visible() { }
+
+// Path-restricted
+pub(in crate::module) fn restricted() { }
+```
+
+### Import Patterns (use)
+
+```rust
+// Specific items
+use std::collections::HashMap;
+use crate::utils::{helper, another_helper};
+
+// Glob import (avoid in libraries)
+use std::io::prelude::*;
+
+// Renaming
+use std::io::Result as IoResult;
+
+// Nested paths
+use std::{
+    collections::{HashMap, HashSet},
+    io::{self, Read, Write},
+};
+
+// Re-export
+pub use self::internal::PublicApi;
+```
+
+### Module Resolution
+
+```
+src/
+├── lib.rs              # Library root
+├── main.rs             # Binary root (optional)
+├── utils.rs            # mod utils (file style)
+├── services/           # mod services (directory style)
+│   ├── mod.rs          # Module root
+│   └── api.rs          # services::api
+└── models/
+    ├── mod.rs
+    ├── user.rs
+    └── order.rs
+```
+
+---
+
+## Go
+
+### Package Declaration
+
+```go
+// Every file starts with package declaration
+package mypackage
+
+// Exported (uppercase)
+func PublicFunction() { }
+var PublicVar = 42
+type PublicStruct struct {
+    PublicField  string
+    privateField int  // unexported field
+}
+
+// Unexported (lowercase)
+func privateFunction() { }
+var privateVar = "internal"
+type privateStruct struct { }
+```
+
+### Import Patterns
+
+```go
+// Single import
+import "fmt"
+
+// Multiple imports
+import (
+    "fmt"
+    "strings"
+
+    // Third-party
+    "github.com/gin-gonic/gin"
+
+    // Local packages
+    "mymodule/internal/utils"
+)
+
+// Aliased import
+import (
+    myfmt "fmt"
+    _ "github.com/lib/pq"  // Side effect only
+    . "math"               // Dot import (avoid)
+)
+```
+
+### Package Structure
+
+```
+mymodule/
+├── go.mod              # Module definition
+├── main.go             # package main
+├── mypackage/          # package mypackage
+│   ├── public.go
+│   └── private.go
+├── internal/           # Internal packages (not importable from outside)
+│   └── utils/
+│       └── helpers.go
+└── cmd/                # Multiple binaries
+    ├── server/
+    │   └── main.go
+    └── cli/
+        └── main.go
+```
+
+### Internal Packages
+
+Go has special `internal/` directory semantics:
+
+```
+mymodule/
+├── internal/           # Only importable by mymodule and children
+│   └── secret/
+└── pkg/                # Convention: public packages
+    └── api/
+```
+
+---
+
+## Translation Patterns
+
+### TypeScript → Python
+
+| TypeScript | Python |
+|------------|--------|
+| `export function foo()` | `def foo():` (public by default) |
+| `export default class X` | `class X:` + add to `__all__` |
+| `import { x } from './mod'` | `from .mod import x` |
+| `import * as utils` | `from . import utils` |
+| Private (no export) | `def _private():` |
+| `index.ts` barrel | `__init__.py` |
+
+### TypeScript → Rust
+
+| TypeScript | Rust |
+|------------|------|
+| `export function foo()` | `pub fn foo()` |
+| `export default` | `pub use` re-export |
+| `import { x } from './mod'` | `use crate::mod::x;` |
+| `import * as utils` | `use crate::utils;` |
+| Private (no export) | `fn private()` (default) |
+| `index.ts` barrel | `mod.rs` or `lib.rs` re-exports |
+
+### TypeScript → Go
+
+| TypeScript | Go |
+|------------|-----|
+| `export function foo()` | `func Foo()` (uppercase) |
+| `export default` | N/A (no default exports) |
+| `import { x } from './mod'` | `import "pkg/mod"; mod.X` |
+| Private (no export) | `func foo()` (lowercase) |
+| `index.ts` barrel | N/A (all files in dir = package) |
+
+### Python → Rust
+
+| Python | Rust |
+|--------|------|
+| `def function():` | `pub fn function()` |
+| `_private()` | `fn private()` |
+| `__init__.py` | `mod.rs` or `lib.rs` |
+| `from .mod import x` | `use crate::mod::x;` |
+| `__all__` | `pub use` re-exports |
+
+### Go → Rust
+
+| Go | Rust |
+|----|------|
+| `func Public()` | `pub fn public()` |
+| `func private()` | `fn private()` |
+| `internal/` | `pub(crate)` |
+| Package (directory) | Module (file or directory) |
+| `import "pkg"` | `use crate::pkg;` |
+
+---
+
+## Circular Dependencies
+
+### Handling Approaches
+
+| Language | Circular Deps | Solution |
+|----------|---------------|----------|
+| TypeScript | Allowed (runtime issues) | Type-only imports, restructure |
+| Python | Allowed (import at use) | Import inside function, restructure |
+| Rust | Not allowed | Restructure into shared module |
+| Go | Not allowed | Restructure, use interfaces |
+
+### Resolution Pattern
+
+```
+Before (circular):
+A ──imports──► B
+▲              │
+└───imports────┘
+
+After (resolved):
+A ──imports──► Common ◄──imports── B
+```
+
+---
+
+## Re-export Patterns
+
+### TypeScript (barrel)
+```typescript
+// index.ts
+export { User, UserService } from './user';
+export { Order } from './order';
+export * from './utils';
+```
+
+### Python (__init__.py)
+```python
+from .user import User, UserService
+from .order import Order
+from .utils import *
+
+__all__ = ['User', 'UserService', 'Order']
+```
+
+### Rust (lib.rs or mod.rs)
+```rust
+mod user;
+mod order;
+mod utils;
+
+pub use user::{User, UserService};
+pub use order::Order;
+pub use utils::*;
+```
+
+### Go (no re-export, flat structure)
+```go
+// Go doesn't have re-exports
+// All exported items in package are directly accessible
+// Consumers import the package and access items directly
+```
+
+---
+
+## Related
+
+- `meta-convert-dev` - Core conversion patterns
+- `references/build-system-mapping.md` - Build configuration
+- `references/naming-conventions.md` - Naming translation

--- a/components/skills/meta-convert-dev/references/naming-conventions.md
+++ b/components/skills/meta-convert-dev/references/naming-conventions.md
@@ -1,0 +1,213 @@
+# Naming Convention Translation
+
+Quick reference for translating naming conventions between programming languages.
+
+## Case Style Reference
+
+| Style | Example | Languages |
+|-------|---------|-----------|
+| `camelCase` | `getUserName` | JavaScript, TypeScript, Java, Go (unexported) |
+| `PascalCase` | `GetUserName` | C#, Go (exported), TypeScript (types) |
+| `snake_case` | `get_user_name` | Python, Rust, Ruby |
+| `SCREAMING_SNAKE` | `MAX_BUFFER_SIZE` | Constants in most languages |
+| `kebab-case` | `get-user-name` | Lisp, CSS, CLI flags, file names |
+| `UPPERCASE` | `HTTP`, `URL` | Acronyms (varies by language) |
+
+---
+
+## Language-Specific Conventions
+
+### TypeScript / JavaScript
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables | camelCase | `userName` |
+| Functions | camelCase | `getUserName()` |
+| Classes | PascalCase | `UserService` |
+| Interfaces | PascalCase | `IUserService` or `UserService` |
+| Types | PascalCase | `UserResponse` |
+| Enums | PascalCase | `UserStatus` |
+| Enum values | PascalCase or SCREAMING_SNAKE | `Active` or `ACTIVE` |
+| Constants | SCREAMING_SNAKE or camelCase | `MAX_RETRIES` or `maxRetries` |
+| Files | kebab-case or camelCase | `user-service.ts` |
+| Acronyms | Uppercase in middle | `parseJSON`, `httpClient` |
+
+### Python
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables | snake_case | `user_name` |
+| Functions | snake_case | `get_user_name()` |
+| Classes | PascalCase | `UserService` |
+| Constants | SCREAMING_SNAKE | `MAX_RETRIES` |
+| Modules | snake_case | `user_service.py` |
+| Packages | snake_case (short) | `mypackage` |
+| Private | Leading underscore | `_internal_method` |
+| "Very private" | Double underscore | `__mangled_name` |
+| Dunder methods | Double underscore both | `__init__`, `__str__` |
+
+### Rust
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables | snake_case | `user_name` |
+| Functions | snake_case | `get_user_name()` |
+| Structs | PascalCase | `UserService` |
+| Enums | PascalCase | `UserStatus` |
+| Enum variants | PascalCase | `UserStatus::Active` |
+| Traits | PascalCase | `Serialize` |
+| Constants | SCREAMING_SNAKE | `MAX_RETRIES` |
+| Static | SCREAMING_SNAKE | `GLOBAL_CONFIG` |
+| Modules | snake_case | `user_service.rs` |
+| Crates | snake_case (or kebab) | `my_crate` |
+| Type parameters | Single uppercase | `T`, `E`, `K`, `V` |
+| Lifetimes | Short lowercase | `'a`, `'static` |
+| Macros | snake_case! | `println!`, `vec!` |
+
+### Go
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Variables (exported) | PascalCase | `UserName` |
+| Variables (unexported) | camelCase | `userName` |
+| Functions (exported) | PascalCase | `GetUserName()` |
+| Functions (unexported) | camelCase | `getUserName()` |
+| Structs | PascalCase | `UserService` |
+| Interfaces | PascalCase + -er suffix | `Reader`, `UserFetcher` |
+| Constants | PascalCase or camelCase | `MaxRetries` |
+| Packages | lowercase, short | `user`, `httputil` |
+| Files | snake_case | `user_service.go` |
+| Acronyms | All caps | `HTTPClient`, `XMLParser` |
+| Receivers | Short (1-2 chars) | `func (u *User) Name()` |
+
+---
+
+## Translation Tables
+
+### TypeScript → Python
+
+| TypeScript | Python | Notes |
+|------------|--------|-------|
+| `getUserName` | `get_user_name` | camelCase → snake_case |
+| `UserService` | `UserService` | PascalCase preserved |
+| `MAX_RETRIES` | `MAX_RETRIES` | SCREAMING_SNAKE preserved |
+| `IUserService` | `UserService` | Drop I prefix (use ABC) |
+| `userService.ts` | `user_service.py` | kebab/camel → snake |
+
+### TypeScript → Rust
+
+| TypeScript | Rust | Notes |
+|------------|------|-------|
+| `getUserName` | `get_user_name` | camelCase → snake_case |
+| `UserService` | `UserService` | PascalCase preserved |
+| `MAX_RETRIES` | `MAX_RETRIES` | SCREAMING_SNAKE preserved |
+| `UserStatus.Active` | `UserStatus::Active` | Enum access syntax |
+| `interface User` | `struct User` or `trait User` | Depends on usage |
+
+### TypeScript → Go
+
+| TypeScript | Go (exported) | Go (unexported) | Notes |
+|------------|---------------|-----------------|-------|
+| `getUserName` | `GetUserName` | `getUserName` | Visibility by case |
+| `UserService` | `UserService` | `userService` | Depends on export |
+| `MAX_RETRIES` | `MaxRetries` | `maxRetries` | Go avoids SCREAMING |
+| `IReader` | `Reader` | - | -er suffix for interfaces |
+
+### Python → Rust
+
+| Python | Rust | Notes |
+|--------|------|-------|
+| `get_user_name` | `get_user_name` | snake_case preserved |
+| `UserService` | `UserService` | PascalCase preserved |
+| `MAX_RETRIES` | `MAX_RETRIES` | Constants preserved |
+| `_private` | `fn private()` (mod private) | Visibility via module |
+| `__init__` | `fn new()` | Convention: new() for constructors |
+
+### Go → Rust
+
+| Go | Rust | Notes |
+|----|------|-------|
+| `GetUserName` | `get_user_name` | PascalCase → snake_case |
+| `userName` | `user_name` | camelCase → snake_case |
+| `UserService` | `UserService` | PascalCase preserved |
+| `MaxRetries` | `MAX_RETRIES` | Constants to SCREAMING |
+| `Reader` | `Read` trait | Similar pattern |
+
+---
+
+## Acronym Handling
+
+### General Rules
+
+| Language | Acronym Handling | Example |
+|----------|------------------|---------|
+| TypeScript | Lowercase after first | `parseJson`, `httpClient` |
+| Python | Lowercase in snake_case | `parse_json`, `http_client` |
+| Rust | Lowercase in snake_case | `parse_json`, `http_client` |
+| Go | ALL CAPS | `ParseJSON`, `HTTPClient` |
+
+### Common Acronyms
+
+| Acronym | TypeScript | Python | Rust | Go |
+|---------|------------|--------|------|-----|
+| HTTP | `httpClient` | `http_client` | `http_client` | `HTTPClient` |
+| JSON | `parseJson` | `parse_json` | `parse_json` | `ParseJSON` |
+| URL | `getUrl` | `get_url` | `get_url` | `GetURL` |
+| ID | `userId` | `user_id` | `user_id` | `UserID` |
+| API | `apiKey` | `api_key` | `api_key` | `APIKey` |
+| SQL | `sqlQuery` | `sql_query` | `sql_query` | `SQLQuery` |
+| XML | `parseXml` | `parse_xml` | `parse_xml` | `ParseXML` |
+| IO | `ioError` | `io_error` | `io_error` | `IOError` |
+
+---
+
+## File and Module Naming
+
+| Language | Files | Modules/Packages |
+|----------|-------|------------------|
+| TypeScript | `kebab-case.ts` or `camelCase.ts` | N/A (file = module) |
+| Python | `snake_case.py` | `snake_case` |
+| Rust | `snake_case.rs` | `snake_case` |
+| Go | `snake_case.go` | `lowercase` (short) |
+
+### Special Files
+
+| Purpose | TypeScript | Python | Rust | Go |
+|---------|------------|--------|------|-----|
+| Entry point | `index.ts`, `main.ts` | `__main__.py` | `main.rs`, `lib.rs` | `main.go` |
+| Package init | N/A | `__init__.py` | `mod.rs` or `lib.rs` | Any file in package |
+| Tests | `*.test.ts`, `*.spec.ts` | `test_*.py` | `*_test.rs` (inline or file) | `*_test.go` |
+
+---
+
+## Automated Conversion
+
+### Tools
+
+| Conversion | Tool/Approach |
+|------------|---------------|
+| camelCase → snake_case | `inflection`, regex |
+| PascalCase → snake_case | `inflection`, regex |
+| Any → Any | `case-converter` libraries |
+
+### Regex Patterns
+
+```python
+# camelCase → snake_case
+import re
+def to_snake_case(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+# snake_case → camelCase
+def to_camel_case(name):
+    components = name.split('_')
+    return components[0] + ''.join(x.title() for x in components[1:])
+```
+
+---
+
+## Related
+
+- `meta-convert-dev` - Core conversion patterns
+- Language-specific `lang-*-dev` skills for detailed conventions

--- a/components/skills/meta-convert-dev/references/performance-considerations.md
+++ b/components/skills/meta-convert-dev/references/performance-considerations.md
@@ -1,0 +1,349 @@
+# Performance Considerations
+
+Guide for understanding and optimizing performance when converting between languages.
+
+## Performance Impact Overview
+
+| Conversion | Typical Impact | Key Factors |
+|------------|----------------|-------------|
+| GC → Ownership (e.g., TS→Rust) | +50-500% faster | No GC pauses, stack allocation |
+| Dynamic → Static typing | +20-100% faster | No runtime type checks |
+| Interpreted → Compiled | +10-100x faster | Direct machine code |
+| Single-threaded → Multi-threaded | Variable | Depends on workload |
+| Sync → Async | Variable | IO-bound vs CPU-bound |
+
+---
+
+## Memory Model Impact
+
+### Garbage Collection vs Manual/Ownership
+
+| Aspect | GC Languages | Ownership (Rust) |
+|--------|--------------|------------------|
+| Allocation | Fast (bump allocator) | Similar or faster |
+| Deallocation | Batched (GC pause) | Immediate (RAII) |
+| Latency | Unpredictable spikes | Predictable |
+| Throughput | Good | Often better |
+| Memory usage | Higher (delayed free) | Lower |
+
+### When GC Overhead Matters
+
+```
+High-frequency allocation:  GC overhead significant
+Long-lived objects:         GC overhead minimal
+Real-time requirements:     GC problematic
+Batch processing:           GC often acceptable
+```
+
+### Mitigation Patterns
+
+**Source (TypeScript) - many allocations:**
+```typescript
+function processItems(items: Item[]): Result[] {
+  return items.map(item => ({
+    id: item.id,
+    value: computeValue(item),  // New object per iteration
+  }));
+}
+```
+
+**Target (Rust) - avoid unnecessary allocations:**
+```rust
+fn process_items(items: &[Item]) -> Vec<Result> {
+    // Pre-allocate with capacity
+    let mut results = Vec::with_capacity(items.len());
+
+    for item in items {
+        results.push(Result {
+            id: item.id,
+            value: compute_value(item),
+        });
+    }
+    results
+}
+```
+
+---
+
+## Type System Impact
+
+### Dynamic vs Static Typing
+
+| Aspect | Dynamic Typing | Static Typing |
+|--------|----------------|---------------|
+| Type checks | Runtime | Compile time |
+| Dispatch | Often indirect | Direct (monomorphized) |
+| Optimization | Limited | Extensive |
+| Inlining | Difficult | Easy |
+
+### Pattern: Avoid Polymorphism Overhead
+
+**Source (Python) - dynamic dispatch:**
+```python
+def process(handler):  # Type unknown at compile time
+    return handler.handle(data)
+```
+
+**Target (Rust) - static dispatch when possible:**
+```rust
+// Dynamic dispatch (trait object)
+fn process_dyn(handler: &dyn Handler) -> Result {
+    handler.handle(&data)  // Indirect call
+}
+
+// Static dispatch (generics) - prefer when possible
+fn process<H: Handler>(handler: &H) -> Result {
+    handler.handle(&data)  // Can be inlined
+}
+```
+
+---
+
+## Collection Performance
+
+### Collection Choice by Operation
+
+| Operation | Best Choice | Avoid |
+|-----------|-------------|-------|
+| Index access | `Vec`/Array | `LinkedList` |
+| Key lookup | `HashMap` | `Vec` + search |
+| Ordered iteration | `Vec`, `BTreeMap` | `HashMap` |
+| Insertion order | `IndexMap` | `HashMap` |
+| Deque (both ends) | `VecDeque` | `Vec` |
+| Unique values | `HashSet` | `Vec` + contains |
+
+### Language-Specific Equivalents
+
+| Operation | TypeScript | Python | Rust | Go |
+|-----------|------------|--------|------|-----|
+| Dynamic array | `Array` | `list` | `Vec<T>` | `[]T` slice |
+| Hash map | `Map` | `dict` | `HashMap<K,V>` | `map[K]V` |
+| Hash set | `Set` | `set` | `HashSet<T>` | `map[T]struct{}` |
+| Ordered map | N/A | `dict` (3.7+) | `BTreeMap` | N/A |
+
+### Capacity Pre-allocation
+
+**Inefficient (reallocations):**
+```rust
+let mut vec = Vec::new();
+for i in 0..1000 {
+    vec.push(i);  // May reallocate multiple times
+}
+```
+
+**Efficient (pre-allocated):**
+```rust
+let mut vec = Vec::with_capacity(1000);
+for i in 0..1000 {
+    vec.push(i);  // No reallocations
+}
+```
+
+---
+
+## String Performance
+
+### String Handling Patterns
+
+| Language | Mutable String | Immutable | Slice/View |
+|----------|----------------|-----------|------------|
+| TypeScript | `string` (immutable) | `string` | N/A |
+| Python | `list` of chars | `str` | Slicing creates copy |
+| Rust | `String` | `String` | `&str` |
+| Go | `[]byte` | `string` | `string` (view) |
+
+### Avoid String Concatenation in Loops
+
+**Inefficient:**
+```rust
+let mut result = String::new();
+for word in words {
+    result = result + &word + " ";  // O(n²) - copies entire string
+}
+```
+
+**Efficient:**
+```rust
+// Option 1: join
+let result = words.join(" ");
+
+// Option 2: with_capacity + push_str
+let total_len: usize = words.iter().map(|w| w.len() + 1).sum();
+let mut result = String::with_capacity(total_len);
+for word in words {
+    result.push_str(&word);
+    result.push(' ');
+}
+```
+
+---
+
+## Async/Concurrency Performance
+
+### Model Comparison
+
+| Model | Best For | Overhead |
+|-------|----------|----------|
+| Async/await | IO-bound, many connections | Low (single thread) |
+| Thread pool | CPU-bound, parallelism | Medium |
+| Green threads | Mixed workloads | Variable |
+| Actor model | Distributed, isolation | Higher |
+
+### Common Pitfalls
+
+**Blocking in async context:**
+```rust
+// ❌ Blocks the async runtime
+async fn bad_example() {
+    std::thread::sleep(Duration::from_secs(1));  // Blocks thread!
+}
+
+// ✓ Use async sleep
+async fn good_example() {
+    tokio::time::sleep(Duration::from_secs(1)).await;
+}
+```
+
+**Unnecessary async:**
+```rust
+// ❌ Async overhead for sync operation
+async fn get_cached_value(&self) -> Value {
+    self.cache.get(&key).cloned()  // No await, no IO
+}
+
+// ✓ Keep it sync
+fn get_cached_value(&self) -> Value {
+    self.cache.get(&key).cloned()
+}
+```
+
+---
+
+## Optimization Checklist
+
+### Before Converting
+
+- [ ] Profile the original code
+- [ ] Identify hot paths (80/20 rule)
+- [ ] Document performance requirements
+- [ ] Create benchmark suite
+
+### During Conversion
+
+- [ ] Use appropriate data structures
+- [ ] Avoid unnecessary allocations
+- [ ] Prefer borrowing over cloning
+- [ ] Use static dispatch when possible
+- [ ] Pre-allocate collections when size is known
+- [ ] Avoid string concatenation in loops
+
+### After Conversion
+
+- [ ] Run benchmark suite
+- [ ] Profile converted code
+- [ ] Compare with original performance
+- [ ] Document any regressions
+
+---
+
+## Profiling Tools
+
+| Language | CPU Profiler | Memory Profiler | Benchmarking |
+|----------|--------------|-----------------|--------------|
+| TypeScript | Chrome DevTools | Chrome DevTools | Benchmark.js |
+| Python | cProfile, py-spy | memory_profiler | pytest-benchmark |
+| Rust | perf, flamegraph | heaptrack, valgrind | criterion |
+| Go | pprof | pprof | testing.B |
+
+### Rust Profiling Example
+
+```rust
+// Cargo.toml
+[dev-dependencies]
+criterion = "0.5"
+
+[[bench]]
+name = "my_benchmark"
+harness = false
+
+// benches/my_benchmark.rs
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_function(c: &mut Criterion) {
+    c.bench_function("function_name", |b| {
+        b.iter(|| {
+            function_to_benchmark(black_box(input))
+        })
+    });
+}
+
+criterion_group!(benches, benchmark_function);
+criterion_main!(benches);
+```
+
+---
+
+## Common Performance Regressions
+
+### 1. Over-cloning
+
+```rust
+// ❌ Cloning when borrowing works
+fn process(data: Vec<Item>) {
+    for item in data.clone().iter() { ... }
+}
+
+// ✓ Borrow instead
+fn process(data: &[Item]) {
+    for item in data.iter() { ... }
+}
+```
+
+### 2. Wrong Collection Type
+
+```rust
+// ❌ O(n) lookup
+let items: Vec<Item> = ...;
+if items.iter().any(|i| i.id == target_id) { ... }
+
+// ✓ O(1) lookup
+let items: HashMap<Id, Item> = ...;
+if items.contains_key(&target_id) { ... }
+```
+
+### 3. Unnecessary Boxing
+
+```rust
+// ❌ Heap allocation for small types
+struct Config {
+    value: Box<i32>,  // Unnecessary indirection
+}
+
+// ✓ Stack allocation
+struct Config {
+    value: i32,
+}
+```
+
+### 4. Missed Parallelization
+
+```rust
+// ❌ Sequential when parallel is possible
+let results: Vec<_> = items.iter()
+    .map(|item| expensive_compute(item))
+    .collect();
+
+// ✓ Parallel with rayon
+use rayon::prelude::*;
+let results: Vec<_> = items.par_iter()
+    .map(|item| expensive_compute(item))
+    .collect();
+```
+
+---
+
+## Related
+
+- `meta-convert-dev` - Core conversion patterns
+- `patterns-concurrency-dev` - Concurrency patterns (when created)
+- Language-specific `lang-*-dev` skills


### PR DESCRIPTION
## Summary

Adds reference documentation to `meta-convert-dev` skill for commonly needed lookup tables and decision frameworks.

- **migration-strategies.md** - Incremental vs full rewrite decision framework
- **naming-conventions.md** - Case style and naming translation tables (camelCase, snake_case, etc.)
- **build-system-mapping.md** - Package manifest and dependency translation (package.json ↔ Cargo.toml ↔ go.mod ↔ pyproject.toml)
- **module-system-comparison.md** - Import/export and visibility patterns across languages
- **performance-considerations.md** - Optimization and profiling guidance for conversions

Closes #222

## Test plan

- [ ] Review reference docs for accuracy
- [ ] Verify links in SKILL.md work correctly
- [ ] Check for completeness against feedback issues #208, #209, #215, #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)