### PR TITLE
feat(skills): address Group 1 feedback for conversion skills

### DIFF
--- a/.claude/commands/create-lang-conversion-skill.md
+++ b/.claude/commands/create-lang-conversion-skill.md
@@ -137,6 +137,14 @@ Before creating a conversion skill, validate that both source and target languag
 | Build | `## Build`, `## Dependencies`, `Cargo`, `package.json` | Project migration |
 | Testing | `## Testing`, `#[test]`, `describe`, `unittest` | Test suite conversion |
 
+**Optional 9th Pillar (for REPL-centric languages):**
+
+| Pillar | Search Terms | Why Essential |
+|--------|-------------|---------------|
+| Dev Workflow | `## REPL`, `## Workflow`, `interactive`, `hot reload` | Development style translation |
+
+Include this pillar when either language is REPL-centric: Clojure, Elixir, Erlang, Lisp, Haskell (GHCi), Scala (Ammonite).
+
 #### Automated Validation
 
 Run this validation automatically when reading the lang-*-dev skills:
@@ -237,6 +245,33 @@ Before creating the skill, research the specific language pair using these struc
 - [ ] JSON/serialization libraries
 - [ ] Testing frameworks
 - [ ] Build tools
+
+#### 3.7 Paradigm Shifts (if applicable)
+- [ ] OOP → Functional: class hierarchies → data + functions, inheritance → composition
+- [ ] Imperative → Declarative: loops → recursion/map/fold, mutation → immutability
+- [ ] Dynamic → Static: duck typing → interfaces/traits, runtime checks → compile-time
+- [ ] Script → Compiled: REPL workflow → build cycle, hot reload → recompile
+
+#### 3.8 Transpilers & Interop Tools
+- [ ] Check for existing transpilers between the languages (e.g., Fable.Python, GopherJS)
+- [ ] Note FFI/interop capabilities (calling one language from the other)
+- [ ] Document bidirectional insights from transpiler implementations
+
+#### 3.9 Platform Ecosystem Differences
+Different runtime platforms have distinct conventions and capabilities:
+
+| Platform | Languages | Key Characteristics |
+|----------|-----------|---------------------|
+| .NET/CLR | C#, F#, VB.NET | Rich stdlib, NuGet, strong async |
+| JVM | Java, Kotlin, Scala, Clojure | Maven/Gradle, enterprise tooling |
+| BEAM/OTP | Erlang, Elixir | Actor model, hot reload, supervision |
+| Native | Rust, C, C++, Go | Direct memory, no GC (Rust/C), system-level |
+| Scripting | Python, Ruby, JavaScript | Dynamic, REPL-first, rapid prototyping |
+
+When converting across platforms:
+- [ ] Note stdlib equivalents (collections, IO, networking)
+- [ ] Consider runtime semantics (exceptions, threading, memory)
+- [ ] Document dependency ecosystem differences (package managers)
 
 #### When to Use WebSearch
 
@@ -356,6 +391,29 @@ For general concepts like the Analyze → Plan → Transform → Validate workfl
 
 ---
 
+## Paradigm Translation (if applicable)
+
+Include this section when converting between different paradigms (OOP→FP, imperative→declarative, etc.)
+
+### Mental Model Shift: <Source Paradigm> → <Target Paradigm>
+
+| <Source> Concept | <Target> Approach | Key Insight |
+|------------------|-------------------|-------------|
+| Class with state | Record + module functions | Data and behavior separated |
+| Inheritance | Composition / Protocols | Favor interfaces over hierarchies |
+| Mutable loops | Recursion / fold / map | Transformation over mutation |
+| Side effects anywhere | Pure functions + IO boundary | Effects pushed to edges |
+
+### Concurrency Mental Model
+
+| <Source> Model | <Target> Model | Conceptual Translation |
+|----------------|----------------|------------------------|
+| Threads + locks | Actors / CSP | Shared state → message passing |
+| Callbacks | Streams / Channels | Inversion of control → data flow |
+| async/await | Process mailboxes | Promise → lightweight process |
+
+---
+
 ## Error Handling
 
 ### <Source> Error Model → <Target> Error Model
@@ -385,6 +443,30 @@ For general concepts like the Analyze → Plan → Transform → Validate workfl
 1. **<Pitfall 1>**: Description and how to avoid
 2. **<Pitfall 2>**: Description and how to avoid
 ...
+
+---
+
+## Limitations (if proceeding with Yellow/Red pillar coverage)
+
+Include this section when creating a conversion skill despite incomplete lang-*-dev coverage.
+
+### Coverage Gaps
+
+| Pillar | Source Skill | Target Skill | Mitigation |
+|--------|--------------|--------------|------------|
+| <Pillar> | ✓/~/✗ | ✓/~/✗ | External research / pattern skill / documented gap |
+
+### Known Limitations
+
+1. **<Area>**: This skill has limited guidance on <topic> because lang-<x>-dev lacks coverage
+2. **<Area>**: Conversion patterns for <feature> may be incomplete
+
+### External Resources Used
+
+| Resource | What It Provided | Reliability |
+|----------|------------------|-------------|
+| Official docs | <topic> patterns | High |
+| Community guide | <topic> examples | Medium |
 
 ---
 
@@ -524,6 +606,16 @@ Run through this checklist before completing:
 - [ ] Error handling section covers full error model
 - [ ] Concurrency section addresses async patterns
 - [ ] Memory/Ownership included if languages differ
+- [ ] Paradigm Translation included if paradigms differ (OOP→FP, etc.)
+
+#### Type Mapping Validation Checklist
+- [ ] **Primitives**: All basic types covered (int, float, string, bool, char)
+- [ ] **Numerics**: Precision differences noted (i32 vs i64, overflow behavior)
+- [ ] **Nullability**: null/nil/None → Option/Maybe mappings clear
+- [ ] **Collections**: Array, List, Map, Set, Tuple equivalents
+- [ ] **Composites**: Struct, Class, Interface, Enum, Union mappings
+- [ ] **Generics**: Type parameter syntax and constraints
+- [ ] **Special types**: Never/Bottom, Unit/Void, Any/Dynamic
 
 #### Example Validation
 - [ ] Examples progress in complexity (simple → complex)

--- a/components/skills/meta-convert-dev/SKILL.md
+++ b/components/skills/meta-convert-dev/SKILL.md
@@ -380,6 +380,9 @@ result = sum(x.value for x in items if x.active)
 | Python | Exceptions | `Exception` hierarchy | `raise` / `try-except` |
 | Go | Error returns | `error` interface | Multiple return values |
 | Rust | Result type | `Result<T, E>` | `?` operator |
+| Erlang | Pattern matching | `{ok, Value}` / `{error, Reason}` | Return tuples |
+| Elixir | Pattern matching | `{:ok, value}` / `{:error, reason}` | Return tuples, `with` |
+| Haskell | Maybe/Either | `Maybe a`, `Either e a` | Monadic bind (`>>=`) |
 
 ### Exception → Result Type
 
@@ -456,6 +459,55 @@ enum AppError {
 }
 ```
 
+### "Let It Crash" Philosophy (BEAM Languages)
+
+Erlang/Elixir use a fundamentally different error philosophy: processes are isolated and supervised, so letting them crash and restart is often the correct approach.
+
+| Traditional Approach | "Let It Crash" Approach |
+|---------------------|------------------------|
+| Catch and handle every error | Handle expected errors, let unexpected ones crash |
+| Error recovery in-process | Supervisor restarts clean process |
+| Complex error handling code | Simple code, complex supervision tree |
+| State corruption possible | Fresh state on restart |
+
+```erlang
+%% Erlang: Supervisor tree
+-module(my_sup).
+-behaviour(supervisor).
+
+init([]) ->
+    ChildSpecs = [
+        #{id => worker1,
+          start => {worker, start_link, []},
+          restart => permanent,
+          shutdown => 5000}
+    ],
+    {ok, {{one_for_one, 5, 10}, ChildSpecs}}.
+```
+
+```elixir
+# Elixir: Supervision tree
+defmodule MySupervisor do
+  use Supervisor
+
+  def start_link(init_arg) do
+    Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    children = [
+      {Worker, []}
+    ]
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end
+```
+
+**When converting TO Erlang/Elixir**: Consider moving error handling from catch-all blocks to supervision strategies.
+
+**When converting FROM Erlang/Elixir**: Translate supervision patterns to explicit error handling, retry logic, and state recovery.
+
 ---
 
 ## Concurrency Model Translation
@@ -470,6 +522,9 @@ enum AppError {
 | Python | `async/await`, asyncio | Threading, multiprocessing | Queue |
 | Go | Goroutines | Built-in | `chan` (first-class) |
 | Rust | `async/await`, Futures | std::thread | mpsc, crossbeam |
+| Erlang | Processes (lightweight) | BEAM scheduler | Mailboxes (first-class) |
+| Elixir | Tasks, GenServer | BEAM scheduler | Mailboxes, Agent |
+| Clojure | core.async, Agents | JVM threads | CSP channels |
 
 ### Promise/Future Translation
 
@@ -509,6 +564,76 @@ func fetchUser(id string) <-chan UserResult {
     }()
     return ch
 }
+```
+
+```erlang
+%% Erlang: spawned process with message passing
+fetch_user(Id) ->
+    Self = self(),
+    spawn(fun() ->
+        case httpc:request(get, {"http://api/users/" ++ Id, []}, [], []) of
+            {ok, {{_, 200, _}, _, Body}} ->
+                Self ! {user, jsx:decode(Body)};
+            {error, Reason} ->
+                Self ! {error, Reason}
+        end
+    end),
+    receive
+        {user, User} -> {ok, User};
+        {error, Reason} -> {error, Reason}
+    after 5000 ->
+        {error, timeout}
+    end.
+```
+
+```elixir
+# Elixir: Task-based async
+def fetch_user(id) do
+  Task.async(fn ->
+    case HTTPoison.get("http://api/users/#{id}") do
+      {:ok, %{status_code: 200, body: body}} ->
+        {:ok, Jason.decode!(body)}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end)
+  |> Task.await(5000)
+end
+```
+
+### Process-Based Concurrency (BEAM Languages)
+
+For Erlang/Elixir, concurrency is based on lightweight processes with message passing:
+
+```erlang
+%% Erlang: GenServer pattern (simplified)
+-module(user_cache).
+-behaviour(gen_server).
+
+init([]) -> {ok, #{}}.
+
+handle_call({get, Id}, _From, State) ->
+    {reply, maps:get(Id, State, undefined), State};
+handle_call({put, Id, User}, _From, State) ->
+    {reply, ok, maps:put(Id, User, State)}.
+```
+
+```elixir
+# Elixir: GenServer
+defmodule UserCache do
+  use GenServer
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  def get(id), do: GenServer.call(__MODULE__, {:get, id})
+  def put(id, user), do: GenServer.call(__MODULE__, {:put, id, user})
+
+  @impl true
+  def init(_), do: {:ok, %{}}
+
+  @impl true
+  def handle_call({:get, id}, _from, state), do: {:reply, Map.get(state, id), state}
+  def handle_call({:put, id, user}, _from, state), do: {:reply, :ok, Map.put(state, id, user)}
+end
 ```
 
 ### Parallel Execution
@@ -614,6 +739,90 @@ When converting GC → Ownership:
    ├─ YES → Return owned value or 'static
    └─ NO → Return borrowed reference
 ```
+
+---
+
+## Paradigm Translation Strategies
+
+When converting between different programming paradigms, patterns don't translate directly.
+
+### OOP → Functional Translation
+
+| OOP Concept | Functional Approach | Key Insight |
+|-------------|---------------------|-------------|
+| Class with fields | Record/struct + module functions | Data and behavior separated |
+| Inheritance hierarchy | Composition / Type classes / Protocols | Favor capabilities over hierarchies |
+| Mutable object state | Immutable data + transformation functions | New version instead of mutation |
+| Method chaining | Function pipelines | `obj.a().b()` → `b(a(obj))` or `obj \|> a \|> b` |
+| Interface | Protocol / Type class / Trait | Behavior contract |
+| Private methods | Module-private functions | Visibility at module level |
+
+### Immutability Patterns
+
+| Mutable Pattern | Immutable Pattern | Example Languages |
+|-----------------|-------------------|-------------------|
+| `obj.field = value` | `{...obj, field: value}` | JS, Clojure, Elixir |
+| `list.push(x)` | `[x \| list]` or `cons(x, list)` | Erlang, Elixir, Haskell |
+| `dict[key] = value` | `Map.put(dict, key, value)` | Elixir, Clojure |
+| Accumulator variables | `fold`/`reduce` with initial value | All functional |
+| In-place sort | Return sorted copy | All functional |
+
+```python
+# Python: Mutable (imperative)
+def process_users(users):
+    result = []
+    for user in users:
+        if user.active:
+            user.score += 10  # Mutation!
+            result.append(user)
+    return result
+```
+
+```elixir
+# Elixir: Immutable (functional)
+def process_users(users) do
+  users
+  |> Enum.filter(& &1.active)
+  |> Enum.map(& %{&1 | score: &1.score + 10})  # New map, not mutation
+end
+```
+
+### State Management Across Paradigms
+
+| OOP Approach | Functional Equivalent |
+|--------------|----------------------|
+| Singleton | Module with state (GenServer, Agent) |
+| Observer pattern | Event streams, pub/sub |
+| Factory pattern | Constructor functions, protocols |
+| Repository | Pure functions + effect boundary |
+
+---
+
+## Platform Ecosystem Translation
+
+When converting between different runtime platforms, consider these ecosystem differences:
+
+### Platform Comparison
+
+| Platform | Languages | Runtime | Package Manager | Key Strengths |
+|----------|-----------|---------|-----------------|---------------|
+| .NET/CLR | C#, F#, VB | Managed, JIT | NuGet | Enterprise, LINQ, async |
+| JVM | Java, Kotlin, Scala, Clojure | Managed, JIT | Maven, Gradle | Ecosystem, stability |
+| BEAM/OTP | Erlang, Elixir | Lightweight processes | Hex, Rebar3 | Fault tolerance, concurrency |
+| Native | Rust, Go, C, C++ | Direct compilation | Cargo, go mod | Performance, control |
+| Scripting | Python, Ruby, JS | Interpreted/JIT | pip, gem, npm | Rapid development |
+
+### Standard Library Mapping
+
+When converting, find equivalent stdlib functions:
+
+| Capability | .NET | JVM | Python | Rust | Erlang/Elixir |
+|------------|------|-----|--------|------|---------------|
+| HTTP Client | HttpClient | java.net.http | requests | reqwest | httpc, HTTPoison |
+| JSON | System.Text.Json | Jackson, Gson | json | serde_json | jsx, Jason |
+| Date/Time | DateTime | java.time | datetime | chrono | calendar, Timex |
+| Regex | System.Text.RegularExpressions | java.util.regex | re | regex | re |
+| Collections | System.Collections.Generic | java.util | builtins | std::collections | maps, lists, Enum |
 
 ---
 
@@ -1118,6 +1327,52 @@ fn benchmark_conversion(c: &mut Criterion) {
 criterion_group!(benches, benchmark_conversion);
 criterion_main!(benches);
 ```
+
+---
+
+## Common Gotchas by Language Family
+
+Different language families share common conversion challenges:
+
+### OOP → Functional Conversions
+
+| OOP Pattern | Functional Challenge | Solution |
+|-------------|---------------------|----------|
+| `this` reference | No implicit self | Pass data explicitly or use closures |
+| Class state | No mutable state | Use immutable records + new versions |
+| Method overriding | No inheritance | Use higher-order functions, protocols |
+| Constructor logic | No side effects | Separate creation from initialization |
+| Private fields | No object encapsulation | Module-level privacy |
+
+### Dynamic → Static Typing Conversions
+
+| Dynamic Pattern | Static Challenge | Solution |
+|-----------------|------------------|----------|
+| Duck typing | Must know types | Define explicit interfaces/traits |
+| `any`/`dynamic` | No escape hatch | Use enums or generics |
+| Runtime type checks | Compile-time types | Pattern matching, type guards |
+| Mixed collections | Homogeneous types | Use sum types (enums) |
+| Monkey patching | No runtime extension | Design for extensibility upfront |
+
+### GC → Ownership Conversions
+
+| GC Pattern | Ownership Challenge | Solution |
+|------------|---------------------|----------|
+| Shared references | Borrow checker | Decide owner, clone if needed |
+| Circular references | Compile error | Use weak refs, Rc/Arc |
+| Global state | Lifetime issues | Dependency injection, Arc<Mutex<T>> |
+| Late initialization | Non-null requirement | Option<T>, lazy_static |
+| Object graphs | Complex lifetimes | Use indices instead of references |
+
+### Scripting → Compiled Conversions
+
+| Script Pattern | Compiled Challenge | Solution |
+|----------------|-------------------|----------|
+| REPL workflow | Build cycle | Fast compiler, watch mode |
+| Dynamic imports | Static dependencies | Module system, feature flags |
+| Hot reload | Recompile required | Fast incremental builds |
+| Runtime eval | No eval | Interpreter embedding, macros |
+| Loose structure | Strict project layout | Follow language conventions |
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses feedback from Group 1 conversion skill subagents (python→fsharp, python→erlang, python→clojure).

### /create-lang-conversion-skill Updates
- Added optional 9th pillar (Dev Workflow) for REPL-centric languages
- Added Paradigm Shifts checklist for research phase
- Added Transpilers & Interop Tools discovery checklist
- Added Platform Ecosystem Differences guide
- Added Paradigm Translation section template with mental model shift tables
- Added Concurrency Mental Model translation table
- Added Limitations section template for Yellow/Red coverage cases
- Added Type Mapping Validation Checklist

### meta-convert-dev Updates
- Added Erlang/Elixir/Clojure to concurrency model comparison
- Added Erlang and Elixir async pattern examples
- Added Process-Based Concurrency section with GenServer examples
- Added "Let It Crash" Philosophy section with supervision trees
- Added Paradigm Translation Strategies (OOP→FP, immutability patterns)
- Added Platform Ecosystem Translation with stdlib mapping
- Added Common Gotchas by Language Family

Addresses feedback from:
- #261 (python-clojure command feedback)
- #262 (python-erlang command feedback)  
- #264 (python-erlang meta-convert-dev feedback)
- #267 (python-fsharp command feedback)
- #268 (python-fsharp meta-convert-dev feedback)

## Test plan

- [x] Verified /create-lang-conversion-skill command structure
- [x] Verified meta-convert-dev skill structure
- [ ] Review new sections for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)