### PR TITLE
fix(skills): address group 1 feedback for conversion skills

### DIFF
--- a/.claude/commands/create-lang-conversion-skill.md
+++ b/.claude/commands/create-lang-conversion-skill.md
@@ -12,11 +12,75 @@ Create a new one-way language conversion skill (`convert-<source>-<target>`) tha
 - `$1` - Source language (lowercase, e.g., `typescript`, `python`, `golang`)
 - `$2` - Target language (lowercase, e.g., `rust`, `python`, `golang`)
 
+## Quick Reference
+
+| Step | Action | Purpose |
+|------|--------|---------|
+| 0 | Check existing | Avoid duplicate skills |
+| 1 | Validate args | Ensure valid language names |
+| 2 | Read foundations | Understand meta-skill patterns |
+| 2.5 | Validate 8 Pillars | Ensure lang skills have coverage |
+| 3 | Research pair | Gather language-specific mappings |
+| 4 | Create directory | Set up skill location |
+| 5 | Generate SKILL.md | Create from template |
+| 6 | Populate content | Fill in language-specific details |
+| 7 | Validate skill | Run quality checklist |
+| 8 | Cross-references | Suggest related skill updates |
+| 9 | Report | Summary of what was created |
+| 10 | Feedback | Self-review and improvement suggestions |
+
+**Modes:**
+- **Create** (default) - New skill from scratch
+- **Update** - Improve existing skill (use `--update` or detect existing)
+
 ## Prerequisites
 
 This command requires the `meta-convert-dev` skill to be available. Read it first to understand the foundational patterns.
 
+---
+
 ## Workflow
+
+### Step 0: Check for Existing Skill
+
+Before creating a new skill, check if one already exists:
+
+```bash
+# Check if skill directory exists
+ls components/skills/convert-$1-$2/
+
+# Search for existing PRs
+gh pr list --search "convert-$1-$2" --state all
+```
+
+**If the skill already exists:**
+
+1. **Confirm with user**: "A `convert-$1-$2` skill already exists. Options:"
+   - **Update mode**: Improve the existing skill (add missing sections, enhance examples)
+   - **Skip**: Move on to next task
+   - **Force create**: Replace existing (requires explicit confirmation)
+
+2. **For update mode**, skip to [Step 6: Populate Content](#step-6-populate-content) and focus on:
+   - Filling gaps identified in validation
+   - Adding missing type mappings
+   - Improving examples
+   - Updating cross-references
+
+3. **Report findings** even if skipping:
+   ```markdown
+   ## Existing Skill Found
+
+   | Field | Value |
+   |-------|-------|
+   | Skill | `convert-$1-$2` |
+   | Status | Already exists |
+   | Location | `components/skills/convert-$1-$2/SKILL.md` |
+   | PR | #XXX (if known) |
+
+   **Recommendation:** [Update / Skip / Review]
+   ```
+
+---
 
 ### Step 1: Validate Arguments
 
@@ -51,71 +115,83 @@ Read these skills to understand patterns and gather examples:
    - `lang-$1-dev` - Source language patterns
    - `lang-$2-dev` - Target language patterns
 
-### Step 2.5: Validate 8 Pillars Coverage
+### Step 2.5: Validate 8 Pillars Coverage (Automated)
 
-Before creating a conversion skill, validate that both source and target language skills have adequate coverage of the **8 Pillars** essential for code conversion:
+Before creating a conversion skill, validate that both source and target language skills have adequate coverage of the **8 Pillars** essential for code conversion.
 
-| Pillar | Description | Why Essential for Conversion |
-|--------|-------------|------------------------------|
-| Module System | Imports, exports, visibility, packages | Import/export translation |
-| Error Handling | Error types, Result/Option, exceptions | Error model translation |
-| Concurrency Model | Async/await, threads, channels | Async pattern translation |
-| Metaprogramming | Decorators, macros, annotations | Attribute/decorator translation |
-| Zero/Default Values | Null, undefined, Option, defaults | Null-safety translation |
-| Serialization Idioms | JSON, struct tags, validation | Data structure translation |
-| Build/Deps | Package managers, build tools | Project migration |
-| Testing Idioms | Test frameworks, mocking | Test suite conversion |
+#### Pillar Reference
 
-#### Validation Process
+| Pillar | Search Terms | Why Essential |
+|--------|-------------|---------------|
+| Module | `## Module`, `import`, `export`, `visibility` | Import/export translation |
+| Error | `## Error`, `Result`, `Exception`, `try/catch` | Error model translation |
+| Concurrency | `## Concurrency`, `async`, `await`, `thread` | Async pattern translation |
+| Metaprogramming | `## Metaprogramming`, `decorator`, `macro`, `annotation` | Attribute translation |
+| Zero/Default | `## Zero`, `## Default`, `null`, `Option`, `None` | Null-safety translation |
+| Serialization | `## Serialization`, `JSON`, `serde`, `marshal` | Data structure translation |
+| Build | `## Build`, `## Dependencies`, `Cargo`, `package.json` | Project migration |
+| Testing | `## Testing`, `#[test]`, `describe`, `unittest` | Test suite conversion |
 
-1. **Read both language skills:**
-   ```
-   components/skills/lang-$1-dev/SKILL.md
-   components/skills/lang-$2-dev/SKILL.md
-   ```
+#### Automated Validation
 
-2. **Check for each pillar** - Look for dedicated sections or substantial coverage:
-   - ✓ = Has a dedicated section or comprehensive coverage
-   - ~ = Mentioned but incomplete
-   - ✗ = Missing entirely
+Run this validation automatically when reading the lang-*-dev skills:
 
-3. **Calculate coverage scores:**
-   - Green: 6-8 pillars covered
-   - Yellow: 4-5 pillars covered
-   - Red: 0-3 pillars covered
+```bash
+# Check for section headers (example for bash, but do this by reading the file)
+for pillar in "Module" "Error" "Concurrency" "Metaprogramming" "Zero\|Default" "Serialization" "Build" "Testing"; do
+  grep -c "## .*$pillar" components/skills/lang-$1-dev/SKILL.md
+done
+```
 
-4. **If either skill scores Yellow or Red:**
+**While reading each skill file, check for these patterns:**
 
-   **Option A: Proceed with warnings** (for time-sensitive tasks)
-   - Document missing pillars in the conversion skill's "Limitations" section
-   - Note that external research was required for those areas
-   - Create follow-up issues to improve lang-*-dev skills
+| Pillar | ✓ Criteria | ~ Criteria | ✗ Criteria |
+|--------|-----------|------------|------------|
+| Module | Has `## Module` section with 50+ lines | Mentioned in another section | No coverage |
+| Error | Has `## Error` section with examples | Has Result/Exception mentions | No coverage |
+| Concurrency | Has `## Concurrency` section | Has async/thread mentions | No coverage |
+| Metaprogramming | Has `## Metaprogramming` section | Has decorator/macro mentions | No coverage |
+| Zero/Default | Has dedicated section or table | Mentioned in types section | No coverage |
+| Serialization | Has `## Serialization` section | Has JSON/serde mentions | No coverage |
+| Build | Has `## Build` section | Has package manager mentions | No coverage |
+| Testing | Has `## Testing` section | Has test framework mentions | No coverage |
 
-   **Option B: Improve lang-*-dev first** (recommended)
-   - Create issues to add missing pillars to lang-*-dev skills
-   - Add the missing content to lang-*-dev skills
-   - Then proceed with conversion skill creation
+#### Quick Score Calculation
 
-   **Option C: Use cross-cutting pattern skills** (for common gaps)
-   - `patterns-concurrency-dev` - Supplements Concurrency gaps
-   - `patterns-serialization-dev` - Supplements Serialization gaps
-   - `patterns-metaprogramming-dev` - Supplements Metaprogramming gaps
-   - Reference these skills in the conversion skill's "See Also" section
+Count section headers matching pillars:
+- **8/8**: Excellent - proceed confidently
+- **6-7/8**: Good - note gaps, proceed with pattern skill references
+- **4-5/8**: Fair - strongly recommend improving lang skills first
+- **0-3/8**: Poor - must improve lang skills before proceeding
 
-   Ask the user which approach they prefer.
+#### Handling Gaps
 
-5. **Report validation results:**
-   ```
-   ## 8 Pillars Validation
+| Score | Action |
+|-------|--------|
+| 6-8/8 | Proceed. Reference pattern skills for missing pillars |
+| 4-5/8 | Ask user: Proceed with gaps documented OR improve skills first |
+| 0-3/8 | Stop. Create issues to improve lang-*-dev skills first |
 
-   | Skill | Module | Error | Concurrency | Metaprog | Zero | Serial | Build | Test | Score |
-   |-------|--------|-------|-------------|----------|------|--------|-------|------|-------|
-   | lang-$1-dev | ✓/~/✗ | ... | ... | ... | ... | ... | ... | ... | X/8 |
-   | lang-$2-dev | ✓/~/✗ | ... | ... | ... | ... | ... | ... | ... | X/8 |
+**Pattern skill supplements:**
+- `patterns-concurrency-dev` → Concurrency gaps
+- `patterns-serialization-dev` → Serialization gaps
+- `patterns-metaprogramming-dev` → Metaprogramming gaps
 
-   **Status:** Green/Yellow/Red
-   **Recommendation:** [Proceed / Improve skills first / Proceed with documented gaps]
-   ```
+#### Report Format
+
+```markdown
+## 8 Pillars Validation
+
+| Skill | Mod | Err | Conc | Meta | Zero | Ser | Build | Test | Score |
+|-------|-----|-----|------|------|------|-----|-------|------|-------|
+| lang-$1-dev | ✓ | ✓ | ✓ | ~ | ✓ | ✓ | ✓ | ✓ | 7.5/8 |
+| lang-$2-dev | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 8/8 |
+
+**Combined Score:** 15.5/16 (Excellent)
+**Gaps:** lang-$1-dev metaprogramming is partial
+**Mitigation:** Reference `patterns-metaprogramming-dev`
+**Decision:** Proceed ✓
+```
 
 ### Step 3: Research Language Pair
 

--- a/components/skills/lang-rust-dev/SKILL.md
+++ b/components/skills/lang-rust-dev/SKILL.md
@@ -1421,6 +1421,260 @@ proptest! {
 
 ---
 
+## Metaprogramming
+
+Rust provides powerful metaprogramming through macros. There are two main types: declarative macros (`macro_rules!`) and procedural macros (derive, attribute, and function-like).
+
+### Declarative Macros (macro_rules!)
+
+```rust
+// Simple macro
+macro_rules! say_hello {
+    () => {
+        println!("Hello!");
+    };
+}
+
+say_hello!();  // Prints: Hello!
+
+// Macro with arguments
+macro_rules! create_function {
+    ($name:ident) => {
+        fn $name() {
+            println!("Called {:?}", stringify!($name));
+        }
+    };
+}
+
+create_function!(foo);
+foo();  // Prints: Called "foo"
+
+// Macro with expression repetition
+macro_rules! vec_of_strings {
+    ($($x:expr),* $(,)?) => {
+        vec![$($x.to_string()),*]
+    };
+}
+
+let v = vec_of_strings!["a", "b", "c"];
+```
+
+### Fragment Specifiers
+
+| Specifier | Matches | Example |
+|-----------|---------|---------|
+| `$x:ident` | Identifier | `foo`, `MyStruct` |
+| `$x:expr` | Expression | `1 + 2`, `foo()` |
+| `$x:ty` | Type | `i32`, `Vec<String>` |
+| `$x:pat` | Pattern | `Some(x)`, `_` |
+| `$x:stmt` | Statement | `let x = 1;` |
+| `$x:block` | Block | `{ ... }` |
+| `$x:item` | Item | `fn foo() {}` |
+| `$x:path` | Path | `std::io::Error` |
+| `$x:tt` | Token tree | Any single token |
+| `$x:literal` | Literal | `"hello"`, `42` |
+
+### Macro Patterns
+
+```rust
+// Multiple match arms
+macro_rules! calculate {
+    // Single value
+    ($e:expr) => { $e };
+    // Two values with operator
+    ($left:expr, $op:tt, $right:expr) => {
+        $left $op $right
+    };
+}
+
+let a = calculate!(5);        // 5
+let b = calculate!(5, +, 3);  // 8
+
+// Recursive macro for variadic arguments
+macro_rules! sum {
+    ($x:expr) => { $x };
+    ($x:expr, $($rest:expr),+) => {
+        $x + sum!($($rest),+)
+    };
+}
+
+let total = sum!(1, 2, 3, 4);  // 10
+```
+
+### Derive Macros
+
+Derive macros generate trait implementations automatically.
+
+```rust
+// Using built-in derives
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+struct User {
+    name: String,
+    age: u32,
+}
+
+// Using third-party derives
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+struct Config {
+    host: String,
+    port: u16,
+}
+```
+
+### Creating Custom Derive Macros
+
+```rust
+// In a proc-macro crate (Cargo.toml: proc-macro = true)
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(MyTrait)]
+pub fn derive_my_trait(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+
+    let expanded = quote! {
+        impl MyTrait for #name {
+            fn describe(&self) -> String {
+                format!("This is a {}", stringify!(#name))
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+// Usage
+#[derive(MyTrait)]
+struct MyStruct;
+```
+
+### Derive Macro with Attributes
+
+```rust
+// Macro definition
+#[proc_macro_derive(Builder, attributes(builder))]
+pub fn derive_builder(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    // Parse #[builder(...)] attributes
+    // Generate builder pattern implementation
+    // ...
+}
+
+// Usage
+#[derive(Builder)]
+struct Command {
+    #[builder(default = "false")]
+    verbose: bool,
+
+    #[builder(each = "arg")]
+    args: Vec<String>,
+}
+```
+
+### Attribute Macros
+
+```rust
+// Macro definition (in proc-macro crate)
+#[proc_macro_attribute]
+pub fn route(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as LitStr);
+    let item = parse_macro_input!(item as ItemFn);
+    let fn_name = &item.sig.ident;
+
+    let expanded = quote! {
+        #item
+
+        inventory::submit! {
+            Route {
+                path: #attr,
+                handler: #fn_name,
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+// Usage
+#[route("/api/users")]
+fn get_users() -> Response {
+    // ...
+}
+```
+
+### Function-like Procedural Macros
+
+```rust
+// Macro definition
+#[proc_macro]
+pub fn sql(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as LitStr);
+    let query = input.value();
+
+    // Validate SQL at compile time
+    // Generate typed query code
+    let expanded = quote! {
+        Query::new(#query)
+    };
+
+    TokenStream::from(expanded)
+}
+
+// Usage
+let query = sql!("SELECT * FROM users WHERE id = $1");
+```
+
+### Common Proc-Macro Crates
+
+| Crate | Purpose | Example |
+|-------|---------|---------|
+| `syn` | Parse Rust code | `parse_macro_input!` |
+| `quote` | Generate Rust code | `quote! { ... }` |
+| `proc-macro2` | TokenStream utilities | Span manipulation |
+| `darling` | Derive macro helpers | Attribute parsing |
+
+### Macro Hygiene
+
+```rust
+macro_rules! using_x {
+    ($e:expr) => {
+        {
+            let x = 42;  // This x is hygienic
+            $e           // $e refers to caller's x
+        }
+    };
+}
+
+let x = 10;
+let result = using_x!(x + 1);  // Uses caller's x=10, not macro's x=42
+assert_eq!(result, 11);
+```
+
+### Debug Macros
+
+```rust
+// Print macro expansion
+// Run: cargo expand
+// Or: cargo expand --lib path::to::module
+
+// Compile-time debugging
+macro_rules! debug_macro {
+    ($($arg:tt)*) => {
+        compile_error!(concat!("Debug: ", stringify!($($arg)*)));
+    };
+}
+```
+
+### See Also
+
+- `patterns-metaprogramming-dev` - Cross-language macro/decorator patterns
+
+---
+
 ## Cross-Cutting Patterns
 
 For cross-language comparison and translation patterns, see:

--- a/components/skills/lang-typescript-dev/SKILL.md
+++ b/components/skills/lang-typescript-dev/SKILL.md
@@ -1451,6 +1451,225 @@ expect.extend({
 
 ---
 
+## Metaprogramming
+
+TypeScript supports decorators for metaprogramming, enabling declarative modifications to classes, methods, and properties. Requires `experimentalDecorators` and optionally `emitDecoratorMetadata` in tsconfig.json.
+
+### Enabling Decorators
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+### Class Decorators
+
+```typescript
+// Class decorator - receives the constructor
+function Sealed(constructor: Function) {
+  Object.seal(constructor);
+  Object.seal(constructor.prototype);
+}
+
+function Entity(tableName: string) {
+  return function <T extends { new (...args: any[]): {} }>(constructor: T) {
+    return class extends constructor {
+      static tableName = tableName;
+    };
+  };
+}
+
+@Sealed
+@Entity('users')
+class User {
+  name: string;
+}
+
+// Access metadata
+console.log((User as any).tableName); // 'users'
+```
+
+### Method Decorators
+
+```typescript
+// Method decorator - receives target, key, descriptor
+function Log(target: any, key: string, descriptor: PropertyDescriptor) {
+  const original = descriptor.value;
+  descriptor.value = function (...args: any[]) {
+    console.log(`Calling ${key} with`, args);
+    const result = original.apply(this, args);
+    console.log(`${key} returned`, result);
+    return result;
+  };
+  return descriptor;
+}
+
+function Debounce(ms: number) {
+  return function (target: any, key: string, descriptor: PropertyDescriptor) {
+    let timeout: NodeJS.Timeout;
+    const original = descriptor.value;
+    descriptor.value = function (...args: any[]) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => original.apply(this, args), ms);
+    };
+    return descriptor;
+  };
+}
+
+class API {
+  @Log
+  @Debounce(300)
+  search(query: string): string[] {
+    return ['result1', 'result2'];
+  }
+}
+```
+
+### Property Decorators
+
+```typescript
+// Property decorator - receives target and key
+function Required(target: any, key: string) {
+  let value: any;
+  const getter = () => value;
+  const setter = (newValue: any) => {
+    if (newValue === undefined || newValue === null) {
+      throw new Error(`${key} is required`);
+    }
+    value = newValue;
+  };
+  Object.defineProperty(target, key, {
+    get: getter,
+    set: setter,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+function Column(options: { type: string; nullable?: boolean }) {
+  return function (target: any, key: string) {
+    const columns = Reflect.getMetadata('columns', target) || [];
+    columns.push({ key, ...options });
+    Reflect.defineMetadata('columns', columns, target);
+  };
+}
+
+class User {
+  @Required
+  @Column({ type: 'varchar', nullable: false })
+  name: string;
+}
+```
+
+### Parameter Decorators
+
+```typescript
+// Parameter decorator - receives target, key, parameter index
+function Inject(token: string) {
+  return function (target: any, key: string, index: number) {
+    const injections = Reflect.getMetadata('injections', target, key) || [];
+    injections[index] = token;
+    Reflect.defineMetadata('injections', injections, target, key);
+  };
+}
+
+class UserService {
+  constructor(
+    @Inject('DATABASE') private db: Database,
+    @Inject('LOGGER') private logger: Logger
+  ) {}
+}
+```
+
+### Reflect Metadata
+
+```typescript
+import 'reflect-metadata';
+
+// Define metadata
+Reflect.defineMetadata('role', 'admin', User);
+Reflect.defineMetadata('role', 'user', User.prototype, 'name');
+
+// Get metadata
+const classRole = Reflect.getMetadata('role', User);
+const propRole = Reflect.getMetadata('role', User.prototype, 'name');
+
+// Get design-time type information (with emitDecoratorMetadata)
+function LogType(target: any, key: string) {
+  const type = Reflect.getMetadata('design:type', target, key);
+  console.log(`${key} type:`, type.name); // e.g., "String", "Number"
+}
+
+// Get parameter types
+function LogParams(target: any, key: string, descriptor: PropertyDescriptor) {
+  const paramTypes = Reflect.getMetadata('design:paramtypes', target, key);
+  console.log(`${key} params:`, paramTypes.map((t: any) => t.name));
+}
+```
+
+### Decorator Factories Pattern
+
+```typescript
+// Composable decorator factory
+interface ValidatorOptions {
+  min?: number;
+  max?: number;
+  pattern?: RegExp;
+  message?: string;
+}
+
+function Validate(options: ValidatorOptions) {
+  return function (target: any, key: string) {
+    const validators = Reflect.getMetadata('validators', target) || {};
+    validators[key] = options;
+    Reflect.defineMetadata('validators', validators, target);
+  };
+}
+
+class CreateUserDto {
+  @Validate({ min: 1, max: 100, message: 'Name must be 1-100 chars' })
+  name: string;
+
+  @Validate({ pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: 'Invalid email' })
+  email: string;
+}
+
+// Runtime validation
+function validate(instance: any): string[] {
+  const validators = Reflect.getMetadata('validators', instance) || {};
+  const errors: string[] = [];
+
+  for (const [key, opts] of Object.entries(validators) as [string, ValidatorOptions][]) {
+    const value = instance[key];
+    if (opts.min && value.length < opts.min) errors.push(opts.message || `${key} too short`);
+    if (opts.max && value.length > opts.max) errors.push(opts.message || `${key} too long`);
+    if (opts.pattern && !opts.pattern.test(value)) errors.push(opts.message || `${key} invalid`);
+  }
+  return errors;
+}
+```
+
+### Common Decorator Libraries
+
+| Library | Purpose | Example |
+|---------|---------|---------|
+| `class-validator` | Validation decorators | `@IsEmail()`, `@Length(1, 100)` |
+| `class-transformer` | Serialization decorators | `@Type()`, `@Expose()` |
+| `typeorm` | ORM decorators | `@Entity()`, `@Column()` |
+| `nestjs` | Framework decorators | `@Controller()`, `@Get()` |
+| `inversify` | DI decorators | `@injectable()`, `@inject()` |
+
+### See Also
+
+- `patterns-metaprogramming-dev` - Cross-language decorator/macro patterns
+
+---
+
 ## Cross-Cutting Patterns
 
 For cross-language comparison and translation patterns, see:


### PR DESCRIPTION
## Summary

Addresses feedback from Group 1 conversion skill subagents regarding the `/create-lang-conversion-skill` command and language skills.

### Command Improvements (`/create-lang-conversion-skill`)
- Added **Quick Reference** table at the top for faster navigation
- Added **Step 0: duplicate detection** to check for existing skills before creating
- Added **Update mode** for improving existing skills (instead of only creating new ones)
- Made **8 Pillars validation more automated** with clear scoring criteria
- Added **combined score format** with mitigation recommendations

### Language Skill Improvements
- Added **Metaprogramming section to lang-typescript-dev** (~200 lines)
  - Class, method, property, and parameter decorators
  - Reflect-metadata usage
  - Decorator factories pattern
  - Common decorator libraries table
- Added **Metaprogramming section to lang-rust-dev** (~250 lines)
  - Declarative macros (`macro_rules!`)
  - Fragment specifiers table
  - Derive macros (built-in and custom)
  - Attribute macros
  - Function-like procedural macros
  - Proc-macro crates table

### Context
Feedback collected from 3 subagents during Group 1 of conversion skill creation:
- All 3 TypeScript conversion skills already existed (PRs #206, #213)
- Agents identified gaps in the command workflow and language skills
- This PR addresses those gaps before proceeding to Group 2

## Test plan
- [ ] Verify `/create-lang-conversion-skill` command has Quick Reference visible
- [ ] Verify Step 0 duplicate detection is present
- [ ] Verify lang-typescript-dev has Metaprogramming section
- [ ] Verify lang-rust-dev has Metaprogramming section
- [ ] Both skills now score 8/8 on pillars

🤖 Generated with [Claude Code](https://claude.com/claude-code)