### PR TITLE
fix(skills): address Group 1 feedback for conversion skills

### DIFF
--- a/.claude/commands/create-lang-conversion-skill.md
+++ b/.claude/commands/create-lang-conversion-skill.md
@@ -106,14 +106,19 @@ Read these skills to understand patterns and gather examples:
    - Idiom translation approaches
    - Testing strategies
 
-2. **Existing conversion skills** (for reference):
+2. **Existing conversion skills** (required - read at least 1):
    - Search for `convert-*` skills in `components/skills/`
-   - Use these as examples for structure and depth
+   - **Read one complete skill** (e.g., `convert-typescript-rust/SKILL.md` lines 1-300) to understand:
+     - Expected depth for type mapping tables
+     - "Why this translation" explanation style
+     - Example complexity progression
    - Borrow patterns that apply to your language pair
 
 3. **Language skills** (if available):
    - `lang-$1-dev` - Source language patterns
    - `lang-$2-dev` - Target language patterns
+
+**Before proceeding**: Confirm you have read at least one complete conversion skill as a reference.
 
 ### Step 2.5: Validate 8 Pillars Coverage (Automated)
 
@@ -195,16 +200,56 @@ Count section headers matching pillars:
 
 ### Step 3: Research Language Pair
 
-Before creating the skill, research the specific language pair:
+Before creating the skill, research the specific language pair using these structured checklists:
 
-1. **Type system differences**: How do types map between languages?
-2. **Error handling**: Exceptions vs Result types vs error returns
-3. **Concurrency models**: async/await, goroutines, threads, etc.
-4. **Memory models**: GC vs ownership vs manual
-5. **Idiomatic patterns**: What's "the way" in each language?
-6. **Ecosystem**: Common library equivalents between languages
+#### 3.1 Type System Differences
+- [ ] Read primitive types sections in both lang skills
+- [ ] Create draft mapping table for primitives
+- [ ] Identify types without direct equivalents
+- [ ] Note numeric precision differences (32-bit vs 64-bit, overflow behavior)
 
-Use WebSearch if needed to find authoritative conversion guides.
+#### 3.2 Error Handling
+- [ ] Identify error model in source (Exceptions? Result types? Error returns?)
+- [ ] Identify error model in target
+- [ ] Map error propagation patterns (try/catch → ?, throw → return Err)
+- [ ] Note any "no runtime errors" guarantees (like Elm)
+
+#### 3.3 Concurrency Models
+- [ ] Identify async model in source (async/await, callbacks, actors?)
+- [ ] Identify async model in target
+- [ ] Map concurrency primitives (Promise → Future, Channel → mpsc)
+- [ ] Note architectural differences (managed runtime vs explicit)
+
+#### 3.4 Memory Models
+- [ ] Source memory model: GC / ownership / manual / managed
+- [ ] Target memory model
+- [ ] If different, plan ownership translation strategy
+- [ ] Note lifetime considerations if applicable
+
+#### 3.5 Idiomatic Patterns
+- [ ] What's considered "the way" in source language?
+- [ ] What's considered "the way" in target language?
+- [ ] Identify patterns that should NOT be directly translated
+- [ ] Note paradigm shifts (OOP → FP, imperative → declarative)
+
+#### 3.6 Ecosystem Equivalents
+- [ ] Common HTTP libraries
+- [ ] JSON/serialization libraries
+- [ ] Testing frameworks
+- [ ] Build tools
+
+#### When to Use WebSearch
+
+Use WebSearch when:
+- Lang skills lack coverage for a pillar
+- Looking for real-world migration guides
+- Finding common pitfalls others have encountered
+
+**Example queries:**
+- `"<Source> to <Target> migration patterns 2024"` - General migration guides
+- `"<Source> <pattern> equivalent in <Target>"` - Specific pattern translations
+- `"Common mistakes converting <Source> to <Target>"` - Pitfalls research
+- `"<Source> vs <Target> error handling"` - Error model comparison
 
 ### Step 4: Create Skill Directory
 
@@ -421,12 +466,38 @@ Fill in the template with specific content for this language pair:
 | Primitive Types | All primitives | Include edge cases (infinity, NaN) |
 | Collection Types | 5+ types | Array, Map, Set, Tuple equivalents |
 | Composite Types | 3+ types | Struct, Class, Interface mappings |
-| Idiom Translations | 5-10 patterns | Common patterns with "why" explanations |
+| Idiom Translations | See priority list below | Common patterns with "why" explanations |
 | Error Handling | Complete section | Full error model translation |
 | Concurrency | Complete section | Async/threading translation |
 | Memory/Ownership | If applicable | Include if languages differ (GC vs ownership) |
 | Examples | 3+ (simple, medium, complex) | Progressive complexity |
 | Pitfalls | 5+ pitfalls | Language-pair specific mistakes |
+
+#### Idiom Translation Priority
+
+**Required patterns (must include):**
+1. Null/optional handling (null → Option, Maybe → nil, etc.)
+2. Collection operations (map, filter, reduce equivalents)
+3. Error propagation (try/catch → Result, throws → Either)
+4. Async/await patterns (if either language has async)
+
+**Language-specific patterns (include 2-6 based on relevance):**
+- Type alias/newtype definitions
+- Pattern matching
+- Generics/type parameters
+- Interface/trait implementations
+- Resource cleanup (using/defer/Drop)
+- Builder patterns
+- Iteration patterns
+
+#### Quality Guidance: Good vs Great
+
+| Aspect | Good | Great |
+|--------|------|-------|
+| Type mapping | `String → &str` | `String → &str for borrowed, String for owned; use Cow<str> when ownership varies` |
+| Why explanation | "Use Result in Rust" | "Use Result because Rust has no exceptions; the ? operator propagates errors like try/catch but at compile time" |
+| Example code | Syntactically correct | Syntactically correct + follows target language conventions (naming, formatting, idioms) |
+| Pitfall | "Don't forget to handle errors" | "TypeScript's `undefined` vs Rust's `Option`: TS allows property access on undefined (runtime error), Rust requires explicit unwrap (compile error)" |
 
 #### Example Complexity Guide
 

--- a/components/skills/lang-elm-dev/SKILL.md
+++ b/components/skills/lang-elm-dev/SKILL.md
@@ -43,6 +43,307 @@ Elm is a purely functional language for building reliable web applications with 
 
 ---
 
+## Module System
+
+Elm uses a simple but strict module system where every file is a module and must declare what it exposes.
+
+### Module Declaration
+
+```elm
+-- Every file MUST start with a module declaration
+module MyModule exposing (publicFunction, PublicType, PublicMsg(..))
+
+-- Expose everything (not recommended for libraries)
+module MyModule exposing (..)
+
+-- Expose specific items
+module MyModule exposing
+    ( User          -- Type but not constructors
+    , Msg(..)       -- Type with all constructors
+    , init          -- Function
+    , update        -- Function
+    )
+
+-- Port modules (for JavaScript interop)
+port module Main exposing (..)
+```
+
+### Import Syntax
+
+```elm
+-- Basic import (must qualify: Dict.empty)
+import Dict
+
+-- Import with alias (shorter qualification)
+import Json.Decode as Decode
+import Json.Encode as E
+
+-- Import exposing specific items (can use unqualified)
+import Html exposing (Html, div, text, button)
+import Html.Events exposing (onClick, onInput)
+
+-- Import exposing everything (use sparingly)
+import List exposing (..)
+
+-- Combined: alias + exposing
+import Html.Attributes as Attr exposing (class, id)
+-- Can use: Attr.style or class (unqualified)
+
+-- Import type constructors
+import Maybe exposing (Maybe(..))  -- Exposes Just and Nothing
+import Result exposing (Result(..)) -- Exposes Ok and Err
+```
+
+### Module Organization
+
+```elm
+-- Recommended project structure:
+-- src/
+--   Main.elm           -- Entry point
+--   Types.elm          -- Shared types
+--   Api.elm            -- HTTP/API functions
+--   Page/
+--     Home.elm         -- Page modules
+--     Users.elm
+--   Components/
+--     Button.elm       -- Reusable components
+--     Modal.elm
+--   Util/
+--     Time.elm         -- Helper functions
+
+-- Types.elm - Shared across modules
+module Types exposing (User, Msg(..), Route(..))
+
+type alias User =
+    { name : String
+    , email : String
+    }
+
+type Msg
+    = NavigateTo Route
+    | GotUsers (Result Http.Error (List User))
+
+type Route
+    = Home
+    | Users
+    | User Int
+```
+
+### Visibility and Encapsulation
+
+```elm
+-- Types.elm: Hide implementation, expose interface
+module Email exposing (Email, fromString, toString)
+
+-- Opaque type: Constructor is NOT exposed
+type Email = Email String
+
+-- Only way to create an Email is through validation
+fromString : String -> Maybe Email
+fromString str =
+    if String.contains "@" str then
+        Just (Email str)
+    else
+        Nothing
+
+-- Only way to get the string back
+toString : Email -> String
+toString (Email str) =
+    str
+
+-- Users CANNOT:
+-- Email "invalid"  -- Error: Email constructor not exposed
+-- case email of Email str -> str  -- Error: Cannot pattern match
+
+-- Users CAN:
+-- Email.fromString "test@example.com" |> Maybe.map Email.toString
+```
+
+### Avoiding Circular Imports
+
+```elm
+-- Problem: A imports B, B imports A → IMPORT CYCLE error
+
+-- Solution: Extract shared types to separate module
+
+-- Before (circular):
+-- User.elm imports Main (for Msg)
+-- Main.elm imports User (for User type)
+
+-- After (fixed):
+-- Types.elm (shared types)
+module Types exposing (User, Msg(..))
+
+type alias User = { name : String }
+type Msg = SetUser User | LoadUsers
+
+-- User.elm imports Types
+module User exposing (view)
+import Types exposing (User, Msg(..))
+
+-- Main.elm imports Types
+module Main exposing (main)
+import Types exposing (User, Msg(..))
+```
+
+---
+
+## Zero and Default Values
+
+Elm takes a fundamentally different approach to "zero" or "default" values compared to most languages. **There are no nulls, no undefined, and no implicit defaults.**
+
+### No Null/Undefined/Nil
+
+```elm
+-- Elm has NO:
+-- - null
+-- - undefined
+-- - nil
+-- - None (unless you define it)
+-- - default constructors
+
+-- Every value MUST be explicitly initialized
+-- Every field MUST have a value
+
+-- This is INVALID:
+-- user = { name = "Alice" }  -- Error: missing email, age fields
+
+-- This is VALID:
+type alias User =
+    { name : String
+    , email : String
+    , age : Int
+    }
+
+user : User
+user =
+    { name = "Alice"
+    , email = "alice@example.com"
+    , age = 30
+    }
+```
+
+### Maybe for Optional Values
+
+```elm
+-- Instead of null, use Maybe for values that might not exist
+
+type Maybe a
+    = Just a
+    | Nothing
+
+-- Optional field
+type alias UserProfile =
+    { name : String
+    , nickname : Maybe String  -- Explicit: might not have one
+    , bio : Maybe String       -- Explicit: might not have one
+    }
+
+-- Creating with optional fields
+profile : UserProfile
+profile =
+    { name = "Alice"
+    , nickname = Nothing       -- Explicitly no nickname
+    , bio = Just "Developer"   -- Has a bio
+    }
+
+-- Must handle both cases - compiler enforces this
+displayNickname : UserProfile -> String
+displayNickname user =
+    case user.nickname of
+        Just nick ->
+            nick
+        Nothing ->
+            user.name  -- Fallback to name
+```
+
+### Providing Defaults Explicitly
+
+```elm
+-- Pattern: Create "empty" or "default" values as functions
+
+emptyUser : User
+emptyUser =
+    { name = ""
+    , email = ""
+    , age = 0
+    }
+
+-- Pattern: Defaults with Maybe
+withDefault : a -> Maybe a -> a
+withDefault default maybe =
+    case maybe of
+        Just value ->
+            value
+        Nothing ->
+            default
+
+-- Usage
+age : Int
+age =
+    user.age
+        |> String.toInt
+        |> Maybe.withDefault 0  -- Explicit default
+
+-- Pattern: Defaults with Result
+defaultOnError : a -> Result error a -> a
+defaultOnError default result =
+    case result of
+        Ok value ->
+            value
+        Err _ ->
+            default
+```
+
+### Comparison to Other Languages
+
+```elm
+-- JavaScript:
+-- const name = user?.name ?? "Anonymous"
+-- const items = response.data || []
+
+-- Elm equivalent:
+name : String
+name =
+    user
+        |> Maybe.map .name
+        |> Maybe.withDefault "Anonymous"
+
+items : List Item
+items =
+    response.data
+        |> Result.withDefault []
+
+-- TypeScript:
+-- interface User { name?: string }  -- Optional property
+
+-- Elm: Make it explicit
+type alias User =
+    { name : Maybe String }  -- Explicit Maybe
+
+-- Or use variant types for more control
+type UserName
+    = Anonymous
+    | Named String
+```
+
+### Why This Matters for Conversion
+
+```elm
+-- When converting FROM languages with nulls:
+-- 1. Identify optional values → use Maybe
+-- 2. Identify fallback patterns → use withDefault
+-- 3. Identify nullable parameters → use Maybe parameters
+-- 4. Identify nullable returns → use Maybe returns
+
+-- When converting TO languages with nulls:
+-- 1. Maybe Nothing → null/None/nil
+-- 2. Maybe (Just x) → x
+-- 3. Maybe.withDefault default → ?? or || operators
+```
+
+---
+
 ## The Elm Architecture (TEA)
 
 The Elm Architecture is the core pattern for all Elm applications. It consists of Model, View, and Update.
@@ -799,6 +1100,352 @@ elm-format src/ --yes
 
 # Review code
 elm-review
+```
+
+---
+
+## Testing
+
+Elm has a mature testing ecosystem with elm-test that emphasizes property-based testing (fuzz testing) alongside traditional unit tests. The strong type system eliminates many bugs, but tests remain valuable for logic and behavior verification.
+
+### Basic Unit Tests
+
+```elm
+module Tests exposing (..)
+
+import Expect exposing (Expectation)
+import Test exposing (Test, describe, test)
+import MyModule exposing (add, parseAge)
+
+-- Simple expectation tests
+suite : Test
+suite =
+    describe "MyModule"
+        [ describe "add"
+            [ test "adds two positive numbers" <|
+                \_ ->
+                    add 2 3
+                        |> Expect.equal 5
+
+            , test "adds negative numbers" <|
+                \_ ->
+                    add (-2) 3
+                        |> Expect.equal 1
+
+            , test "identity with zero" <|
+                \_ ->
+                    add 0 5
+                        |> Expect.equal 5
+            ]
+
+        , describe "parseAge"
+            [ test "parses valid age" <|
+                \_ ->
+                    parseAge "25"
+                        |> Expect.equal (Ok 25)
+
+            , test "rejects negative age" <|
+                \_ ->
+                    parseAge "-5"
+                        |> Expect.err
+
+            , test "rejects non-numeric input" <|
+                \_ ->
+                    parseAge "abc"
+                        |> Expect.err
+            ]
+        ]
+```
+
+### Fuzz Testing (Property-Based Testing)
+
+```elm
+import Fuzz exposing (Fuzzer, int, intRange, list, string)
+import Test exposing (Test, describe, fuzz, fuzz2)
+
+fuzzSuite : Test
+fuzzSuite =
+    describe "Property-based tests"
+        [ fuzz int "add is commutative" <|
+            \x ->
+                add x 5
+                    |> Expect.equal (add 5 x)
+
+        , fuzz2 int int "add is associative" <|
+            \x y ->
+                add x y
+                    |> Expect.equal (add y x)
+
+        , fuzz (intRange 0 150) "valid ages are accepted" <|
+            \age ->
+                parseAge (String.fromInt age)
+                    |> Expect.ok
+
+        , fuzz string "parseAge handles any string" <|
+            \str ->
+                -- Should never crash, always returns Result
+                case parseAge str of
+                    Ok age ->
+                        age |> Expect.atLeast 0
+
+                    Err _ ->
+                        Expect.pass
+        ]
+
+-- Custom Fuzzers
+userFuzzer : Fuzzer User
+userFuzzer =
+    Fuzz.map3 User
+        Fuzz.string                    -- name
+        (Fuzz.map (\s -> s ++ "@example.com") Fuzz.string)  -- email
+        (Fuzz.intRange 0 120)          -- age
+
+userListFuzzer : Fuzzer (List User)
+userListFuzzer =
+    Fuzz.list userFuzzer
+```
+
+### Testing The Elm Architecture
+
+```elm
+import Test exposing (Test, describe, test)
+import Main exposing (Model, Msg(..), update, init)
+
+-- Test update function
+updateTests : Test
+updateTests =
+    describe "update"
+        [ test "Increment increases count" <|
+            \_ ->
+                let
+                    ( model, _ ) =
+                        init ()
+
+                    ( newModel, _ ) =
+                        update Increment model
+                in
+                newModel.count
+                    |> Expect.equal 1
+
+        , test "Decrement decreases count" <|
+            \_ ->
+                let
+                    model =
+                        { count = 5 }
+
+                    ( newModel, _ ) =
+                        update Decrement model
+                in
+                newModel.count
+                    |> Expect.equal 4
+
+        , test "Reset sets count to zero" <|
+            \_ ->
+                let
+                    model =
+                        { count = 100 }
+
+                    ( newModel, _ ) =
+                        update Reset model
+                in
+                newModel.count
+                    |> Expect.equal 0
+        ]
+
+-- Test that update returns expected commands
+commandTests : Test
+commandTests =
+    describe "commands"
+        [ test "FetchUsers returns Http command" <|
+            \_ ->
+                let
+                    ( _, cmd ) =
+                        update FetchUsers initialModel
+                in
+                cmd
+                    |> Expect.notEqual Cmd.none
+
+        , test "Increment returns no command" <|
+            \_ ->
+                let
+                    ( _, cmd ) =
+                        update Increment initialModel
+                in
+                cmd
+                    |> Expect.equal Cmd.none
+        ]
+```
+
+### Testing JSON Decoders
+
+```elm
+import Json.Decode as Decode
+import Test exposing (Test, describe, test)
+import Expect
+
+decoderTests : Test
+decoderTests =
+    describe "JSON Decoders"
+        [ test "decodes valid user JSON" <|
+            \_ ->
+                let
+                    json =
+                        """{"name": "Alice", "email": "alice@example.com", "age": 30}"""
+                in
+                Decode.decodeString userDecoder json
+                    |> Expect.equal
+                        (Ok { name = "Alice", email = "alice@example.com", age = 30 })
+
+        , test "fails on missing field" <|
+            \_ ->
+                let
+                    json =
+                        """{"name": "Alice", "age": 30}"""
+                in
+                Decode.decodeString userDecoder json
+                    |> Expect.err
+
+        , test "fails on wrong type" <|
+            \_ ->
+                let
+                    json =
+                        """{"name": "Alice", "email": "alice@example.com", "age": "thirty"}"""
+                in
+                Decode.decodeString userDecoder json
+                    |> Expect.err
+
+        , test "decodes list of users" <|
+            \_ ->
+                let
+                    json =
+                        """[{"name": "Alice", "email": "a@b.com", "age": 30}]"""
+                in
+                Decode.decodeString (Decode.list userDecoder) json
+                    |> Result.map List.length
+                    |> Expect.equal (Ok 1)
+        ]
+```
+
+### Test Organization
+
+```bash
+# Recommended test structure
+tests/
+├── Tests.elm           # Main test module, imports all
+├── UnitTests/
+│   ├── UserTests.elm   # Tests for User module
+│   ├── ApiTests.elm    # Tests for API module
+│   └── UtilTests.elm   # Tests for utilities
+└── FuzzTests/
+    └── PropertyTests.elm  # Fuzz/property tests
+```
+
+```elm
+-- tests/Tests.elm
+module Tests exposing (suite)
+
+import Test exposing (Test, describe)
+import UnitTests.UserTests
+import UnitTests.ApiTests
+import FuzzTests.PropertyTests
+
+suite : Test
+suite =
+    describe "All Tests"
+        [ UnitTests.UserTests.suite
+        , UnitTests.ApiTests.suite
+        , FuzzTests.PropertyTests.suite
+        ]
+```
+
+### Running Tests
+
+```bash
+# Install elm-test
+npm install -g elm-test
+
+# Initialize tests in project
+elm-test init
+
+# Run all tests
+elm-test
+
+# Run tests in watch mode
+elm-test --watch
+
+# Run specific test file
+elm-test tests/UserTests.elm
+
+# Run with different seed (for fuzz tests)
+elm-test --seed 12345
+
+# Run with more fuzz iterations
+elm-test --fuzz 1000
+```
+
+### Expectation Helpers
+
+```elm
+import Expect exposing (Expectation)
+
+-- Equality
+Expect.equal expected actual
+Expect.notEqual unexpected actual
+
+-- Comparisons
+Expect.lessThan upper actual
+Expect.atMost upper actual
+Expect.greaterThan lower actual
+Expect.atLeast lower actual
+
+-- Floating point (with tolerance)
+Expect.within (Expect.Absolute 0.001) 3.14159 pi
+
+-- Boolean
+Expect.true "should be true" condition
+Expect.false "should be false" condition
+
+-- Result/Maybe
+Expect.ok result        -- Result is Ok
+Expect.err result       -- Result is Err
+Expect.just maybe       -- Maybe is Just (Elm 0.19+)
+Expect.nothing maybe    -- Maybe is Nothing
+
+-- Lists
+Expect.equalLists expected actual
+
+-- Custom failure
+Expect.fail "Custom failure message"
+Expect.pass
+```
+
+### What Tests Actually Catch in Elm
+
+```elm
+-- Types catch these (NO tests needed):
+-- - Null pointer exceptions (no null in Elm)
+-- - Type mismatches (compiler catches)
+-- - Missing pattern matches (compiler catches)
+-- - Undefined functions (compiler catches)
+
+-- Tests catch these (tests valuable):
+-- - Business logic errors
+-- - Off-by-one errors
+-- - Edge cases (empty lists, zero, negative numbers)
+-- - JSON decode/encode round-trips
+-- - Algorithm correctness
+-- - State machine transitions (TEA update logic)
+
+-- Example: Type system prevents this, no test needed
+getName : User -> String  -- Can NEVER be called with null
+
+-- Example: Test needed for business logic
+isEligible : User -> Bool
+isEligible user =
+    user.age >= 18 && user.verified
+    -- Test: age=17, verified=true → false
+    -- Test: age=18, verified=false → false
+    -- Test: age=18, verified=true → true
 ```
 
 ---


### PR DESCRIPTION
## Summary

Addresses subagent feedback from Group 1 conversion skill creation:

- **`/create-lang-conversion-skill` command improvements** (#276):
  - Added explicit instruction to read at least one complete example skill before starting
  - Added structured research checklists (3.1-3.6) for systematic coverage
  - Added WebSearch guidance with example query patterns
  - Added idiom translation priority list (required vs optional patterns)
  - Added quality guidance table showing "Good vs Great" examples

- **`lang-elm-dev` skill expansion** (#277):
  - Added Module System section with visibility patterns and opaque types
  - Added Zero/Default Values section explaining Elm's no-null philosophy
  - Added comprehensive Testing section covering elm-test, fuzz testing, TEA testing
  - Now covers all 8 Pillars (was missing 3, now 8/8)

## Test plan

- [ ] Review command changes for clarity
- [ ] Review lang-elm-dev for accuracy and completeness
- [ ] Verify all 8 pillars are now covered

Closes #276
Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)