### PR TITLE
feat(skills): add meta-convert-guide skill with progressive disclosure

### DIFF
--- a/components/skills/meta-convert-guide/FORMS.md
+++ b/components/skills/meta-convert-guide/FORMS.md
@@ -1,0 +1,320 @@
+# Conversion Forms & Templates
+
+Templates, checklists, and decision trees for language conversion projects.
+
+---
+
+## Type Mapping Template
+
+Use this template when planning a conversion. Fill in all rows before starting transformation.
+
+```markdown
+## Type Mapping: <Source> → <Target>
+
+### Primitive Types
+
+| <Source> | <Target> | Notes |
+|----------|----------|-------|
+| `string` | | |
+| `number` / `int` | | |
+| `float` / `double` | | |
+| `boolean` / `bool` | | |
+| `null` / `nil` / `None` | | |
+| `undefined` | | |
+| `void` / `unit` | | |
+
+### Composite Types
+
+| <Source> | <Target> | Notes |
+|----------|----------|-------|
+| `Array<T>` / `list` / `[]T` | | |
+| `Map<K,V>` / `dict` / `map[K]V` | | |
+| `Set<T>` / `set` | | |
+| `Tuple` | | |
+| `Optional<T>` / `T?` / `Option[T]` | | |
+| `Union` / `enum` | | |
+
+### Structural Types
+
+| <Source> | <Target> | Notes |
+|----------|----------|-------|
+| `interface` | | |
+| `class` | | |
+| `abstract class` | | |
+| `enum` | | |
+| `type alias` | | |
+
+### Function Types
+
+| <Source> | <Target> | Notes |
+|----------|----------|-------|
+| Function signature | | |
+| Lambda / closure | | |
+| Generic function | | |
+| Async function | | |
+```
+
+---
+
+## Ownership Decision Tree
+
+Use when converting from GC languages to ownership-based (Rust).
+
+```
+START: Is this data shared across components?
+│
+├─ YES: Is it mutated by multiple parts?
+│   │
+│   ├─ YES: Multi-threaded access?
+│   │   ├─ YES → Arc<Mutex<T>> or channels
+│   │   └─ NO  → Rc<RefCell<T>>
+│   │
+│   └─ NO: → Arc<T> (shared, immutable)
+│
+└─ NO: Single owner
+    │
+    ├─ Does data outlive its creator?
+    │   ├─ YES → Return owned value (move)
+    │   └─ NO  → Return borrowed reference (&T)
+    │
+    └─ Is mutation needed?
+        ├─ YES → &mut T (exclusive borrow)
+        └─ NO  → &T (shared borrow)
+```
+
+---
+
+## Clone vs Borrow Decision Tree
+
+```
+START: Is the data expensive to clone?
+│
+├─ YES: Use borrowing with lifetimes
+│   │
+│   ├─ Single owner needed? → &T / &mut T
+│   └─ Multiple owners needed? → Arc<T> / Rc<T>
+│
+└─ NO: Clone freely
+    │
+    ├─ Small data (< 64 bytes)? → Copy if possible
+    └─ Larger data? → Clone explicitly, consider Cow<T>
+```
+
+---
+
+## Conversion Self-Review Checklist
+
+Complete before marking a conversion done:
+
+### Type System
+- [ ] All primitive types mapped
+- [ ] All composite types mapped
+- [ ] Generic constraints translated
+- [ ] Nullable handling explicit (Option/Maybe/nil)
+
+### Error Handling
+- [ ] Exception → Result/Error return pattern applied
+- [ ] Error types defined
+- [ ] Error propagation idiom used (?, try, if err != nil)
+- [ ] Panic/crash conditions documented
+
+### Concurrency
+- [ ] Async model translated (Promise → Future, etc.)
+- [ ] Thread safety verified
+- [ ] Shared state properly synchronized
+- [ ] Cancellation patterns implemented
+
+### Memory (if applicable)
+- [ ] Ownership clearly defined
+- [ ] Lifetimes annotated where needed
+- [ ] No unnecessary cloning
+- [ ] Resource cleanup verified (RAII/defer/finally)
+
+### Idioms
+- [ ] Code follows target language conventions
+- [ ] Naming conventions applied (snake_case, camelCase, etc.)
+- [ ] Not "source language in target syntax"
+- [ ] Standard library used where appropriate
+
+### Testing
+- [ ] Original tests ported
+- [ ] Golden tests for I/O comparison
+- [ ] Edge cases covered
+- [ ] Property-based tests for invariants
+
+### Documentation
+- [ ] Public APIs documented
+- [ ] Conversion notes for non-obvious translations
+- [ ] Dependencies documented
+
+---
+
+## Testing Strategy Checklist
+
+```
+TESTING PYRAMID FOR CONVERSIONS
+
+                    ┌───────────────┐
+                    │  Integration  │  ← Same API behavior
+                    └───────────────┘
+               ┌─────────────────────────┐
+               │    Property-Based       │  ← Invariants hold
+               └─────────────────────────┘
+          ┌───────────────────────────────────┐
+          │           Unit Tests              │  ← Logic match
+          └───────────────────────────────────┘
+     ┌─────────────────────────────────────────────┐
+     │        Golden / Snapshot Tests              │  ← I/O match
+     └─────────────────────────────────────────────┘
+```
+
+### Pre-Conversion
+- [ ] Export golden test data from original implementation
+- [ ] Document expected behavior for edge cases
+- [ ] Identify performance baseline
+
+### During Conversion
+- [ ] Port unit tests first (before implementation)
+- [ ] Run tests after each module conversion
+- [ ] Track test coverage
+
+### Post-Conversion
+- [ ] All original tests pass
+- [ ] Golden tests match original output
+- [ ] Property-based tests verify invariants
+- [ ] Performance meets or exceeds baseline
+- [ ] Integration tests pass
+
+---
+
+## Performance Checklist
+
+Use after conversion to verify performance characteristics:
+
+### Memory
+- [ ] No unnecessary allocations
+- [ ] String building uses appropriate method (join, builder)
+- [ ] Collections pre-sized when size known
+- [ ] Large data uses references, not clones
+
+### Computation
+- [ ] Appropriate collection types (HashMap vs Vec for lookup)
+- [ ] Lazy evaluation where beneficial
+- [ ] Hot paths identified and optimized
+- [ ] No redundant computation
+
+### Concurrency
+- [ ] Parallelism used where appropriate
+- [ ] No unnecessary synchronization
+- [ ] Lock contention minimized
+- [ ] Async used for I/O-bound work
+
+### Verification
+- [ ] Benchmarks written for critical paths
+- [ ] Compared to original implementation
+- [ ] Memory profiling done
+- [ ] No regressions from original
+
+---
+
+## APTV Phase Checklist
+
+### Analyze Phase
+- [ ] Source code structure understood
+- [ ] All types/interfaces identified
+- [ ] All functions/methods catalogued
+- [ ] Module boundaries mapped
+- [ ] External dependencies listed
+- [ ] Language-specific features noted
+
+### Plan Phase
+- [ ] Type mapping table complete
+- [ ] Idiom translations identified
+- [ ] Module/package structure designed
+- [ ] Dependencies selected
+- [ ] Testing strategy defined
+- [ ] Tooling set up
+
+### Transform Phase
+- [ ] Types and interfaces converted first
+- [ ] Core logic converted
+- [ ] Target idioms adopted (not transliterated)
+- [ ] Tests passing incrementally
+- [ ] Code reviewed for idiomatic style
+
+### Validate Phase
+- [ ] All tests pass
+- [ ] Golden tests match
+- [ ] Property-based tests pass
+- [ ] Performance acceptable
+- [ ] Code review complete
+- [ ] Documentation complete
+
+---
+
+## Error Model Translation Template
+
+```markdown
+## Error Translation: <Source> → <Target>
+
+### Source Error Model
+- Pattern: (exceptions / error returns / Result types)
+- Propagation: (throw/try-catch / if err != nil / ? operator)
+- Hierarchy: (describe error class structure)
+
+### Target Error Model
+- Pattern: (exceptions / error returns / Result types)
+- Propagation: (throw/try-catch / if err != nil / ? operator)
+- Hierarchy: (describe error type structure)
+
+### Mapping
+
+| Source Error | Target Error | Notes |
+|--------------|--------------|-------|
+| Base exception | | |
+| Not found | | |
+| Validation | | |
+| IO error | | |
+| Network error | | |
+| Auth error | | |
+
+### Propagation Translation
+
+| Source | Target |
+|--------|--------|
+| `throw new Error(msg)` | |
+| `try { } catch (e) { }` | |
+| `throw` (rethrow) | |
+| `finally { }` | |
+```
+
+---
+
+## Concurrency Translation Template
+
+```markdown
+## Concurrency Translation: <Source> → <Target>
+
+### Source Model
+- Async pattern: (Promises / async-await / goroutines / actors)
+- Threading: (single-threaded / green threads / OS threads)
+- Channels: (available / not available)
+
+### Target Model
+- Async pattern: (Promises / async-await / goroutines / actors)
+- Threading: (single-threaded / green threads / OS threads)
+- Channels: (available / not available)
+
+### Pattern Mapping
+
+| Source Pattern | Target Pattern | Notes |
+|----------------|----------------|-------|
+| `async function` | | |
+| `await promise` | | |
+| `Promise.all([])` | | |
+| `Promise.race([])` | | |
+| spawn/thread | | |
+| channel send | | |
+| channel receive | | |
+| mutex/lock | | |
+```

--- a/components/skills/meta-convert-guide/SKILL.md
+++ b/components/skills/meta-convert-guide/SKILL.md
@@ -1,0 +1,408 @@
+---
+name: meta-convert-guide
+description: Guide for translating code between programming languages. Use when converting code from one language to another, planning language migrations, understanding conversion challenges, asking about type mappings, idiom translations, or referencing pattern mappings. Covers APTV workflow, type systems, error handling, concurrency, and language-specific gotchas.
+---
+
+# Language Conversion Guide
+
+Comprehensive patterns and strategies for converting code between programming languages.
+
+## Quick Navigation
+
+| Resource                                                 | Purpose                               |
+| -------------------------------------------------------- | ------------------------------------- |
+| [FORMS.md](./FORMS.md)                                   | Templates, checklists, decision trees |
+| [tables/quick-reference.md](./tables/quick-reference.md) | Condensed lookup tables               |
+
+### Examples
+
+| File                                                             | Content                                      |
+| ---------------------------------------------------------------- | -------------------------------------------- |
+| [examples/idiom-translation.md](./examples/idiom-translation.md) | Null handling, collections, pattern matching |
+| [examples/error-handling.md](./examples/error-handling.md)       | Exception→Result, error hierarchies          |
+| [examples/concurrency.md](./examples/concurrency.md)             | Promise/Future, parallel execution           |
+| [examples/metaprogramming.md](./examples/metaprogramming.md)     | Decorators, macros, DI patterns              |
+| [examples/serialization.md](./examples/serialization.md)         | JSON, validation, polymorphic types          |
+
+### Reference Guides
+
+| File                                                                           | Content                            |
+| ------------------------------------------------------------------------------ | ---------------------------------- |
+| [reference/type-system-mapping.md](./reference/type-system-mapping.md)         | Primitives, composites, generics   |
+| [reference/error-handling.md](./reference/error-handling.md)                   | Error models, let-it-crash         |
+| [reference/concurrency.md](./reference/concurrency.md)                         | Async models, channels, goroutines |
+| [reference/dev-workflow-repl.md](./reference/dev-workflow-repl.md)             | 9th pillar, REPL patterns          |
+| [reference/memory-ownership.md](./reference/memory-ownership.md)               | GC→ownership, borrowing            |
+| [reference/evaluation-strategy.md](./reference/evaluation-strategy.md)         | Lazy vs eager patterns             |
+| [reference/metaprogramming.md](./reference/metaprogramming.md)                 | Macros, reflection, code gen       |
+| [reference/type-system-translation.md](./reference/type-system-translation.md) | Static↔dynamic, inference         |
+| [reference/paradigm-translation.md](./reference/paradigm-translation.md)       | OOP→FP, FP→FP                      |
+| [reference/serialization.md](./reference/serialization.md)                     | Library mapping, attributes        |
+| [reference/typescript-patterns.md](./reference/typescript-patterns.md)         | Type guards, mapped types          |
+| [reference/hkt-type-classes.md](./reference/hkt-type-classes.md)               | HKTs, Functor, Monad               |
+| [reference/async-patterns.md](./reference/async-patterns.md)                   | Cancellation, streams              |
+| [reference/dependency-management.md](./reference/dependency-management.md)     | Package ecosystems                 |
+| [reference/performance.md](./reference/performance.md)                         | Pitfalls, benchmarking             |
+
+### Gotchas
+
+| File                                                                   | Content                              |
+| ---------------------------------------------------------------------- | ------------------------------------ |
+| [reference/gotchas/by-family.md](./reference/gotchas/by-family.md)     | OOP→FP, Dynamic→Static, GC→Ownership |
+| [reference/gotchas/by-language.md](./reference/gotchas/by-language.md) | Python→Rust, TypeScript→Rust, etc.   |
+
+---
+
+## When to Use This Skill
+
+- Converting code from one language to another
+- Planning a language migration
+- Understanding conversion challenges between languages
+- Looking up type mappings or idiom translations
+- Referencing error handling, concurrency, or async patterns across languages
+- Learning about gotchas when converting between specific language families
+
+## This Skill Does NOT Cover
+
+- Creating new conversion skills (see `meta-convert-dev`)
+- Language tutorials (see `lang-*-dev` skills)
+- Runtime interop/FFI (see language-specific interop skills)
+
+## Related Skills
+
+- `meta-convert-dev` - For creating new `convert-X-Y` skills
+- `convert-*` skills - Language-pair specific conversion skills
+
+---
+
+## Core Conversion Methodology
+
+### The APTV Workflow
+
+Every conversion follows: **Analyze → Plan → Transform → Validate**
+
+```asciidoc
+┌─────────────────────────────────────────────────────────────┐
+│                    CONVERSION WORKFLOW                       │
+├─────────────────────────────────────────────────────────────┤
+│  1. ANALYZE    │  Understand source code structure          │
+│                │  • Parse and identify components            │
+│                │  • Map dependencies                         │
+│                │  • Identify language-specific patterns      │
+├─────────────────────────────────────────────────────────────┤
+│  2. PLAN       │  Design the target architecture            │
+│                │  • Create type mapping table                │
+│                │  • Identify idiom translations              │
+│                │  • Plan module/package structure            │
+├─────────────────────────────────────────────────────────────┤
+│  3. TRANSFORM  │  Convert code systematically               │
+│                │  • Types and interfaces first               │
+│                │  • Core logic second                        │
+│                │  • Adopt target idioms (don't transliterate)│
+├─────────────────────────────────────────────────────────────┤
+│  4. VALIDATE   │  Verify functional equivalence             │
+│                │  • Run original tests against new code      │
+│                │  • Property-based testing for edge cases    │
+│                │  • Performance comparison if relevant       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+> **See also:** [FORMS.md](./FORMS.md) for APTV phase checklists
+
+### Analyze Phase
+
+Before writing any target code:
+
+1. **Parse the source** - Understand structure, not just syntax
+2. **Identify components**:
+   - Types/interfaces/classes
+   - Functions/methods
+   - Module boundaries
+   - External dependencies
+3. **Note language-specific features**:
+   - Generics usage
+   - Error handling patterns
+   - Async patterns
+   - Memory management approach
+
+### Plan Phase
+
+Create explicit mappings before transforming. Use the templates in [FORMS.md](./FORMS.md):
+
+```markdown
+## Type Mapping Table
+
+| Source (TypeScript) | Target (Rust)      | Notes             |
+| ------------------- | ------------------ | ----------------- |
+| `string`            | `String` / `&str`  | Owned vs borrowed |
+| `number`            | `i32` / `f64`      | Specify precision |
+| `T[]`               | `Vec<T>`           | Owned collection  |
+| `T \| null`         | `Option<T>`        | Nullable handling |
+| `Promise<T>`        | `Future<Output=T>` | Async handling    |
+```
+
+> **See also:** [reference/type-system-mapping.md](./reference/type-system-mapping.md) for complete mappings
+
+### Transform Phase
+
+**Golden Rule: Adopt target idioms, don't write "Source code in Target syntax"**
+
+```typescript
+// Source: TypeScript
+function findUser(id: string): User | null {
+  const user = users.find((u) => u.id === id);
+  return user || null;
+}
+```
+
+```rust
+// BAD: Transliterated (TypeScript in Rust clothing)
+fn find_user(id: String) -> Option<User> {
+    let user = users.iter().find(|u| u.id == id);
+    match user {
+        Some(u) => Some(u.clone()),
+        None => None,
+    }
+}
+
+// GOOD: Idiomatic Rust
+fn find_user(id: &str) -> Option<&User> {
+    users.iter().find(|u| u.id == id)
+}
+```
+
+> **See also:** [examples/idiom-translation.md](./examples/idiom-translation.md) for more patterns
+
+### Validate Phase
+
+1. **Functional equivalence**: Same inputs → same outputs
+2. **Edge case coverage**: Property-based tests
+3. **Error behavior**: Same error conditions trigger appropriately
+4. **Performance baseline**: Comparable or better performance
+
+> **See also:** [FORMS.md](./FORMS.md) for testing strategy checklist
+
+---
+
+## The 8 Pillars of Conversion
+
+Every comprehensive conversion addresses these domains:
+
+| Pillar                     | What to Convert                | Reference                                                                  |
+| -------------------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| 1. **Module System**       | Imports, exports, packages     | [reference/type-system-mapping.md](./reference/type-system-mapping.md)     |
+| 2. **Error Handling**      | Exceptions, Results, panics    | [reference/error-handling.md](./reference/error-handling.md)               |
+| 3. **Concurrency**         | Async, threads, channels       | [reference/concurrency.md](./reference/concurrency.md)                     |
+| 4. **Metaprogramming**     | Decorators, macros, reflection | [reference/metaprogramming.md](./reference/metaprogramming.md)             |
+| 5. **Zero/Default Values** | Nullability, defaults          | [reference/type-system-mapping.md](./reference/type-system-mapping.md)     |
+| 6. **Serialization**       | JSON, validation, schemas      | [reference/serialization.md](./reference/serialization.md)                 |
+| 7. **Build System**        | Package managers, dependencies | [reference/dependency-management.md](./reference/dependency-management.md) |
+| 8. **Testing**             | Test frameworks, assertions    | [FORMS.md](./FORMS.md)                                                     |
+
+### The 9th Pillar: Dev Workflow
+
+For REPL-centric languages (Clojure, Elixir, Haskell), add:
+
+| Source          | Target    | Consideration             |
+| --------------- | --------- | ------------------------- |
+| REPL-centric    | Compiled  | Document workflow changes |
+| Hot reload      | Recompile | Faster incremental builds |
+| Live inspection | Debugging | Logger, debugger setup    |
+
+> **See also:** [reference/dev-workflow-repl.md](./reference/dev-workflow-repl.md)
+
+---
+
+## Quick Reference Tables
+
+### Type System Comparison
+
+| Language   | Typing      | Null Safety         | Generics   |
+| ---------- | ----------- | ------------------- | ---------- |
+| TypeScript | Static      | Optional (`strict`) | Full       |
+| Python     | Dynamic     | None (runtime)      | Type hints |
+| Rust       | Static      | Enforced (`Option`) | Full       |
+| Go         | Static      | Nil pointers        | 1.18+      |
+| Elixir     | Dynamic     | nil atoms           | None       |
+| Haskell    | Static (HM) | Enforced (`Maybe`)  | Full + HKT |
+
+> **See also:** [tables/quick-reference.md](./tables/quick-reference.md) for complete tables
+
+### Error Model Comparison
+
+| Language   | Model         | Propagation                |
+| ---------- | ------------- | -------------------------- |
+| TypeScript | Exceptions    | `throw` / `try-catch`      |
+| Python     | Exceptions    | `raise` / `try-except`     |
+| Rust       | Result type   | `?` operator               |
+| Go         | Error returns | `if err != nil`            |
+| Elixir     | Pattern match | `{:ok, _}` / `{:error, _}` |
+| Haskell    | Either/Maybe  | Monadic bind               |
+
+> **See also:** [reference/error-handling.md](./reference/error-handling.md)
+
+### Concurrency Model Comparison
+
+| Language   | Model      | Primitives            |
+| ---------- | ---------- | --------------------- |
+| TypeScript | Event loop | Promises, async/await |
+| Python     | Event loop | asyncio, await        |
+| Rust       | Futures    | tokio, async/await    |
+| Go         | CSP        | Goroutines, channels  |
+| Elixir     | Actors     | Processes, GenServer  |
+| Erlang     | Actors     | Processes, mailboxes  |
+
+> **See also:** [reference/concurrency.md](./reference/concurrency.md)
+
+---
+
+## Common Conversion Patterns
+
+### Null Handling
+
+| Source           | Target Rust            | Pattern           |
+| ---------------- | ---------------------- | ----------------- |
+| `x ?? default`   | `x.unwrap_or(default)` | Default value     |
+| `x?.prop`        | `x.map(\|v\| v.prop)`  | Optional chaining |
+| `if (x != null)` | `if let Some(v) = x`   | Null check        |
+
+> **See also:** [examples/idiom-translation.md](./examples/idiom-translation.md)
+
+### Error Propagation
+
+| Source                 | Target                                         | Pattern           |
+| ---------------------- | ---------------------------------------------- | ----------------- |
+| `throw new Error(msg)` | `return Err(Error::new(msg))`                  | Throw → Result    |
+| `try { } catch { }`    | `match result { Ok(_) => ..., Err(_) => ... }` | Try/catch → match |
+| Rethrow                | `?` operator                                   | Propagate error   |
+
+> **See also:** [examples/error-handling.md](./examples/error-handling.md)
+
+### Collection Operations
+
+| Source (JS/TS)     | Target (Rust)           | Notes               |
+| ------------------ | ----------------------- | ------------------- |
+| `.map(f)`          | `.iter().map(f)`        | Lazy in Rust        |
+| `.filter(f)`       | `.iter().filter(f)`     | Lazy in Rust        |
+| `.reduce(f, init)` | `.iter().fold(init, f)` | Different arg order |
+| `.find(f)`         | `.iter().find(f)`       | Returns Option      |
+
+> **See also:** [tables/quick-reference.md](./tables/quick-reference.md)
+
+---
+
+## Decision Trees
+
+### When to Clone vs Borrow
+
+```
+Is the data needed after the function returns?
+├─ NO → Borrow (&T)
+└─ YES → Does caller need to keep using it?
+         ├─ NO → Move (T)
+         └─ YES → Clone (.clone())
+```
+
+> **See also:** [FORMS.md](./FORMS.md) for complete decision trees
+
+### GC → Ownership Strategy
+
+```
+Is this data shared across components?
+├─ YES → Consider Arc<T> or Rc<T>
+└─ NO → Single owner, use moves
+
+Is this data mutated by multiple parts?
+├─ YES → Arc<Mutex<T>> or channels
+└─ NO → Immutable borrows (&T)
+```
+
+> **See also:** [reference/memory-ownership.md](./reference/memory-ownership.md)
+
+---
+
+## Common Pitfalls
+
+| Pitfall                   | Wrong                           | Right                 |
+| ------------------------- | ------------------------------- | --------------------- |
+| **Transliteration**       | Write TypeScript in Rust syntax | Write idiomatic Rust  |
+| **Ignoring idioms**       | Port class hierarchies to Rust  | Use enums and traits  |
+| **1:1 mapping**           | Every function maps exactly     | Restructure as needed |
+| **Preserve inefficiency** | Port inefficient algorithms     | Optimize for target   |
+| **Ignore conventions**    | camelCase in Python             | snake_case (Python)   |
+
+> **See also:** [reference/gotchas/by-family.md](./reference/gotchas/by-family.md)
+
+---
+
+## Testing Conversions
+
+### Testing Pyramid
+
+```asciidoc
+         ┌───────────────┐
+         │  Integration  │  Same API behavior
+         └───────────────┘
+    ┌─────────────────────────┐
+    │    Property-Based       │  Invariants hold
+    └─────────────────────────┘
+ ┌───────────────────────────────────┐
+ │           Unit Tests              │  Logic matches
+ └───────────────────────────────────┘
+┌─────────────────────────────────────────┐
+│        Input/Output Comparison          │  Golden tests
+└─────────────────────────────────────────┘
+```
+
+### Golden Testing
+
+1. Generate test cases from original implementation
+2. Save as JSON fixtures
+3. Run converted code against same inputs
+4. Compare outputs
+
+> **See also:** [FORMS.md](./FORMS.md) for testing checklist
+
+---
+
+## Language-Specific Quick Links
+
+### Converting FROM
+
+| Source     | Key Gotchas                  | Reference                                                                           |
+| ---------- | ---------------------------- | ----------------------------------------------------------------------------------- |
+| Python     | Duck typing, None everywhere | [reference/gotchas/by-language.md](./reference/gotchas/by-language.md#python--rust) |
+| TypeScript | Optional properties, any     | [reference/typescript-patterns.md](./reference/typescript-patterns.md)              |
+| Go         | Zero values, nil             | [reference/gotchas/by-language.md](./reference/gotchas/by-language.md#go--rust)     |
+| Java       | Null, checked exceptions     | [reference/gotchas/by-language.md](./reference/gotchas/by-language.md#java--rust)   |
+| Haskell    | HKTs, laziness               | [reference/hkt-type-classes.md](./reference/hkt-type-classes.md)                    |
+| Elixir     | Pattern matching, processes  | [reference/gotchas/by-language.md](./reference/gotchas/by-language.md#elixir--rust) |
+
+### Converting TO
+
+| Target | Key Considerations          | Reference                                                                      |
+| ------ | --------------------------- | ------------------------------------------------------------------------------ |
+| Rust   | Ownership, borrowing        | [reference/memory-ownership.md](./reference/memory-ownership.md)               |
+| Go     | Simplicity, explicit errors | [reference/error-handling.md](./reference/error-handling.md)                   |
+| Python | Dynamic typing              | [reference/type-system-translation.md](./reference/type-system-translation.md) |
+| Elixir | Functional, BEAM            | [reference/paradigm-translation.md](./reference/paradigm-translation.md)       |
+
+---
+
+## References
+
+### Related Skills
+
+- `meta-convert-dev` - For creating new `convert-X-Y` skills
+- `convert-typescript-rust` - TypeScript → Rust conversion
+- `convert-python-rust` - Python → Rust conversion
+- `convert-golang-rust` - Go → Rust conversion
+
+### Language Skills
+
+For language-specific fundamentals (not conversion):
+
+- `lang-typescript-dev` - TypeScript development patterns
+- `lang-python-dev` - Python development patterns
+- `lang-rust-dev` - Rust development patterns
+- `lang-elixir-dev` - Elixir development patterns

--- a/components/skills/meta-convert-guide/examples/concurrency.md
+++ b/components/skills/meta-convert-guide/examples/concurrency.md
@@ -1,0 +1,470 @@
+# Concurrency Examples
+
+Code examples showing concurrency pattern translation between languages.
+
+---
+
+## Promise/Future Translation
+
+### TypeScript Promise → Multiple Languages
+
+```typescript
+// TypeScript: Promise-based
+async function fetchUser(id: string): Promise<User> {
+  const response = await fetch(`/users/${id}`);
+  return response.json();
+}
+```
+
+```rust
+// Rust: Future-based (with tokio)
+async fn fetch_user(id: &str) -> Result<User, reqwest::Error> {
+    let user = reqwest::get(format!("/users/{}", id))
+        .await?
+        .json::<User>()
+        .await?;
+    Ok(user)
+}
+```
+
+```go
+// Go: goroutine with channel
+func fetchUser(id string) <-chan UserResult {
+    ch := make(chan UserResult, 1)
+    go func() {
+        resp, err := http.Get(fmt.Sprintf("/users/%s", id))
+        if err != nil {
+            ch <- UserResult{Err: err}
+            return
+        }
+        defer resp.Body.Close()
+        var user User
+        json.NewDecoder(resp.Body).Decode(&user)
+        ch <- UserResult{User: user}
+    }()
+    return ch
+}
+```
+
+```python
+# Python: asyncio
+async def fetch_user(id: str) -> User:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"/users/{id}") as response:
+            return await response.json()
+```
+
+```elixir
+# Elixir: Task-based async
+def fetch_user(id) do
+  Task.async(fn ->
+    case HTTPoison.get("http://api/users/#{id}") do
+      {:ok, %{status_code: 200, body: body}} ->
+        {:ok, Jason.decode!(body)}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end)
+  |> Task.await(5000)
+end
+```
+
+```erlang
+%% Erlang: spawned process with message passing
+fetch_user(Id) ->
+    Self = self(),
+    spawn(fun() ->
+        case httpc:request(get, {"http://api/users/" ++ Id, []}, [], []) of
+            {ok, {{_, 200, _}, _, Body}} ->
+                Self ! {user, jsx:decode(Body)};
+            {error, Reason} ->
+                Self ! {error, Reason}
+        end
+    end),
+    receive
+        {user, User} -> {ok, User};
+        {error, Reason} -> {error, Reason}
+    after 5000 ->
+        {error, timeout}
+    end.
+```
+
+---
+
+## Parallel Execution
+
+### Promise.all Equivalent
+
+```typescript
+// TypeScript: Promise.all
+const [users, orders] = await Promise.all([fetchUsers(), fetchOrders()]);
+```
+
+```rust
+// Rust: tokio::join!
+let (users, orders) = tokio::join!(
+    fetch_users(),
+    fetch_orders()
+);
+
+// Or with try_join! for Result types
+let (users, orders) = tokio::try_join!(
+    fetch_users(),
+    fetch_orders()
+)?;
+```
+
+```go
+// Go: goroutines with WaitGroup
+var wg sync.WaitGroup
+var users []User
+var orders []Order
+var usersErr, ordersErr error
+
+wg.Add(2)
+go func() {
+    defer wg.Done()
+    users, usersErr = fetchUsers()
+}()
+go func() {
+    defer wg.Done()
+    orders, ordersErr = fetchOrders()
+}()
+wg.Wait()
+
+if usersErr != nil || ordersErr != nil {
+    // handle errors
+}
+```
+
+```python
+# Python: asyncio.gather
+users, orders = await asyncio.gather(
+    fetch_users(),
+    fetch_orders()
+)
+```
+
+```elixir
+# Elixir: Task.async_stream or parallel tasks
+tasks = [
+  Task.async(fn -> fetch_users() end),
+  Task.async(fn -> fetch_orders() end)
+]
+
+[users, orders] = Task.await_many(tasks)
+```
+
+---
+
+## Racing / First to Complete
+
+```typescript
+// TypeScript: Promise.race
+const result = await Promise.race([
+  fetchFromPrimary(),
+  fetchFromBackup(),
+  timeout(5000),
+]);
+```
+
+```rust
+// Rust: tokio::select!
+let result = tokio::select! {
+    r = fetch_from_primary() => r,
+    r = fetch_from_backup() => r,
+    _ = tokio::time::sleep(Duration::from_secs(5)) => {
+        Err(Error::Timeout)
+    }
+};
+```
+
+```go
+// Go: select with channels
+select {
+case result := <-primaryChan:
+    return result, nil
+case result := <-backupChan:
+    return result, nil
+case <-time.After(5 * time.Second):
+    return nil, errors.New("timeout")
+}
+```
+
+```elixir
+# Elixir: Task with timeout
+task = Task.async(fn -> fetch_data() end)
+case Task.yield(task, 5000) || Task.shutdown(task) do
+  {:ok, result} -> {:ok, result}
+  nil -> {:error, :timeout}
+end
+```
+
+---
+
+## Channel Patterns
+
+### Producer-Consumer
+
+```go
+// Go: channel-based producer-consumer
+func producer(ch chan<- int) {
+    for i := 0; i < 100; i++ {
+        ch <- i
+    }
+    close(ch)
+}
+
+func consumer(ch <-chan int) {
+    for value := range ch {
+        process(value)
+    }
+}
+
+func main() {
+    ch := make(chan int, 10)
+    go producer(ch)
+    consumer(ch)
+}
+```
+
+```rust
+// Rust: tokio mpsc channel
+use tokio::sync::mpsc;
+
+async fn producer(tx: mpsc::Sender<i32>) {
+    for i in 0..100 {
+        tx.send(i).await.unwrap();
+    }
+}
+
+async fn consumer(mut rx: mpsc::Receiver<i32>) {
+    while let Some(value) = rx.recv().await {
+        process(value).await;
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let (tx, rx) = mpsc::channel(10);
+    tokio::spawn(producer(tx));
+    consumer(rx).await;
+}
+```
+
+```elixir
+# Elixir: GenServer as producer-consumer
+defmodule Producer do
+  use GenServer
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def produce(item), do: GenServer.cast(__MODULE__, {:produce, item})
+
+  @impl true
+  def init(_), do: {:ok, :queue.new()}
+
+  @impl true
+  def handle_cast({:produce, item}, queue) do
+    {:noreply, :queue.in(item, queue)}
+  end
+
+  @impl true
+  def handle_call(:consume, _from, queue) do
+    case :queue.out(queue) do
+      {{:value, item}, new_queue} -> {:reply, {:ok, item}, new_queue}
+      {:empty, queue} -> {:reply, :empty, queue}
+    end
+  end
+end
+```
+
+---
+
+## Mutex / Locking
+
+### Shared State Protection
+
+```typescript
+// TypeScript: no native mutex, use locks library or avoid
+import { Mutex } from "async-mutex";
+
+const mutex = new Mutex();
+let counter = 0;
+
+async function increment() {
+  const release = await mutex.acquire();
+  try {
+    counter++;
+  } finally {
+    release();
+  }
+}
+```
+
+```rust
+// Rust: Mutex
+use std::sync::{Arc, Mutex};
+
+let counter = Arc::new(Mutex::new(0));
+
+// In each thread/task
+let counter = Arc::clone(&counter);
+tokio::spawn(async move {
+    let mut guard = counter.lock().unwrap();
+    *guard += 1;
+});
+```
+
+```go
+// Go: sync.Mutex
+var mu sync.Mutex
+var counter int
+
+func increment() {
+    mu.Lock()
+    defer mu.Unlock()
+    counter++
+}
+```
+
+```python
+# Python: asyncio.Lock
+import asyncio
+
+lock = asyncio.Lock()
+counter = 0
+
+async def increment():
+    global counter
+    async with lock:
+        counter += 1
+```
+
+```elixir
+# Elixir: Agent for simple state
+{:ok, counter} = Agent.start_link(fn -> 0 end)
+
+Agent.update(counter, &(&1 + 1))
+Agent.get(counter, & &1)
+```
+
+---
+
+## Worker Pool
+
+```typescript
+// TypeScript: p-limit for concurrency control
+import pLimit from "p-limit";
+
+const limit = pLimit(5); // 5 concurrent workers
+
+const results = await Promise.all(
+  items.map((item) => limit(() => processItem(item))),
+);
+```
+
+```rust
+// Rust: tokio semaphore or buffer_unordered
+use futures::stream::{self, StreamExt};
+
+let results: Vec<_> = stream::iter(items)
+    .map(|item| process_item(item))
+    .buffer_unordered(5)  // 5 concurrent
+    .collect()
+    .await;
+```
+
+```go
+// Go: worker pool with semaphore
+sem := make(chan struct{}, 5)  // 5 workers
+results := make(chan Result, len(items))
+
+for _, item := range items {
+    sem <- struct{}{}  // acquire
+    go func(item Item) {
+        defer func() { <-sem }()  // release
+        results <- processItem(item)
+    }(item)
+}
+
+// Collect results
+for i := 0; i < len(items); i++ {
+    result := <-results
+    // handle result
+}
+```
+
+```elixir
+# Elixir: Task.async_stream with max_concurrency
+items
+|> Task.async_stream(&process_item/1, max_concurrency: 5)
+|> Enum.to_list()
+```
+
+---
+
+## Cancellation
+
+```typescript
+// TypeScript: AbortController
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+```
+
+```rust
+// Rust: tokio select for cancellation
+use tokio::time::{timeout, Duration};
+
+async fn fetch_with_timeout(url: &str, ms: u64) -> Result<Response, Error> {
+    timeout(Duration::from_millis(ms), reqwest::get(url))
+        .await
+        .map_err(|_| Error::Timeout)?
+        .map_err(Error::Request)
+}
+
+// Or explicit select
+tokio::select! {
+    result = fetch(url) => result,
+    _ = tokio::time::sleep(duration) => Err(Error::Timeout),
+}
+```
+
+```go
+// Go: Context for cancellation
+func fetchWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+
+    req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+    return http.DefaultClient.Do(req)
+}
+```
+
+```python
+# Python: asyncio.wait_for
+async def fetch_with_timeout(url: str, timeout: float):
+    try:
+        return await asyncio.wait_for(fetch(url), timeout=timeout)
+    except asyncio.TimeoutError:
+        raise TimeoutError(f"Request to {url} timed out")
+```
+
+```elixir
+# Elixir: Task with timeout
+def fetch_with_timeout(url, timeout_ms) do
+  task = Task.async(fn -> fetch(url) end)
+  case Task.yield(task, timeout_ms) do
+    {:ok, result} -> {:ok, result}
+    nil ->
+      Task.shutdown(task, :brutal_kill)
+      {:error, :timeout}
+  end
+end
+```

--- a/components/skills/meta-convert-guide/examples/error-handling.md
+++ b/components/skills/meta-convert-guide/examples/error-handling.md
@@ -1,0 +1,435 @@
+# Error Handling Examples
+
+Code examples showing error handling translation between languages.
+
+---
+
+## Exception → Result Type
+
+### TypeScript → Rust
+
+```typescript
+// TypeScript: throws exception
+function parseConfig(path: string): Config {
+  const content = fs.readFileSync(path, "utf-8");
+  try {
+    return JSON.parse(content);
+  } catch (e) {
+    throw new Error(`Failed to parse config: ${e.message}`);
+  }
+}
+
+// Usage
+try {
+  const config = parseConfig("config.json");
+  console.log(config);
+} catch (e) {
+  console.error("Config error:", e);
+}
+```
+
+```rust
+// Rust: returns Result
+fn parse_config(path: &Path) -> Result<Config, ConfigError> {
+    let content = fs::read_to_string(path)
+        .map_err(|e| ConfigError::ReadFailed(e))?;
+    serde_json::from_str(&content)
+        .map_err(|e| ConfigError::ParseFailed(e))
+}
+
+// Usage
+match parse_config(Path::new("config.json")) {
+    Ok(config) => println!("{:?}", config),
+    Err(e) => eprintln!("Config error: {}", e),
+}
+
+// Or with ? in caller
+let config = parse_config(Path::new("config.json"))?;
+```
+
+---
+
+## Exception → Error Return
+
+### TypeScript → Go
+
+```typescript
+// TypeScript: throws
+function divide(a: number, b: number): number {
+  if (b === 0) throw new Error("division by zero");
+  return a / b;
+}
+
+// Usage
+try {
+  const result = divide(10, 0);
+} catch (e) {
+  console.error(e.message);
+}
+```
+
+```go
+// Go: error return
+func divide(a, b float64) (float64, error) {
+    if b == 0 {
+        return 0, errors.New("division by zero")
+    }
+    return a / b, nil
+}
+
+// Usage
+result, err := divide(10, 0)
+if err != nil {
+    log.Printf("Error: %v", err)
+    return
+}
+fmt.Println(result)
+```
+
+---
+
+## Error Hierarchy Translation
+
+### TypeScript Class Hierarchy → Rust Enum
+
+```typescript
+// TypeScript: class hierarchy
+class AppError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+  ) {
+    super(message);
+    this.name = "AppError";
+  }
+}
+
+class NotFoundError extends AppError {
+  constructor(resource: string) {
+    super(`${resource} not found`, "NOT_FOUND");
+  }
+}
+
+class ValidationError extends AppError {
+  constructor(
+    message: string,
+    public field: string,
+  ) {
+    super(message, "VALIDATION");
+  }
+}
+
+// Usage
+function findUser(id: string): User {
+  const user = db.get(id);
+  if (!user) throw new NotFoundError("User");
+  return user;
+}
+```
+
+```rust
+// Rust: enum variants with thiserror
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum AppError {
+    #[error("{resource} not found")]
+    NotFound { resource: String },
+
+    #[error("validation failed on {field}: {message}")]
+    Validation { field: String, message: String },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+}
+
+// Usage
+fn find_user(id: &str) -> Result<User, AppError> {
+    db.get(id).ok_or_else(|| AppError::NotFound {
+        resource: "User".into()
+    })
+}
+```
+
+---
+
+## Python Exception → Rust Result
+
+```python
+# Python: exceptions with context
+class UserError(Exception):
+    pass
+
+class NotFoundError(UserError):
+    def __init__(self, resource: str, id: str):
+        self.resource = resource
+        self.id = id
+        super().__init__(f"{resource} with id {id} not found")
+
+def get_user(user_id: str) -> User:
+    try:
+        return db.query(User).get(user_id)
+    except DatabaseError as e:
+        raise UserError(f"Database failed: {e}") from e
+    if user is None:
+        raise NotFoundError("User", user_id)
+    return user
+```
+
+```rust
+// Rust: error types with context
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum UserError {
+    #[error("{resource} with id {id} not found")]
+    NotFound { resource: String, id: String },
+
+    #[error("database failed")]
+    Database(#[from] sqlx::Error),
+}
+
+fn get_user(user_id: &str) -> Result<User, UserError> {
+    let user = db.query::<User>()
+        .get(user_id)?;  // Database errors auto-convert
+
+    user.ok_or_else(|| UserError::NotFound {
+        resource: "User".into(),
+        id: user_id.into(),
+    })
+}
+```
+
+---
+
+## Go Error → Rust Result
+
+```go
+// Go: error wrapping
+import (
+    "errors"
+    "fmt"
+)
+
+var ErrNotFound = errors.New("not found")
+var ErrValidation = errors.New("validation failed")
+
+func GetUser(id string) (*User, error) {
+    user, err := db.Query(id)
+    if err != nil {
+        return nil, fmt.Errorf("database query: %w", err)
+    }
+    if user == nil {
+        return nil, fmt.Errorf("user %s: %w", id, ErrNotFound)
+    }
+    return user, nil
+}
+
+// Checking error type
+if errors.Is(err, ErrNotFound) {
+    // handle not found
+}
+```
+
+```rust
+// Rust: equivalent pattern
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum UserError {
+    #[error("user {0} not found")]
+    NotFound(String),
+
+    #[error("database query failed")]
+    Database(#[from] sqlx::Error),
+}
+
+fn get_user(id: &str) -> Result<User, UserError> {
+    let user = db.query(id)?;  // auto-wraps database errors
+
+    user.ok_or_else(|| UserError::NotFound(id.into()))
+}
+
+// Checking error type
+match result {
+    Err(UserError::NotFound(id)) => { /* handle */ }
+    Err(UserError::Database(e)) => { /* handle */ }
+    Ok(user) => { /* success */ }
+}
+```
+
+---
+
+## Elixir Pattern Matching → Other Languages
+
+```elixir
+# Elixir: tuple-based errors with pattern matching
+def get_user(id) do
+  case Repo.get(User, id) do
+    nil -> {:error, :not_found}
+    user -> {:ok, user}
+  end
+end
+
+def create_order(user_id, items) do
+  with {:ok, user} <- get_user(user_id),
+       {:ok, validated} <- validate_items(items),
+       {:ok, order} <- Repo.insert(%Order{user: user, items: validated}) do
+    {:ok, order}
+  else
+    {:error, :not_found} -> {:error, "User not found"}
+    {:error, :invalid_items} -> {:error, "Invalid items"}
+    {:error, changeset} -> {:error, format_errors(changeset)}
+  end
+end
+```
+
+```rust
+// Rust: Result chaining
+fn get_user(id: i64) -> Result<User, UserError> {
+    repo.get::<User>(id)
+        .ok_or(UserError::NotFound)
+}
+
+fn create_order(user_id: i64, items: Vec<Item>) -> Result<Order, OrderError> {
+    let user = get_user(user_id)
+        .map_err(|_| OrderError::UserNotFound)?;
+
+    let validated = validate_items(&items)
+        .map_err(|_| OrderError::InvalidItems)?;
+
+    repo.insert(Order::new(user, validated))
+        .map_err(OrderError::Database)
+}
+```
+
+```typescript
+// TypeScript: Result type pattern (neverthrow library)
+import { ok, err, Result } from "neverthrow";
+
+function getUser(id: string): Result<User, "not_found"> {
+  const user = repo.get(id);
+  return user ? ok(user) : err("not_found");
+}
+
+function createOrder(
+  userId: string,
+  items: Item[],
+): Result<Order, OrderError> {
+  return getUser(userId)
+    .mapErr(() => ({ type: "user_not_found" as const }))
+    .andThen((user) =>
+      validateItems(items)
+        .mapErr(() => ({ type: "invalid_items" as const }))
+        .map((validated) => ({ user, validated })),
+    )
+    .andThen(({ user, validated }) => repo.insert(new Order(user, validated)));
+}
+```
+
+---
+
+## Error Context / Wrapping
+
+### Adding Context to Errors
+
+```typescript
+// TypeScript: error cause (ES2022)
+try {
+  await fetchData();
+} catch (e) {
+  throw new Error("Failed to load user data", { cause: e });
+}
+```
+
+```rust
+// Rust: anyhow for context
+use anyhow::{Context, Result};
+
+fn load_user_data() -> Result<UserData> {
+    let response = fetch_data()
+        .context("Failed to fetch from API")?;
+
+    parse_response(response)
+        .context("Failed to parse user data")
+}
+```
+
+```go
+// Go: fmt.Errorf with %w
+func loadUserData() (*UserData, error) {
+    response, err := fetchData()
+    if err != nil {
+        return nil, fmt.Errorf("failed to fetch from API: %w", err)
+    }
+
+    data, err := parseResponse(response)
+    if err != nil {
+        return nil, fmt.Errorf("failed to parse user data: %w", err)
+    }
+
+    return data, nil
+}
+```
+
+```python
+# Python: exception chaining
+try:
+    response = fetch_data()
+except RequestError as e:
+    raise UserDataError("Failed to fetch from API") from e
+
+try:
+    data = parse_response(response)
+except ParseError as e:
+    raise UserDataError("Failed to parse user data") from e
+```
+
+---
+
+## Panic vs Error
+
+### When to Panic/Crash
+
+| Scenario | Rust | Go | Elixir |
+|----------|------|-----|--------|
+| Invalid args (programmer error) | `panic!` | `panic()` | `raise` |
+| Recoverable failure | `Result<T, E>` | `error` return | `{:error, reason}` |
+| Unrecoverable state | `panic!` | `panic()` | Supervisor restart |
+| Out of memory | `panic!` (implicit) | `panic()` | VM handles |
+
+```rust
+// Rust: panic for invariant violations
+fn get_index(items: &[Item], index: usize) -> &Item {
+    // Panic if index out of bounds - programmer error
+    &items[index]
+}
+
+// Result for expected failures
+fn find_by_id(items: &[Item], id: &str) -> Option<&Item> {
+    items.iter().find(|i| i.id == id)
+}
+```
+
+```go
+// Go: panic for unrecoverable, error for expected
+func mustParseConfig(path string) Config {
+    config, err := parseConfig(path)
+    if err != nil {
+        panic(fmt.Sprintf("invalid config: %v", err))
+    }
+    return config
+}
+
+func parseConfig(path string) (Config, error) {
+    // Returns error for handling
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return Config{}, err
+    }
+    // ...
+}
+```

--- a/components/skills/meta-convert-guide/examples/idiom-translation.md
+++ b/components/skills/meta-convert-guide/examples/idiom-translation.md
@@ -1,0 +1,480 @@
+# Idiom Translation Examples
+
+Code examples showing idiomatic translations between languages.
+
+> **Philosophy**: Adopt target idioms, don't write "Source code in Target syntax"
+
+---
+
+## Translation Approaches
+
+| Approach | When to Use | Example |
+|----------|-------------|---------|
+| **Literal** | Simple operations, primitives | `x + y` → `x + y` |
+| **Semantic** | Same concept, different syntax | `arr.map()` → `.iter().map()` |
+| **Idiomatic** | Different paradigm | Class hierarchy → Trait + Structs |
+| **Redesign** | No equivalent | Prototype chain → Explicit composition |
+
+---
+
+## Null Handling
+
+### TypeScript → Multiple Languages
+
+```typescript
+// TypeScript: null coalescing
+const name = user?.name ?? "Anonymous";
+```
+
+```rust
+// Rust: Option combinators
+let name = user.as_ref()
+    .map(|u| u.name.as_str())
+    .unwrap_or("Anonymous");
+```
+
+```go
+// Go: explicit nil check
+var name string
+if user != nil && user.Name != "" {
+    name = user.Name
+} else {
+    name = "Anonymous"
+}
+```
+
+```python
+# Python: or operator (careful with falsy values)
+name = (user and user.name) or "Anonymous"
+
+# Safer Python
+name = user.name if user and user.name else "Anonymous"
+```
+
+```elixir
+# Elixir: pattern matching with default
+name = case user do
+  %{name: name} when name != nil -> name
+  _ -> "Anonymous"
+end
+
+# Or with || operator
+name = (user && user.name) || "Anonymous"
+```
+
+```clojure
+;; Clojure: or with get
+(def name (or (:name user) "Anonymous"))
+
+;; With some->
+(def name (or (some-> user :name) "Anonymous"))
+```
+
+---
+
+## Collection Operations
+
+### Filter + Map + Reduce
+
+```typescript
+// TypeScript: chained methods
+const result = items
+  .filter((x) => x.active)
+  .map((x) => x.value)
+  .reduce((a, b) => a + b, 0);
+```
+
+```rust
+// Rust: iterator adaptors
+let result: i32 = items.iter()
+    .filter(|x| x.active)
+    .map(|x| x.value)
+    .sum();
+```
+
+```go
+// Go: explicit loops (pre-generics style)
+var result int
+for _, x := range items {
+    if x.Active {
+        result += x.Value
+    }
+}
+```
+
+```python
+# Python: generator expressions
+result = sum(x.value for x in items if x.active)
+```
+
+```elixir
+# Elixir: pipe operator
+result = items
+  |> Enum.filter(& &1.active)
+  |> Enum.map(& &1.value)
+  |> Enum.sum()
+```
+
+```clojure
+;; Clojure: threading macro
+(def result
+  (->> items
+       (filter :active)
+       (map :value)
+       (reduce + 0)))
+```
+
+```haskell
+-- Haskell: function composition
+result = sum $ map value $ filter active items
+
+-- Or with & operator (left-to-right)
+result = items & filter active & map value & sum
+```
+
+---
+
+## Finding Elements
+
+### Find First Match
+
+```typescript
+// TypeScript
+const user = users.find((u) => u.id === id);
+if (user) {
+  process(user);
+}
+```
+
+```rust
+// Rust
+if let Some(user) = users.iter().find(|u| u.id == id) {
+    process(user);
+}
+```
+
+```go
+// Go
+var found *User
+for _, u := range users {
+    if u.ID == id {
+        found = &u
+        break
+    }
+}
+if found != nil {
+    process(found)
+}
+```
+
+```python
+# Python
+user = next((u for u in users if u.id == id), None)
+if user:
+    process(user)
+```
+
+```elixir
+# Elixir
+case Enum.find(users, fn u -> u.id == id end) do
+  nil -> :not_found
+  user -> process(user)
+end
+```
+
+---
+
+## Grouping Data
+
+### Group By Key
+
+```typescript
+// TypeScript
+const grouped = items.reduce(
+  (acc, item) => {
+    const key = item.category;
+    acc[key] = acc[key] || [];
+    acc[key].push(item);
+    return acc;
+  },
+  {} as Record<string, Item[]>,
+);
+```
+
+```rust
+// Rust: use itertools or fold
+use itertools::Itertools;
+
+let grouped: HashMap<String, Vec<&Item>> = items
+    .iter()
+    .into_group_map_by(|item| item.category.clone());
+
+// Or with fold
+let grouped = items.iter().fold(
+    HashMap::new(),
+    |mut acc, item| {
+        acc.entry(item.category.clone())
+           .or_insert_with(Vec::new)
+           .push(item);
+        acc
+    }
+);
+```
+
+```python
+# Python: defaultdict
+from collections import defaultdict
+
+grouped = defaultdict(list)
+for item in items:
+    grouped[item.category].append(item)
+
+# Or with itertools
+from itertools import groupby
+grouped = {k: list(v) for k, v in groupby(sorted(items, key=lambda x: x.category), key=lambda x: x.category)}
+```
+
+```elixir
+# Elixir
+grouped = Enum.group_by(items, & &1.category)
+```
+
+```clojure
+;; Clojure
+(def grouped (group-by :category items))
+```
+
+---
+
+## String Building
+
+### Concatenation Patterns
+
+```typescript
+// TypeScript: template literals
+const message = `Hello, ${user.name}! You have ${count} items.`;
+```
+
+```rust
+// Rust: format! macro
+let message = format!("Hello, {}! You have {} items.", user.name, count);
+```
+
+```go
+// Go: fmt.Sprintf
+message := fmt.Sprintf("Hello, %s! You have %d items.", user.Name, count)
+```
+
+```python
+# Python: f-strings
+message = f"Hello, {user.name}! You have {count} items."
+```
+
+```elixir
+# Elixir: string interpolation
+message = "Hello, #{user.name}! You have #{count} items."
+```
+
+### Building Large Strings
+
+```typescript
+// TypeScript: array join
+const parts: string[] = [];
+for (const item of items) {
+  parts.push(item.name);
+}
+const result = parts.join(", ");
+```
+
+```rust
+// Rust: collect with join (preferred)
+let result: String = items
+    .iter()
+    .map(|item| item.name.as_str())
+    .collect::<Vec<_>>()
+    .join(", ");
+
+// Or itertools
+use itertools::Itertools;
+let result = items.iter().map(|i| &i.name).join(", ");
+```
+
+```go
+// Go: strings.Builder
+var builder strings.Builder
+for i, item := range items {
+    if i > 0 {
+        builder.WriteString(", ")
+    }
+    builder.WriteString(item.Name)
+}
+result := builder.String()
+```
+
+```python
+# Python: join
+result = ", ".join(item.name for item in items)
+```
+
+---
+
+## Early Return Patterns
+
+### Guard Clauses
+
+```typescript
+// TypeScript
+function process(user: User | null): Result {
+  if (!user) return { error: "No user" };
+  if (!user.active) return { error: "Inactive" };
+  if (!user.verified) return { error: "Not verified" };
+
+  return { data: doWork(user) };
+}
+```
+
+```rust
+// Rust: ? operator with Result
+fn process(user: Option<&User>) -> Result<Data, Error> {
+    let user = user.ok_or(Error::NoUser)?;
+    if !user.active { return Err(Error::Inactive); }
+    if !user.verified { return Err(Error::NotVerified); }
+
+    Ok(do_work(user))
+}
+```
+
+```go
+// Go: early returns
+func process(user *User) (Result, error) {
+    if user == nil {
+        return Result{}, errors.New("no user")
+    }
+    if !user.Active {
+        return Result{}, errors.New("inactive")
+    }
+    if !user.Verified {
+        return Result{}, errors.New("not verified")
+    }
+
+    return doWork(user), nil
+}
+```
+
+```elixir
+# Elixir: with statement
+def process(user) do
+  with {:ok, user} <- validate_exists(user),
+       {:ok, user} <- validate_active(user),
+       {:ok, user} <- validate_verified(user) do
+    {:ok, do_work(user)}
+  end
+end
+```
+
+---
+
+## Pattern Matching
+
+### Destructuring
+
+```typescript
+// TypeScript
+const { name, age, email } = user;
+const [first, second, ...rest] = items;
+```
+
+```rust
+// Rust
+let User { name, age, email, .. } = user;
+let [first, second, rest @ ..] = items[..] else { panic!() };
+
+// Or with slice patterns
+if let [first, second, rest @ ..] = &items[..] {
+    // use first, second, rest
+}
+```
+
+```python
+# Python
+name, age, email = user.name, user.age, user.email
+first, second, *rest = items
+```
+
+```elixir
+# Elixir
+%{name: name, age: age, email: email} = user
+[first, second | rest] = items
+```
+
+```clojure
+;; Clojure
+(let [{:keys [name age email]} user
+      [first second & rest] items]
+  ...)
+```
+
+---
+
+## Default Values
+
+### With Fallbacks
+
+```typescript
+// TypeScript
+function greet(name?: string, greeting = "Hello") {
+  return `${greeting}, ${name ?? "World"}!`;
+}
+```
+
+```rust
+// Rust: Option with unwrap_or
+fn greet(name: Option<&str>, greeting: Option<&str>) -> String {
+    let name = name.unwrap_or("World");
+    let greeting = greeting.unwrap_or("Hello");
+    format!("{}, {}!", greeting, name)
+}
+
+// Or with Default trait for structs
+#[derive(Default)]
+struct Config {
+    timeout: u32,  // defaults to 0
+    retries: u32,  // defaults to 0
+}
+
+impl Config {
+    fn new() -> Self {
+        Self {
+            timeout: 30,
+            retries: 3,
+            ..Default::default()
+        }
+    }
+}
+```
+
+```go
+// Go: explicit checks
+func greet(name, greeting string) string {
+    if name == "" {
+        name = "World"
+    }
+    if greeting == "" {
+        greeting = "Hello"
+    }
+    return fmt.Sprintf("%s, %s!", greeting, name)
+}
+```
+
+```python
+# Python
+def greet(name: str = "World", greeting: str = "Hello") -> str:
+    return f"{greeting}, {name}!"
+```
+
+```elixir
+# Elixir: default arguments
+def greet(name \\ "World", greeting \\ "Hello") do
+  "#{greeting}, #{name}!"
+end
+```

--- a/components/skills/meta-convert-guide/examples/metaprogramming.md
+++ b/components/skills/meta-convert-guide/examples/metaprogramming.md
@@ -1,0 +1,532 @@
+# Metaprogramming Examples
+
+Code examples showing metaprogramming pattern translation between languages.
+
+---
+
+## Decorator → Attribute Translation
+
+### TypeScript Decorators → Rust Attributes
+
+```typescript
+// TypeScript: Decorators (class/method/property)
+@Controller("/users")
+class UserController {
+  @Get("/:id")
+  @Authenticate
+  async getUser(@Param("id") id: string): Promise<User> {
+    return this.userService.find(id);
+  }
+}
+```
+
+```rust
+// Rust: Attributes + Proc Macros (axum style)
+#[derive(Clone)]
+struct UserController {
+    user_service: Arc<UserService>,
+}
+
+impl UserController {
+    async fn get_user(
+        State(controller): State<Self>,
+        Path(id): Path<String>,
+        _auth: AuthenticatedUser,  // extractor handles auth
+    ) -> Result<Json<User>, AppError> {
+        let user = controller.user_service.find(&id).await?;
+        Ok(Json(user))
+    }
+}
+
+// Router setup
+let app = Router::new()
+    .route("/users/:id", get(UserController::get_user))
+    .with_state(controller);
+```
+
+### TypeScript → Python
+
+```typescript
+// TypeScript: Method decorator
+function Log(target: any, key: string, descriptor: PropertyDescriptor) {
+  const original = descriptor.value;
+  descriptor.value = function (...args: any[]) {
+    console.log(`Calling ${key} with`, args);
+    return original.apply(this, args);
+  };
+}
+
+class Service {
+  @Log
+  process(data: string): string {
+    return data.toUpperCase();
+  }
+}
+```
+
+```python
+# Python: Decorator function
+from functools import wraps
+
+def log(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        print(f"Calling {func.__name__} with {args}, {kwargs}")
+        return func(*args, **kwargs)
+    return wrapper
+
+class Service:
+    @log
+    def process(self, data: str) -> str:
+        return data.upper()
+```
+
+### TypeScript → Go
+
+```typescript
+// TypeScript: Decorator for metadata
+@Controller("/users")
+class UserController {
+  @Get("/:id")
+  getUser(@Param("id") id: string): User {
+    // ...
+  }
+}
+```
+
+```go
+// Go: No decorators - use struct tags + code generation
+// go:generate annotations or explicit registration
+
+type UserController struct{}
+
+type GetUserRequest struct {
+    ID string `path:"id" validate:"required"`
+}
+
+func (c *UserController) GetUser(ctx context.Context, req GetUserRequest) (*User, error) {
+    return c.userService.Find(ctx, req.ID)
+}
+
+// Manual route registration
+func RegisterRoutes(r *mux.Router, c *UserController) {
+    r.HandleFunc("/users/{id}", c.handleGetUser).Methods("GET")
+}
+```
+
+---
+
+## Macro Translation
+
+### Clojure Macro → Rust Macro
+
+```clojure
+;; Clojure: Macro for compile-time transformation
+(defmacro unless [pred & body]
+  `(if (not ~pred)
+     (do ~@body)))
+
+(unless (empty? items)
+  (process items))
+```
+
+```rust
+// Rust: Declarative macro equivalent
+macro_rules! unless {
+    ($pred:expr, $body:block) => {
+        if !$pred $body
+    };
+}
+
+unless!(items.is_empty(), {
+    process(&items);
+});
+```
+
+### Elixir Macro → Rust Macro
+
+```elixir
+# Elixir: Hygienic macro
+defmacro unless(pred, do: body) do
+  quote do
+    if !unquote(pred), do: unquote(body)
+  end
+end
+
+unless Enum.empty?(items) do
+  process(items)
+end
+```
+
+```rust
+// Rust: Declarative macro (hygienic by default)
+macro_rules! unless {
+    ($pred:expr, $body:expr) => {
+        if !$pred { $body }
+    };
+}
+
+unless!(items.is_empty(), process(&items));
+```
+
+---
+
+## Mixin / Trait Composition
+
+### TypeScript Mixin → Rust Derive
+
+```typescript
+// TypeScript: Mixin pattern
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+function Timestamped<TBase extends Constructor>(Base: TBase) {
+  return class extends Base {
+    createdAt = new Date();
+    updatedAt = new Date();
+  };
+}
+
+class User extends Timestamped(BaseModel) {
+  name: string;
+}
+```
+
+```rust
+// Rust: Trait + derive macro
+use chrono::{DateTime, Utc};
+
+// Define trait
+trait Timestamped {
+    fn created_at(&self) -> DateTime<Utc>;
+    fn updated_at(&self) -> DateTime<Utc>;
+}
+
+// Derive macro (would be defined in proc macro crate)
+#[derive(Timestamped)]
+struct User {
+    name: String,
+    // created_at and updated_at added by derive macro
+}
+
+// Or manual implementation with composition
+struct User {
+    name: String,
+    timestamps: Timestamps,
+}
+
+struct Timestamps {
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+```
+
+### Python Mixin → Rust Trait
+
+```python
+# Python: Multiple inheritance (mixin classes)
+class TimestampedMixin:
+    created_at: datetime
+    updated_at: datetime
+
+    def touch(self):
+        self.updated_at = datetime.now()
+
+class AuditableMixin:
+    created_by: str
+    updated_by: str
+
+class User(TimestampedMixin, AuditableMixin, BaseModel):
+    name: str
+```
+
+```rust
+// Rust: Multiple trait implementations
+trait Timestamped {
+    fn created_at(&self) -> DateTime<Utc>;
+    fn updated_at(&self) -> DateTime<Utc>;
+    fn touch(&mut self);
+}
+
+trait Auditable {
+    fn created_by(&self) -> &str;
+    fn updated_by(&self) -> &str;
+}
+
+struct User {
+    name: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    created_by: String,
+    updated_by: String,
+}
+
+impl Timestamped for User {
+    fn created_at(&self) -> DateTime<Utc> { self.created_at }
+    fn updated_at(&self) -> DateTime<Utc> { self.updated_at }
+    fn touch(&mut self) { self.updated_at = Utc::now(); }
+}
+
+impl Auditable for User {
+    fn created_by(&self) -> &str { &self.created_by }
+    fn updated_by(&self) -> &str { &self.updated_by }
+}
+```
+
+---
+
+## Dependency Injection
+
+### TypeScript DI → Rust Constructor Injection
+
+```typescript
+// TypeScript: Decorator-based DI (NestJS style)
+@Injectable()
+class UserService {
+  constructor(
+    @Inject("DATABASE") private db: Database,
+    private logger: Logger,
+  ) {}
+
+  async findUser(id: string): Promise<User> {
+    this.logger.info(`Finding user ${id}`);
+    return this.db.query("SELECT * FROM users WHERE id = ?", [id]);
+  }
+}
+
+// Module configuration
+@Module({
+  providers: [
+    UserService,
+    { provide: "DATABASE", useClass: PostgresDatabase },
+    Logger,
+  ],
+})
+class UserModule {}
+```
+
+```rust
+// Rust: Constructor injection (no runtime DI)
+struct UserService {
+    db: Arc<dyn Database>,
+    logger: Arc<dyn Logger>,
+}
+
+impl UserService {
+    fn new(db: Arc<dyn Database>, logger: Arc<dyn Logger>) -> Self {
+        Self { db, logger }
+    }
+
+    async fn find_user(&self, id: &str) -> Result<User, Error> {
+        self.logger.info(&format!("Finding user {}", id));
+        self.db.query("SELECT * FROM users WHERE id = ?", &[id]).await
+    }
+}
+
+// Composition root (main.rs or similar)
+fn create_services() -> UserService {
+    let db: Arc<dyn Database> = Arc::new(PostgresDatabase::new());
+    let logger: Arc<dyn Logger> = Arc::new(ConsoleLogger::new());
+    UserService::new(db, logger)
+}
+```
+
+### TypeScript DI → Go Interface Injection
+
+```typescript
+// TypeScript: Interface-based DI
+interface Logger {
+  info(msg: string): void;
+}
+
+@Injectable()
+class UserService {
+  constructor(private logger: Logger) {}
+}
+```
+
+```go
+// Go: Interface-based DI (idiomatic)
+type Logger interface {
+    Info(msg string)
+}
+
+type UserService struct {
+    logger Logger
+}
+
+func NewUserService(logger Logger) *UserService {
+    return &UserService{logger: logger}
+}
+
+func (s *UserService) FindUser(id string) (*User, error) {
+    s.logger.Info(fmt.Sprintf("Finding user %s", id))
+    // ...
+}
+
+// Wire up in main
+func main() {
+    logger := NewConsoleLogger()
+    userService := NewUserService(logger)
+    // ...
+}
+```
+
+---
+
+## Reflection
+
+### Python Reflection → Rust Alternatives
+
+```python
+# Python: Dynamic attribute access
+class Config:
+    host: str = "localhost"
+    port: int = 8080
+
+def get_field(obj, name: str):
+    return getattr(obj, name)
+
+def set_field(obj, name: str, value):
+    setattr(obj, name, value)
+
+def list_fields(obj):
+    return [k for k in dir(obj) if not k.startswith('_')]
+```
+
+```rust
+// Rust: No runtime reflection - use macros or traits
+
+// Option 1: Enum for known fields
+enum ConfigField {
+    Host,
+    Port,
+}
+
+impl Config {
+    fn get_field(&self, field: ConfigField) -> String {
+        match field {
+            ConfigField::Host => self.host.clone(),
+            ConfigField::Port => self.port.to_string(),
+        }
+    }
+}
+
+// Option 2: Derive macro for reflection-like behavior
+// (using serde as example)
+#[derive(Serialize, Deserialize)]
+struct Config {
+    host: String,
+    port: u16,
+}
+
+// Access fields via serialization
+let json = serde_json::to_value(&config)?;
+let host = json.get("host");
+
+// Option 3: Trait for known behavior
+trait Configurable {
+    fn get(&self, key: &str) -> Option<String>;
+    fn set(&mut self, key: &str, value: &str) -> Result<(), Error>;
+    fn fields(&self) -> Vec<&str>;
+}
+```
+
+### TypeScript Reflection → Go Struct Tags
+
+```typescript
+// TypeScript: Reflect metadata
+import "reflect-metadata";
+
+class User {
+  @Column("varchar")
+  name: string;
+
+  @Column("int")
+  age: number;
+}
+
+// Read metadata
+const columns = Reflect.getMetadata("columns", User);
+```
+
+```go
+// Go: Struct tags + reflect package
+type User struct {
+    Name string `db:"name" type:"varchar"`
+    Age  int    `db:"age" type:"int"`
+}
+
+func GetColumns(v interface{}) map[string]string {
+    columns := make(map[string]string)
+    t := reflect.TypeOf(v)
+    for i := 0; i < t.NumField(); i++ {
+        field := t.Field(i)
+        dbName := field.Tag.Get("db")
+        dbType := field.Tag.Get("type")
+        if dbName != "" {
+            columns[dbName] = dbType
+        }
+    }
+    return columns
+}
+```
+
+---
+
+## Code Generation
+
+### Runtime Code Gen → Compile-Time
+
+```python
+# Python: Runtime class creation
+def create_model(name: str, fields: dict):
+    return type(name, (), fields)
+
+User = create_model('User', {
+    'name': '',
+    'age': 0,
+    '__init__': lambda self, name, age: setattr(self, 'name', name) or setattr(self, 'age', age)
+})
+```
+
+```rust
+// Rust: Compile-time macro
+macro_rules! create_model {
+    ($name:ident { $($field:ident: $type:ty),* $(,)? }) => {
+        #[derive(Debug, Default)]
+        struct $name {
+            $($field: $type),*
+        }
+
+        impl $name {
+            fn new($($field: $type),*) -> Self {
+                Self { $($field),* }
+            }
+        }
+    };
+}
+
+create_model!(User {
+    name: String,
+    age: u32,
+});
+
+// Usage
+let user = User::new("Alice".into(), 30);
+```
+
+```go
+// Go: go generate + text templates
+//go:generate go run gen.go
+
+// gen.go creates model code at build time
+// models_gen.go (generated):
+type User struct {
+    Name string
+    Age  int
+}
+
+func NewUser(name string, age int) *User {
+    return &User{Name: name, Age: age}
+}
+```

--- a/components/skills/meta-convert-guide/examples/serialization.md
+++ b/components/skills/meta-convert-guide/examples/serialization.md
@@ -1,0 +1,534 @@
+# Serialization Examples
+
+Code examples showing serialization pattern translation between languages.
+
+---
+
+## Basic JSON Serialization
+
+### TypeScript → Multiple Languages
+
+```typescript
+// TypeScript: class-transformer decorators
+import { Expose, Exclude, Transform, Type } from "class-transformer";
+
+class User {
+  @Expose()
+  id: string;
+
+  @Expose({ name: "full_name" })
+  fullName: string;
+
+  @Type(() => Date)
+  @Transform(({ value }) => new Date(value))
+  createdAt: Date;
+
+  @Exclude()
+  password: string;
+}
+```
+
+```rust
+// Rust: serde attributes
+use serde::{Serialize, Deserialize};
+use chrono::{DateTime, Utc};
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    id: String,
+
+    #[serde(rename = "full_name")]
+    full_name: String,
+
+    #[serde(with = "chrono::serde::ts_seconds")]
+    created_at: DateTime<Utc>,
+
+    #[serde(skip)]
+    password: String,
+}
+```
+
+```python
+# Python: Pydantic with field configuration
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+class User(BaseModel):
+    id: str
+    full_name: str = Field(alias="fullName")
+    created_at: datetime
+    password: str = Field(exclude=True)
+
+    class Config:
+        populate_by_name = True
+```
+
+```go
+// Go: struct tags
+type User struct {
+    ID        string    `json:"id"`
+    FullName  string    `json:"full_name"`
+    CreatedAt time.Time `json:"created_at"`
+    Password  string    `json:"-"`  // excluded
+}
+```
+
+```elixir
+# Elixir: Jason with derived encoder
+defmodule User do
+  @derive {Jason.Encoder, only: [:id, :full_name, :created_at]}
+  defstruct [:id, :full_name, :created_at, :password]
+end
+
+# Or with custom encoding
+defimpl Jason.Encoder, for: User do
+  def encode(%User{} = user, opts) do
+    Jason.Encode.map(%{
+      id: user.id,
+      full_name: user.full_name,
+      created_at: DateTime.to_iso8601(user.created_at)
+    }, opts)
+  end
+end
+```
+
+---
+
+## Validation
+
+### TypeScript Zod → Rust validator
+
+```typescript
+// TypeScript: Zod schema
+import { z } from "zod";
+
+const UserSchema = z.object({
+  email: z.string().email(),
+  age: z.number().min(0).max(150),
+  role: z.enum(["admin", "user", "guest"]),
+});
+
+type User = z.infer<typeof UserSchema>;
+
+// Validation
+const result = UserSchema.safeParse(input);
+if (result.success) {
+  const user = result.data;
+} else {
+  console.error(result.error);
+}
+```
+
+```rust
+// Rust: validator crate
+use validator::Validate;
+use serde::Deserialize;
+
+#[derive(Validate, Deserialize)]
+struct User {
+    #[validate(email)]
+    email: String,
+
+    #[validate(range(min = 0, max = 150))]
+    age: u8,
+
+    role: Role,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Role {
+    Admin,
+    User,
+    Guest,
+}
+
+// Validation
+fn validate_user(input: &str) -> Result<User, Error> {
+    let user: User = serde_json::from_str(input)?;
+    user.validate()?;
+    Ok(user)
+}
+```
+
+### TypeScript Zod → Python Pydantic
+
+```typescript
+// TypeScript: Zod with custom validation
+const OrderSchema = z.object({
+  items: z.array(z.string()).min(1, "At least one item required"),
+  total: z.number().positive(),
+  discount: z.number().min(0).max(100).optional(),
+});
+```
+
+```python
+# Python: Pydantic with validators
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional
+
+class Order(BaseModel):
+    items: list[str] = Field(min_length=1)
+    total: float = Field(gt=0)
+    discount: Optional[float] = Field(default=None, ge=0, le=100)
+
+    @field_validator('items')
+    @classmethod
+    def items_not_empty(cls, v):
+        if not v:
+            raise ValueError('At least one item required')
+        return v
+```
+
+---
+
+## Polymorphic / Tagged Union
+
+### TypeScript Discriminated Union → Rust Tagged Enum
+
+```typescript
+// TypeScript: Discriminated union
+type Shape =
+  | { type: "circle"; radius: number }
+  | { type: "rectangle"; width: number; height: number }
+  | { type: "triangle"; base: number; height: number };
+
+// Serializes as: {"type": "circle", "radius": 5}
+```
+
+```rust
+// Rust: Tagged enum (serde)
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+    Triangle { base: f64, height: f64 },
+}
+
+// Serializes as: {"type": "circle", "radius": 5}
+```
+
+```python
+# Python: Pydantic with discriminator
+from pydantic import BaseModel, Field
+from typing import Literal, Union
+
+class Circle(BaseModel):
+    type: Literal["circle"] = "circle"
+    radius: float
+
+class Rectangle(BaseModel):
+    type: Literal["rectangle"] = "rectangle"
+    width: float
+    height: float
+
+class Triangle(BaseModel):
+    type: Literal["triangle"] = "triangle"
+    base: float
+    height: float
+
+Shape = Union[Circle, Rectangle, Triangle]
+
+# Or with discriminated union (Pydantic v2)
+from pydantic import Discriminator
+
+Shape = Annotated[
+    Union[Circle, Rectangle, Triangle],
+    Discriminator("type")
+]
+```
+
+```go
+// Go: Interface with type field
+type Shape interface {
+    ShapeType() string
+}
+
+type Circle struct {
+    Type   string  `json:"type"`
+    Radius float64 `json:"radius"`
+}
+func (c Circle) ShapeType() string { return "circle" }
+
+type Rectangle struct {
+    Type   string  `json:"type"`
+    Width  float64 `json:"width"`
+    Height float64 `json:"height"`
+}
+func (r Rectangle) ShapeType() string { return "rectangle" }
+
+// Custom unmarshaling needed for polymorphic JSON
+func UnmarshalShape(data []byte) (Shape, error) {
+    var raw struct { Type string `json:"type"` }
+    json.Unmarshal(data, &raw)
+
+    switch raw.Type {
+    case "circle":
+        var c Circle
+        err := json.Unmarshal(data, &c)
+        return c, err
+    case "rectangle":
+        var r Rectangle
+        err := json.Unmarshal(data, &r)
+        return r, err
+    default:
+        return nil, errors.New("unknown shape type")
+    }
+}
+```
+
+---
+
+## Custom Serializers
+
+### TypeScript Custom Transformer → Rust Serde
+
+```typescript
+// TypeScript: Custom transformer
+class DateTransformer implements ValueTransformer {
+  to(value: Date): string {
+    return value.toISOString();
+  }
+  from(value: string): Date {
+    return new Date(value);
+  }
+}
+
+class Event {
+  @Transform(({ value }) => new Date(value), { toClassOnly: true })
+  @Transform(({ value }) => value.toISOString(), { toPlainOnly: true })
+  timestamp: Date;
+}
+```
+
+```rust
+// Rust: Custom serde serializer
+mod iso_date {
+    use chrono::{DateTime, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        s.serialize_str(&date.to_rfc3339())
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+    where D: Deserializer<'de> {
+        let s = String::deserialize(d)?;
+        DateTime::parse_from_rfc3339(&s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Event {
+    #[serde(with = "iso_date")]
+    timestamp: DateTime<Utc>,
+}
+```
+
+---
+
+## Optional / Default Fields
+
+```typescript
+// TypeScript: Optional with defaults
+interface Config {
+  host: string;
+  port?: number; // Optional
+  timeout?: number;
+}
+
+const defaults: Config = {
+  host: "localhost",
+  port: 8080,
+  timeout: 30,
+};
+
+function loadConfig(input: Partial<Config>): Config {
+  return { ...defaults, ...input };
+}
+```
+
+```rust
+// Rust: serde defaults
+#[derive(Serialize, Deserialize)]
+struct Config {
+    host: String,
+
+    #[serde(default = "default_port")]
+    port: u16,
+
+    #[serde(default)]  // Uses Default::default() -> 0
+    timeout: u32,
+}
+
+fn default_port() -> u16 { 8080 }
+
+// Or with Default derive
+#[derive(Serialize, Deserialize, Default)]
+#[serde(default)]  // Use defaults for all missing fields
+struct Config {
+    #[serde(default = "default_host")]
+    host: String,
+    #[serde(default = "default_port")]
+    port: u16,
+    timeout: u32,  // defaults to 0
+}
+```
+
+```python
+# Python: Pydantic defaults
+from pydantic import BaseModel
+
+class Config(BaseModel):
+    host: str = "localhost"
+    port: int = 8080
+    timeout: int = 30
+```
+
+```go
+// Go: Defaults via constructor or post-unmarshal
+type Config struct {
+    Host    string `json:"host"`
+    Port    int    `json:"port"`
+    Timeout int    `json:"timeout"`
+}
+
+func NewConfig() Config {
+    return Config{
+        Host:    "localhost",
+        Port:    8080,
+        Timeout: 30,
+    }
+}
+
+func LoadConfig(data []byte) (Config, error) {
+    config := NewConfig()  // Start with defaults
+    err := json.Unmarshal(data, &config)  // Override with provided values
+    return config, err
+}
+```
+
+---
+
+## Nested Objects
+
+```typescript
+// TypeScript: Nested types
+interface Address {
+  street: string;
+  city: string;
+  country: string;
+}
+
+interface User {
+  name: string;
+  address: Address;
+  tags: string[];
+}
+```
+
+```rust
+// Rust: Nested structs
+#[derive(Serialize, Deserialize)]
+struct Address {
+    street: String,
+    city: String,
+    country: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct User {
+    name: String,
+    address: Address,
+    tags: Vec<String>,
+}
+```
+
+```python
+# Python: Nested models
+from pydantic import BaseModel
+
+class Address(BaseModel):
+    street: str
+    city: str
+    country: str
+
+class User(BaseModel):
+    name: str
+    address: Address
+    tags: list[str]
+```
+
+---
+
+## Schema Versioning
+
+```typescript
+// TypeScript: Version handling
+interface UserV1 {
+  version: 1;
+  name: string;
+}
+
+interface UserV2 {
+  version: 2;
+  firstName: string;
+  lastName: string;
+}
+
+type User = UserV1 | UserV2;
+
+function migrateToLatest(user: User): UserV2 {
+  if (user.version === 1) {
+    const [firstName, ...rest] = user.name.split(" ");
+    return {
+      version: 2,
+      firstName,
+      lastName: rest.join(" "),
+    };
+  }
+  return user;
+}
+```
+
+```rust
+// Rust: Versioned schema pattern
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "version")]
+enum UserRecord {
+    #[serde(rename = "1")]
+    V1(UserV1),
+    #[serde(rename = "2")]
+    V2(UserV2),
+}
+
+#[derive(Serialize, Deserialize)]
+struct UserV1 {
+    name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct UserV2 {
+    first_name: String,
+    last_name: String,
+}
+
+impl UserRecord {
+    fn to_latest(self) -> UserV2 {
+        match self {
+            UserRecord::V1(v1) => {
+                let parts: Vec<&str> = v1.name.splitn(2, ' ').collect();
+                UserV2 {
+                    first_name: parts.get(0).unwrap_or(&"").to_string(),
+                    last_name: parts.get(1).unwrap_or(&"").to_string(),
+                }
+            }
+            UserRecord::V2(v2) => v2,
+        }
+    }
+}
+```

--- a/components/skills/meta-convert-guide/reference/async-patterns.md
+++ b/components/skills/meta-convert-guide/reference/async-patterns.md
@@ -1,0 +1,404 @@
+# Async Pattern Reference (Deep Dive)
+
+Advanced async patterns including cancellation, streams, and structured concurrency.
+
+---
+
+## Runtime Comparison
+
+| Aspect       | JS/TS           | Python                 | Go                   | Rust               |
+|--------------|-----------------|------------------------|----------------------|--------------------|
+| Runtime      | V8 event loop   | asyncio event loop     | Go scheduler         | tokio/async-std    |
+| Default      | Single-threaded | Single-threaded        | Multi-threaded       | Multi-threaded     |
+| Blocking     | Never block!    | Never block!           | Goroutines can block | Use spawn_blocking |
+| Cancellation | AbortController | asyncio.CancelledError | Context              | Drop / select!     |
+
+---
+
+## Cancellation Patterns
+
+### TypeScript: AbortController
+
+```typescript
+async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Manual cancellation
+const controller = new AbortController();
+startFetch(controller.signal);
+// Later:
+controller.abort();  // Cancels the fetch
+```
+
+### Rust: tokio select!
+
+```rust
+use tokio::time::{timeout, Duration};
+
+// Timeout wrapper
+async fn fetch_with_timeout(url: &str, ms: u64) -> Result<Response, Error> {
+    timeout(Duration::from_millis(ms), reqwest::get(url))
+        .await
+        .map_err(|_| Error::Timeout)?
+        .map_err(Error::Request)
+}
+
+// Explicit select for multiple cancellation sources
+async fn fetch_cancellable(
+    url: &str,
+    cancel: tokio::sync::oneshot::Receiver<()>
+) -> Result<Response, Error> {
+    tokio::select! {
+        result = reqwest::get(url) => result.map_err(Error::Request),
+        _ = cancel => Err(Error::Cancelled),
+    }
+}
+```
+
+### Go: Context
+
+```go
+func fetchWithTimeout(url string, timeout time.Duration) (*http.Response, error) {
+    ctx, cancel := context.WithTimeout(context.Background(), timeout)
+    defer cancel()
+
+    req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+    if err != nil {
+        return nil, err
+    }
+    return http.DefaultClient.Do(req)
+}
+
+// Propagate cancellation
+func handler(ctx context.Context) error {
+    // Pass context to all operations
+    result, err := doWork(ctx)
+    if err == context.Canceled {
+        return nil  // Clean shutdown
+    }
+    return err
+}
+```
+
+### Python: asyncio cancellation
+
+```python
+import asyncio
+
+async def fetch_with_timeout(url: str, timeout: float):
+    try:
+        return await asyncio.wait_for(fetch(url), timeout=timeout)
+    except asyncio.TimeoutError:
+        raise TimeoutError(f"Request to {url} timed out")
+
+# Manual cancellation
+task = asyncio.create_task(long_running())
+# Later:
+task.cancel()
+try:
+    await task
+except asyncio.CancelledError:
+    print("Task was cancelled")
+```
+
+### Elixir: Task shutdown
+
+```elixir
+def fetch_with_timeout(url, timeout_ms) do
+  task = Task.async(fn -> fetch(url) end)
+  case Task.yield(task, timeout_ms) do
+    {:ok, result} -> {:ok, result}
+    nil ->
+      Task.shutdown(task, :brutal_kill)
+      {:error, :timeout}
+  end
+end
+```
+
+---
+
+## Stream / Async Iterator Patterns
+
+### TypeScript: AsyncIterable
+
+```typescript
+async function* fetchPages(baseUrl: string): AsyncIterable<Page> {
+  let page = 1;
+  while (true) {
+    const response = await fetch(`${baseUrl}?page=${page}`);
+    if (!response.ok) break;
+    yield await response.json();
+    page++;
+  }
+}
+
+// Consuming
+for await (const page of fetchPages(url)) {
+  process(page);
+}
+```
+
+### Rust: Stream
+
+```rust
+use futures::stream::{self, Stream, StreamExt};
+
+fn fetch_pages(base_url: &str) -> impl Stream<Item = Page> {
+    stream::unfold(1, move |page| async move {
+        let url = format!("{}?page={}", base_url, page);
+        match reqwest::get(&url).await {
+            Ok(resp) if resp.status().is_success() => {
+                let data: Page = resp.json().await.ok()?;
+                Some((data, page + 1))
+            }
+            _ => None,
+        }
+    })
+}
+
+// Consuming
+let mut pages = fetch_pages(url);
+while let Some(page) = pages.next().await {
+    process(page);
+}
+
+// Or with stream combinators
+fetch_pages(url)
+    .filter(|p| async { p.has_content() })
+    .take(10)
+    .for_each(|p| async { process(p) })
+    .await;
+```
+
+### Python: Async Generator
+
+```python
+async def fetch_pages(base_url: str):
+    page = 1
+    while True:
+        response = await fetch(f"{base_url}?page={page}")
+        if not response.ok:
+            break
+        yield await response.json()
+        page += 1
+
+# Consuming
+async for page in fetch_pages(url):
+    process(page)
+```
+
+### Go: Channel-based Stream
+
+```go
+func fetchPages(baseUrl string) <-chan Page {
+    ch := make(chan Page)
+    go func() {
+        defer close(ch)
+        page := 1
+        for {
+            resp, err := http.Get(fmt.Sprintf("%s?page=%d", baseUrl, page))
+            if err != nil || resp.StatusCode != 200 {
+                return
+            }
+            var p Page
+            json.NewDecoder(resp.Body).Decode(&p)
+            resp.Body.Close()
+            ch <- p
+            page++
+        }
+    }()
+    return ch
+}
+
+// Consuming
+for page := range fetchPages(url) {
+    process(page)
+}
+```
+
+---
+
+## Structured Concurrency
+
+### Concept
+
+All spawned tasks complete before parent completes. No orphaned tasks.
+
+### Go: errgroup
+
+```go
+import "golang.org/x/sync/errgroup"
+
+func processAll(ctx context.Context, items []Item) error {
+    g, ctx := errgroup.WithContext(ctx)
+
+    for _, item := range items {
+        item := item  // Capture for closure
+        g.Go(func() error {
+            return process(ctx, item)
+        })
+    }
+
+    return g.Wait()  // Waits for all, returns first error
+}
+```
+
+### Rust: tokio JoinSet
+
+```rust
+use tokio::task::JoinSet;
+
+async fn process_all(items: Vec<Item>) -> Result<Vec<Output>, Error> {
+    let mut set = JoinSet::new();
+
+    for item in items {
+        set.spawn(async move { process(item).await });
+    }
+
+    let mut results = Vec::new();
+    while let Some(result) = set.join_next().await {
+        results.push(result??);
+    }
+    Ok(results)
+}
+```
+
+### Python: TaskGroup (3.11+)
+
+```python
+async def process_all(items: list[Item]) -> list[Output]:
+    async with asyncio.TaskGroup() as tg:
+        tasks = [tg.create_task(process(item)) for item in items]
+    return [task.result() for task in tasks]
+```
+
+---
+
+## Backpressure Patterns
+
+### Bounded Channels
+
+```rust
+// Rust: Bounded channel
+let (tx, rx) = tokio::sync::mpsc::channel(100);  // Max 100 buffered
+
+// Sender blocks when buffer full
+tx.send(item).await?;  // Waits if buffer full
+```
+
+```go
+// Go: Buffered channel
+ch := make(chan Item, 100)  // Max 100 buffered
+
+// Sender blocks when buffer full
+ch <- item  // Blocks if buffer full
+```
+
+### Rate Limiting
+
+```rust
+// Rust: Rate limiting with governor
+use governor::{Quota, RateLimiter};
+
+let limiter = RateLimiter::direct(Quota::per_second(10));
+
+for item in items {
+    limiter.until_ready().await;  // Wait for permit
+    process(item).await;
+}
+```
+
+---
+
+## Parallel vs Concurrent
+
+| Pattern | Use Case | TypeScript | Rust | Go |
+|---------|----------|------------|------|-----|
+| Concurrent | I/O bound | `Promise.all` | `join!` | Goroutines |
+| Parallel | CPU bound | Web Workers | `rayon` | Goroutines |
+
+### CPU-Bound Parallelism
+
+```rust
+// Rust: rayon for CPU-bound parallel work
+use rayon::prelude::*;
+
+let results: Vec<_> = items
+    .par_iter()
+    .map(|item| cpu_intensive_work(item))
+    .collect();
+```
+
+```go
+// Go: Goroutines work for both
+var wg sync.WaitGroup
+results := make([]Result, len(items))
+
+for i, item := range items {
+    wg.Add(1)
+    go func(i int, item Item) {
+        defer wg.Done()
+        results[i] = cpuIntensiveWork(item)
+    }(i, item)
+}
+wg.Wait()
+```
+
+---
+
+## Error Handling in Async
+
+### Collecting All Errors
+
+```rust
+// Rust: Collect successes, log failures
+let results: Vec<_> = futures::future::join_all(
+    items.into_iter().map(|item| async move {
+        process(item).await
+    })
+).await;
+
+let (successes, failures): (Vec<_>, Vec<_>) = results
+    .into_iter()
+    .partition(Result::is_ok);
+
+let successes: Vec<_> = successes.into_iter()
+    .filter_map(Result::ok)
+    .collect();
+
+for err in failures.into_iter().filter_map(Result::err) {
+    log::error!("Failed: {}", err);
+}
+```
+
+### Fail Fast
+
+```rust
+// Rust: Stop on first error
+use futures::TryStreamExt;
+
+let results = futures::stream::iter(items)
+    .map(|item| process(item))
+    .buffer_unordered(10)
+    .try_collect::<Vec<_>>()
+    .await?;  // Returns first error
+```
+
+```go
+// Go: errgroup fails fast
+g, ctx := errgroup.WithContext(ctx)
+for _, item := range items {
+    item := item
+    g.Go(func() error {
+        return process(ctx, item)  // Context cancelled on first error
+    })
+}
+return g.Wait()  // Returns first error
+```

--- a/components/skills/meta-convert-guide/reference/concurrency.md
+++ b/components/skills/meta-convert-guide/reference/concurrency.md
@@ -1,0 +1,218 @@
+# Concurrency Reference
+
+Comprehensive reference for concurrency model translation.
+
+---
+
+## Model Comparison
+
+| Language   | Async Model             | Threading                  | Channels                |
+|------------|-------------------------|----------------------------|-------------------------|
+| TypeScript | `async/await`, Promises | Web Workers (limited)      | -                       |
+| Python     | `async/await`, asyncio  | Threading, multiprocessing | Queue                   |
+| Go         | Goroutines              | Built-in                   | `chan` (first-class)    |
+| Rust       | `async/await`, Futures  | std::thread                | mpsc, crossbeam         |
+| Erlang     | Processes (lightweight) | BEAM scheduler             | Mailboxes (first-class) |
+| Elixir     | Tasks, GenServer        | BEAM scheduler             | Mailboxes, Agent        |
+| Clojure    | core.async, Agents      | JVM threads                | CSP channels            |
+| Haskell    | async, STM              | forkIO, threads            | MVar, TVar, Chan        |
+
+---
+
+## Async Runtime Comparison
+
+| Aspect       | JS/TS           | Python                 | Go                   | Rust               |
+|--------------|-----------------|------------------------|----------------------|-------------------|
+| Runtime      | V8 event loop   | asyncio event loop     | Go scheduler         | tokio/async-std    |
+| Default      | Single-threaded | Single-threaded        | Multi-threaded       | Multi-threaded     |
+| Blocking     | Never block!    | Never block!           | Goroutines can block | Use spawn_blocking |
+| Cancellation | AbortController | asyncio.CancelledError | Context              | Drop / select!     |
+
+---
+
+## Pattern Mappings
+
+### Basic Async
+
+| Pattern | TypeScript | Rust | Go | Python |
+|---------|------------|------|-----|--------|
+| Define async | `async function f()` | `async fn f()` | `go func()` | `async def f()` |
+| Await | `await promise` | `future.await` | Channel receive | `await coro` |
+| Create task | - | `tokio::spawn()` | `go func()` | `asyncio.create_task()` |
+| Parallel | `Promise.all()` | `tokio::join!()` | WaitGroup | `asyncio.gather()` |
+| Race | `Promise.race()` | `tokio::select!` | `select {}` | `asyncio.wait(..., FIRST_COMPLETED)` |
+
+### Channel Patterns
+
+| Pattern | Go | Rust | Elixir | Clojure |
+|---------|-----|------|--------|---------|
+| Create | `make(chan T)` | `mpsc::channel()` | Process mailbox | `(chan)` |
+| Send | `ch <- val` | `tx.send(val)` | `send(pid, msg)` | `(>! ch val)` |
+| Receive | `<-ch` | `rx.recv()` | `receive do` | `(<! ch)` |
+| Buffered | `make(chan T, n)` | `mpsc::channel(n)` | N/A | `(chan n)` |
+| Close | `close(ch)` | Drop sender | N/A | `(close! ch)` |
+
+---
+
+## Process-Based Concurrency (BEAM)
+
+### GenServer Pattern
+
+```elixir
+defmodule Counter do
+  use GenServer
+
+  # Client API
+  def start_link(initial), do: GenServer.start_link(__MODULE__, initial, name: __MODULE__)
+  def increment, do: GenServer.cast(__MODULE__, :increment)
+  def get, do: GenServer.call(__MODULE__, :get)
+
+  # Server Callbacks
+  @impl true
+  def init(initial), do: {:ok, initial}
+
+  @impl true
+  def handle_cast(:increment, count), do: {:noreply, count + 1}
+
+  @impl true
+  def handle_call(:get, _from, count), do: {:reply, count, count}
+end
+```
+
+### Translation to Other Languages
+
+| GenServer Concept | Rust | Go | Clojure |
+|-------------------|------|-----|---------|
+| Process | Actor (actix) | Goroutine | core.async go block |
+| State | Arc<Mutex<T>> | Struct + mutex | Atom/Agent |
+| Call (sync) | Channel + response | Channel pair | (async/<!! ...) |
+| Cast (async) | Channel (no response) | Channel | (go (>! ...)) |
+| Supervision | Manual restart logic | errgroup | component |
+
+---
+
+## Synchronization Primitives
+
+| Primitive | Rust | Go | Python | Purpose |
+|-----------|------|-----|--------|---------|
+| Mutex | `Mutex<T>` | `sync.Mutex` | `threading.Lock` | Exclusive access |
+| RWLock | `RwLock<T>` | `sync.RWMutex` | `threading.RLock` | Read-heavy workloads |
+| Semaphore | `tokio::sync::Semaphore` | `chan struct{}` | `asyncio.Semaphore` | Limit concurrency |
+| Barrier | `std::sync::Barrier` | `sync.WaitGroup` | `threading.Barrier` | Wait for all |
+| Once | `std::sync::Once` | `sync.Once` | - | One-time init |
+| Condition | `std::sync::Condvar` | `sync.Cond` | `threading.Condition` | Wait for condition |
+
+---
+
+## Shared State Strategies
+
+### Single-Threaded (No Sync Needed)
+
+| Language | Pattern |
+|----------|---------|
+| TypeScript | Regular objects (event loop is single-threaded) |
+| Python (asyncio) | Regular objects (await points are cooperative) |
+
+### Multi-Threaded
+
+| Pattern | Rust | Go |
+|---------|------|-----|
+| Shared immutable | `Arc<T>` | Pointer to immutable |
+| Shared mutable | `Arc<Mutex<T>>` | Pointer + `sync.Mutex` |
+| Per-thread | `thread_local!` | goroutine-local |
+| Message passing | Channels | Channels |
+
+---
+
+## Parallel Execution Patterns
+
+### Map-Reduce Style
+
+| Language | Pattern |
+|----------|---------|
+| Rust | `rayon::par_iter().map().reduce()` |
+| Go | Goroutines + channels + WaitGroup |
+| Python | `concurrent.futures.ProcessPoolExecutor` |
+| Elixir | `Task.async_stream()` |
+
+### Worker Pool
+
+| Language | Pattern |
+|----------|---------|
+| TypeScript | `p-limit` library |
+| Rust | `buffer_unordered(n)` on stream |
+| Go | Buffered channel as semaphore |
+| Python | `asyncio.Semaphore` |
+| Elixir | `Task.async_stream(..., max_concurrency: n)` |
+
+---
+
+## Cancellation Strategies
+
+| Language | Mechanism | Scope |
+|----------|-----------|-------|
+| TypeScript | `AbortController` | Per-request |
+| Python | `asyncio.CancelledError` | Per-task |
+| Go | `context.Context` | Request tree |
+| Rust | Drop + `select!` | Per-future |
+| Elixir | `Task.shutdown/2` | Per-task |
+
+### Go Context Propagation
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+    ctx := r.Context()
+
+    // Pass context down
+    result, err := doWork(ctx)
+    if err == context.Canceled {
+        return // Client disconnected
+    }
+}
+
+func doWork(ctx context.Context) (Result, error) {
+    select {
+    case <-ctx.Done():
+        return Result{}, ctx.Err()
+    case result := <-workChan:
+        return result, nil
+    }
+}
+```
+
+### Rust Select
+
+```rust
+tokio::select! {
+    result = do_work() => {
+        handle_result(result)
+    }
+    _ = shutdown_signal.recv() => {
+        // Graceful shutdown
+        return;
+    }
+}
+```
+
+---
+
+## Async Streams
+
+| Language | Type | Create | Consume |
+|----------|------|--------|---------|
+| TypeScript | `AsyncIterable<T>` | `async function*` | `for await` |
+| Rust | `Stream<Item=T>` | `stream::unfold` | `while let Some(x) = s.next().await` |
+| Python | `AsyncIterator` | `async def` with `yield` | `async for` |
+| Go | `<-chan T` | Goroutine + channel | `for v := range ch` |
+
+---
+
+## Common Pitfalls
+
+| Issue | Symptom | Solution |
+|-------|---------|----------|
+| Deadlock | Program hangs | Consistent lock ordering, timeouts |
+| Data race | Inconsistent data | Use proper synchronization |
+| Starvation | Some tasks never run | Fair scheduling, priorities |
+| Blocking in async | Poor throughput | `spawn_blocking`, separate threads |
+| Channel leak | Memory growth | Ensure senders close channels |

--- a/components/skills/meta-convert-guide/reference/dependency-management.md
+++ b/components/skills/meta-convert-guide/reference/dependency-management.md
@@ -1,0 +1,268 @@
+# Dependency Management Reference
+
+Package ecosystem mapping and dependency translation strategies.
+
+---
+
+## Package Manager Mapping
+
+| Language   | Package Manager | Lock File | Registry |
+|------------|-----------------|-----------|----------|
+| TypeScript | npm / yarn / pnpm | package-lock.json / yarn.lock | npmjs.com |
+| Python     | pip / poetry / pdm | requirements.txt / poetry.lock | pypi.org |
+| Rust       | Cargo | Cargo.lock | crates.io |
+| Go         | go mod | go.sum | proxy.golang.org |
+| Elixir     | Mix / Hex | mix.lock | hex.pm |
+| Clojure    | deps.edn / Leiningen | - | clojars.org, Maven Central |
+| Haskell    | Cabal / Stack | - | hackage.haskell.org |
+
+---
+
+## Common Library Translations
+
+### HTTP Client
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| axios, fetch | requests, httpx | reqwest | net/http | HTTPoison, Finch |
+| got | aiohttp | hyper | - | Tesla |
+
+### JSON
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| built-in | json (stdlib) | serde_json | encoding/json | Jason |
+| - | orjson | simd-json | - | Poison |
+
+### Async Runtime
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| built-in | asyncio | tokio | built-in | built-in (BEAM) |
+| - | trio | async-std | - | - |
+
+### CLI Parsing
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| commander | argparse | clap | flag | OptionParser |
+| yargs | click | structopt | cobra | - |
+
+### Logging
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| winston | logging | tracing | log/slog | Logger |
+| pino | loguru | log | zap | - |
+
+### Testing
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| jest | pytest | built-in | testing | ExUnit |
+| vitest | unittest | - | testify | - |
+
+### Date/Time
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| date-fns | datetime | chrono | time | Timex |
+| luxon | arrow | - | - | - |
+
+### Database
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| prisma | sqlalchemy | diesel | gorm | Ecto |
+| typeorm | tortoise | sqlx | sqlx | - |
+| knex | peewee | sea-orm | - | - |
+
+### Validation
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| zod | pydantic | validator | go-validator | Ecto.Changeset |
+| joi | marshmallow | - | ozzo | Vex |
+
+### Environment
+
+| TypeScript | Python | Rust | Go | Elixir |
+|------------|--------|------|-----|--------|
+| dotenv | python-dotenv | dotenvy | godotenv | Dotenv |
+
+---
+
+## Project Structure Translation
+
+### TypeScript → Rust
+
+```
+# TypeScript              # Rust
+package.json         →    Cargo.toml
+src/                 →    src/
+  index.ts           →      main.rs / lib.rs
+  utils/             →      utils/
+    mod.ts           →        mod.rs
+tsconfig.json        →    (handled by Cargo)
+node_modules/        →    target/
+```
+
+### Python → Rust
+
+```
+# Python                  # Rust
+pyproject.toml       →    Cargo.toml
+src/mypackage/       →    src/
+  __init__.py        →      lib.rs
+  utils.py           →      utils.rs
+tests/               →    tests/
+requirements.txt     →    (in Cargo.toml)
+```
+
+### Go → Rust
+
+```
+# Go                      # Rust
+go.mod               →    Cargo.toml
+main.go              →    src/main.rs
+pkg/                 →    src/
+  utils/             →      utils/
+    utils.go         →        mod.rs
+cmd/                 →    src/bin/
+```
+
+---
+
+## Dependency Version Strategies
+
+### Semantic Versioning
+
+| Specifier | Meaning | npm | Cargo | pip |
+|-----------|---------|-----|-------|-----|
+| Exact | Only this version | `1.2.3` | `=1.2.3` | `==1.2.3` |
+| Caret | Compatible updates | `^1.2.3` | `1.2.3` (default) | - |
+| Tilde | Patch updates only | `~1.2.3` | `~1.2.3` | `~=1.2.3` |
+| Range | Version range | `>=1.0 <2.0` | `>=1.0, <2.0` | `>=1.0,<2.0` |
+| Wildcard | Any patch | `1.2.*` | `1.2.*` | - |
+
+### Pre-1.0 Dependencies
+
+```toml
+# Cargo.toml - Pre-1.0 crates: minor versions can break
+reqwest = "0.11"  # 0.12 might be breaking
+
+# For stability, pin more precisely
+reqwest = "~0.11.20"
+```
+
+---
+
+## Feature Flags
+
+### Cargo (Rust)
+
+```toml
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+
+# Optional features
+reqwest = { version = "0.11", optional = true }
+
+[features]
+default = []
+http = ["reqwest"]
+```
+
+### Package.json (TypeScript)
+
+```json
+{
+  "dependencies": {
+    "lodash": "^4.17.21"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.3.2"
+  }
+}
+```
+
+---
+
+## Workspace / Monorepo
+
+### Cargo Workspace
+
+```toml
+# Cargo.toml (root)
+[workspace]
+members = [
+    "crates/core",
+    "crates/cli",
+    "crates/web",
+]
+
+[workspace.dependencies]
+serde = "1.0"
+tokio = { version = "1", features = ["full"] }
+```
+
+### npm Workspaces
+
+```json
+{
+  "workspaces": ["packages/*"]
+}
+```
+
+### Go Workspace
+
+```
+// go.work
+go 1.21
+
+use (
+    ./core
+    ./cli
+    ./web
+)
+```
+
+---
+
+## Migration Strategies
+
+### Gradual Migration
+
+1. **Keep both systems running**
+   - Add new dependencies to target
+   - Wrap old code with new interfaces
+
+2. **Migrate module by module**
+   - Start with leaf dependencies
+   - Work toward core
+
+3. **Update imports incrementally**
+   - Change import paths
+   - Update type signatures
+
+### Dependency Audit
+
+When converting, audit dependencies:
+
+1. **Security**: Check for known vulnerabilities
+2. **Maintenance**: Is it actively maintained?
+3. **Compatibility**: Does it work with your target version?
+4. **Alternatives**: Is there a better equivalent in target language?
+
+---
+
+## Common Gotchas
+
+| Issue | Solution |
+|-------|----------|
+| Version conflicts | Use workspace dependencies |
+| Missing equivalent | Build adapter or find alternative |
+| Different APIs | Create wrapper module |
+| Native dependencies | Check platform support |
+| License compatibility | Audit licenses |

--- a/components/skills/meta-convert-guide/reference/dev-workflow-repl.md
+++ b/components/skills/meta-convert-guide/reference/dev-workflow-repl.md
@@ -1,0 +1,270 @@
+# Dev Workflow & REPL Reference (9th Pillar)
+
+Guidance for translating development workflows, especially REPL-centric patterns.
+
+---
+
+## Why This Matters
+
+REPL-centric languages enable a fundamentally different development style:
+
+- Incremental, exploratory development
+- Immediate feedback on code changes
+- Hot code reloading in production (BEAM)
+- Interactive debugging and data inspection
+
+When converting FROM these languages, developers lose familiar workflows.
+When converting TO them, developers gain powerful new capabilities.
+
+---
+
+## REPL-Centric Languages
+
+| Language    | REPL/Workflow       | Key Features                                          |
+|-------------|---------------------|-------------------------------------------------------|
+| Clojure     | `clj`, CIDER, Calva | Send forms to REPL, hot reload, REPL-driven design    |
+| Elixir      | `iex`, IEx.pry      | Interactive shell, hot code loading, remote debugging |
+| Erlang      | `erl`, observer     | Shell, hot code loading, runtime introspection        |
+| Haskell     | `ghci`              | Type checking, expression evaluation, :reload         |
+| Lisp/Scheme | Various             | SLIME/Sly, image-based development                    |
+| F#          | FSI, Ionide         | Scripts, notebooks, interactive exploration           |
+
+---
+
+## Workflow Translation: REPL → Compiled
+
+When converting FROM REPL-centric TO compiled languages:
+
+| REPL Workflow              | Compiled Equivalent       | Tools                      |
+|----------------------------|---------------------------|----------------------------|
+| Send expression to REPL    | Run tests / scratch files | cargo watch, go run        |
+| Hot reload function        | Recompile + restart       | Fast incremental builds    |
+| Interactive debugging      | Debugger breakpoints      | lldb, delve, gdb           |
+| Data inspection at runtime | Logging, tracing          | tracing crate, log package |
+| REPL-driven design         | Test-driven design        | Property-based tests       |
+
+### Development Speed Comparison
+
+| Task | REPL Language | Compiled Language |
+|------|---------------|-------------------|
+| Try new function | < 1 second | 5-30 seconds |
+| Modify and retest | < 1 second | 2-10 seconds |
+| Inspect data | Immediate | Add logging, rebuild |
+| Debug issue | Inspect in REPL | Debugger or logs |
+
+### Maintaining Rapid Feedback
+
+**For Rust:**
+```bash
+# Fast iteration with cargo watch
+cargo watch -x test
+cargo watch -x "run -- args"
+
+# REPL-like exploration
+evcxr  # Limited Rust REPL
+```
+
+**For Go:**
+```bash
+# Fast rebuilds
+go run .
+
+# Watch mode
+air  # Hot reload for web apps
+```
+
+---
+
+## Workflow Translation: Compiled → REPL
+
+When converting FROM compiled TO REPL-centric languages:
+
+| Compiled Workflow        | REPL Enhancement             | Benefit              |
+|--------------------------|------------------------------|----------------------|
+| Write test, compile, run | Evaluate expression directly | Instant feedback     |
+| Step debugger            | Data inspection in REPL      | Richer exploration   |
+| Print-based debugging    | Live value inspection        | No recompile needed  |
+| Full rebuild on change   | Reload single function       | Sub-second iteration |
+
+### New Capabilities to Leverage
+
+**In Clojure:**
+```clojure
+;; Evaluate in REPL, see result immediately
+(defn process-user [user]
+  (-> user
+      (update :name str/upper-case)
+      (assoc :processed-at (java.time.Instant/now))))
+
+;; Test immediately:
+(process-user {:name "alice"})
+;; => {:name "ALICE", :processed-at #inst "2024-..."}
+```
+
+**In Elixir:**
+```elixir
+# IEx.pry for inline debugging
+def process(data) do
+  require IEx
+  IEx.pry()  # Execution pauses here, can inspect
+
+  transform(data)
+end
+```
+
+---
+
+## Hot Code Loading (BEAM)
+
+Erlang/Elixir support hot code loading in production.
+
+### How It Works
+
+1. Compile new module version
+2. Load into running VM
+3. Running processes upgrade on next function call
+4. Old version kept for in-flight calls
+5. Old version purged after grace period
+
+### Production Hot Reload
+
+```elixir
+# Deploy without restart
+# Processes automatically upgrade
+
+defmodule Counter do
+  use GenServer
+
+  # Old version running in production
+  def handle_call(:get, _from, count) do
+    {:reply, count, count}
+  end
+
+  # Deploy new version - running processes upgrade
+  def handle_call(:get, _from, count) do
+    {:reply, {:count, count, :version, 2}, count}
+  end
+end
+```
+
+### Converting FROM BEAM
+
+When moving away from Erlang/Elixir, document that:
+
+- Hot reload won't be available (requires restart)
+- Blue-green deployments or rolling updates replace hot loading
+- Feature flags can simulate gradual rollout
+- Deployment pipeline needs adjustment
+
+### Converting TO BEAM
+
+Take advantage of:
+
+- Zero-downtime deployments
+- Live debugging with `:observer`
+- Remote shell into production
+- Runtime code modification for debugging
+
+---
+
+## Development Tool Mapping
+
+| Capability        | Clojure        | Elixir           | Haskell     | Rust            | Go             |
+|-------------------|----------------|------------------|-------------|-----------------|----------------|
+| REPL              | clj/CIDER      | iex              | ghci        | evcxr (limited) | gore (limited) |
+| Watch mode        | shadow-cljs    | mix test --watch | ghcid       | cargo watch     | air            |
+| Hot reload        | Built-in       | Built-in         | :reload     | No              | No             |
+| Interactive debug | CIDER debugger | IEx.pry          | GHCi :break | lldb            | delve          |
+| Notebooks         | Clerk          | Livebook         | IHaskell    | Rust Jupyter    | -              |
+
+---
+
+## Editor Integration
+
+### REPL-Integrated Editors
+
+| Editor | Clojure | Elixir | Haskell |
+|--------|---------|--------|---------|
+| VS Code | Calva | ElixirLS | Haskell extension |
+| Emacs | CIDER | Alchemist | haskell-mode |
+| IntelliJ | Cursive | - | IntelliJ Haskell |
+| Vim/Neovim | Conjure | - | haskell-vim |
+
+### Key REPL Keybindings to Learn
+
+| Action | Purpose |
+|--------|---------|
+| Eval expression | Run code under cursor |
+| Eval buffer | Reload entire file |
+| Eval region | Run selected code |
+| Show docs | View documentation |
+| Jump to definition | Navigate codebase |
+| Inspect value | Examine data structures |
+
+---
+
+## Testing Strategy Translation
+
+| REPL Pattern | Compiled Equivalent |
+|--------------|---------------------|
+| REPL exploration | Unit tests |
+| Quick experiments | Property-based tests |
+| Interactive validation | Integration tests |
+| Live inspection | Logging + tracing |
+
+### From REPL-Driven to Test-Driven
+
+```clojure
+;; Clojure: REPL-driven development
+(defn process-user [user]
+  (-> user
+      (update :name str/upper-case)
+      (assoc :processed-at (java.time.Instant/now))))
+
+;; Evaluate in REPL:
+(process-user {:name "alice"})
+;; => {:name "ALICE", :processed-at #inst "2024-..."}
+```
+
+```rust
+// Rust: Test-driven equivalent
+fn process_user(mut user: User) -> User {
+    user.name = user.name.to_uppercase();
+    user.processed_at = Some(Utc::now());
+    user
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_user() {
+        let user = User { name: "alice".into(), processed_at: None };
+        let result = process_user(user);
+        assert_eq!(result.name, "ALICE");
+        assert!(result.processed_at.is_some());
+    }
+}
+// Run with: cargo watch -x test
+```
+
+---
+
+## Livebook / Notebooks
+
+Some REPL languages have notebook environments:
+
+| Language | Notebook | Use Case |
+|----------|----------|----------|
+| Elixir | Livebook | Data exploration, docs |
+| Clojure | Clerk | Visual notebooks |
+| Haskell | IHaskell | Jupyter integration |
+| Python | Jupyter | Data science standard |
+
+### When Converting FROM Notebooks
+
+- Extract reusable code to modules
+- Convert cells to functions
+- Add proper tests
+- Document data dependencies

--- a/components/skills/meta-convert-guide/reference/error-handling.md
+++ b/components/skills/meta-convert-guide/reference/error-handling.md
@@ -1,0 +1,259 @@
+# Error Handling Reference
+
+Comprehensive reference for error handling translation between languages.
+
+---
+
+## Error Model Comparison
+
+| Language   | Primary Model    | Error Type                          | Propagation            |
+|------------|------------------|-------------------------------------|------------------------|
+| TypeScript | Exceptions       | `Error` class                       | `throw` / `try-catch`  |
+| Python     | Exceptions       | `Exception` hierarchy               | `raise` / `try-except` |
+| Go         | Error returns    | `error` interface                   | Multiple return values |
+| Rust       | Result type      | `Result<T, E>`                      | `?` operator           |
+| Erlang     | Pattern matching | `{ok, Value}` / `{error, Reason}`   | Return tuples          |
+| Elixir     | Pattern matching | `{:ok, value}` / `{:error, reason}` | Return tuples, `with`  |
+| Haskell    | Maybe/Either     | `Maybe a`, `Either e a`             | Monadic bind (`>>=`)   |
+| Scala      | Try/Either       | `Try[T]`, `Either[E, T]`            | `for` comprehensions   |
+| F#         | Result           | `Result<'T, 'E>`                    | `result { }` CE        |
+
+---
+
+## Translation Patterns
+
+### Exception → Result Type
+
+| Exception Pattern | Result Pattern |
+|-------------------|----------------|
+| `throw new Error(msg)` | `Err(Error::new(msg))` |
+| `try { ... } catch (e) { ... }` | `match result { Ok(v) => ..., Err(e) => ... }` |
+| `throw` (rethrow) | `?` operator |
+| `finally { ... }` | RAII / Drop / defer |
+| Exception hierarchy | Enum variants |
+
+### Exception → Error Return (Go)
+
+| Exception Pattern | Go Pattern |
+|-------------------|------------|
+| `throw new Error(msg)` | `return ..., errors.New(msg)` |
+| `try { ... }` | `result, err := ...` |
+| `catch (e) { ... }` | `if err != nil { ... }` |
+| `throw` (rethrow) | `return ..., err` |
+| `finally { ... }` | `defer func() { ... }()` |
+
+---
+
+## Error Hierarchy Translation
+
+### Class Hierarchy → Enum
+
+```
+TypeScript Class Hierarchy:
+    Error
+    ├── AppError (code: string)
+    │   ├── NotFoundError
+    │   ├── ValidationError (field: string)
+    │   └── AuthError
+    └── NetworkError
+
+Rust Enum:
+    enum AppError {
+        NotFound { resource: String },
+        Validation { field: String, message: String },
+        Auth { reason: String },
+        Network(reqwest::Error),
+        Io(std::io::Error),
+    }
+```
+
+### Creating Error Types
+
+**Rust (with thiserror):**
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+enum AppError {
+    #[error("{resource} not found")]
+    NotFound { resource: String },
+
+    #[error("validation failed on {field}: {message}")]
+    Validation { field: String, message: String },
+
+    #[error("authentication failed: {reason}")]
+    Auth { reason: String },
+
+    #[error(transparent)]
+    Network(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+```
+
+**Go (with error types):**
+```go
+var (
+    ErrNotFound   = errors.New("not found")
+    ErrValidation = errors.New("validation failed")
+    ErrAuth       = errors.New("authentication failed")
+)
+
+type NotFoundError struct {
+    Resource string
+}
+
+func (e NotFoundError) Error() string {
+    return fmt.Sprintf("%s not found", e.Resource)
+}
+
+func (e NotFoundError) Is(target error) bool {
+    return target == ErrNotFound
+}
+```
+
+---
+
+## "Let It Crash" Philosophy (BEAM)
+
+Erlang/Elixir use a fundamentally different error philosophy.
+
+### Comparison
+
+| Traditional Approach         | "Let It Crash" Approach                           |
+|------------------------------|---------------------------------------------------|
+| Catch and handle every error | Handle expected errors, let unexpected ones crash |
+| Error recovery in-process    | Supervisor restarts clean process                 |
+| Complex error handling code  | Simple code, complex supervision tree             |
+| State corruption possible    | Fresh state on restart                            |
+
+### When to Use Each
+
+**Handle explicitly:**
+- Expected conditions (user not found, validation failed)
+- Business logic errors
+- Recoverable states
+
+**Let crash:**
+- Programmer errors (nil dereference)
+- Unrecoverable state corruption
+- Configuration errors at startup
+- Network partitions (let supervisor handle)
+
+### Supervision Strategies
+
+| Strategy | Behavior |
+|----------|----------|
+| `:one_for_one` | Restart only crashed child |
+| `:one_for_all` | Restart all children if one crashes |
+| `:rest_for_one` | Restart crashed child and all after it |
+| `:simple_one_for_one` | Dynamic children, same spec |
+
+---
+
+## Error Context / Wrapping
+
+### Adding Context
+
+| Language | Pattern |
+|----------|---------|
+| Rust | `anyhow::Context` or manual |
+| Go | `fmt.Errorf("context: %w", err)` |
+| Python | `raise NewError("context") from err` |
+| TypeScript | `new Error("msg", { cause: err })` |
+
+### Rust Context Example
+
+```rust
+use anyhow::{Context, Result};
+
+fn load_config() -> Result<Config> {
+    let path = get_config_path()
+        .context("failed to determine config path")?;
+
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+
+    parse_config(&content)
+        .context("failed to parse config")
+}
+```
+
+---
+
+## Error Propagation Patterns
+
+### Rust ? Operator
+
+```rust
+fn process() -> Result<Output, Error> {
+    let a = step_a()?;  // Returns early if Err
+    let b = step_b(a)?;
+    let c = step_c(b)?;
+    Ok(c)
+}
+```
+
+### Go Error Checking
+
+```go
+func process() (Output, error) {
+    a, err := stepA()
+    if err != nil {
+        return Output{}, fmt.Errorf("step a: %w", err)
+    }
+
+    b, err := stepB(a)
+    if err != nil {
+        return Output{}, fmt.Errorf("step b: %w", err)
+    }
+
+    c, err := stepC(b)
+    if err != nil {
+        return Output{}, fmt.Errorf("step c: %w", err)
+    }
+
+    return c, nil
+}
+```
+
+### Elixir with Statement
+
+```elixir
+def process() do
+  with {:ok, a} <- step_a(),
+       {:ok, b} <- step_b(a),
+       {:ok, c} <- step_c(b) do
+    {:ok, c}
+  else
+    {:error, reason} -> {:error, reason}
+  end
+end
+```
+
+---
+
+## Panic vs Error Decision
+
+### When to Panic/Crash
+
+| Scenario | Action |
+|----------|--------|
+| Invalid function arguments (programmer error) | Panic |
+| Recoverable failure (file not found) | Return error |
+| Unrecoverable state corruption | Panic |
+| Out of memory | Panic (implicit) |
+| Configuration error at startup | Panic |
+| Network timeout | Return error |
+| Division by zero (user input) | Return error |
+| Division by zero (hardcoded) | Panic |
+
+### Language-Specific
+
+| Language | Panic | Error |
+|----------|-------|-------|
+| Rust | `panic!`, `unwrap()` | `Result<T, E>` |
+| Go | `panic()` | `error` return |
+| Python | Unhandled exception | Caught exception |
+| Elixir | Supervisor restart | `{:error, reason}` |

--- a/components/skills/meta-convert-guide/reference/evaluation-strategy.md
+++ b/components/skills/meta-convert-guide/reference/evaluation-strategy.md
@@ -1,0 +1,266 @@
+# Evaluation Strategy Reference
+
+Guide for translating between lazy and eager evaluation strategies.
+
+---
+
+## Evaluation Strategy Overview
+
+| Language   | Default Strategy | Lazy Support                           | Eager Support                   |
+|------------|------------------|----------------------------------------|---------------------------------|
+| Haskell    | Lazy             | Built-in                               | `seq`, `deepseq`, bang patterns |
+| Scala      | Eager            | `lazy val`, by-name params, `LazyList` | Default                         |
+| Clojure    | Eager            | Lazy seqs, `delay`/`force`             | Default                         |
+| Erlang     | Eager            | Manual thunks                          | Default                         |
+| Elixir     | Eager            | Streams, lazy enums                    | Default                         |
+| F#         | Eager            | `Lazy<T>`, `seq { }`                   | Default                         |
+| Rust       | Eager            | Iterators (lazy), `Lazy<T>`            | Default                         |
+| Python     | Eager            | Generators, itertools                  | Default                         |
+| JavaScript | Eager            | Generators                             | Default                         |
+
+---
+
+## Key Differences
+
+| Aspect | Lazy Evaluation | Eager Evaluation |
+|--------|-----------------|------------------|
+| When computed | On demand | Immediately |
+| Infinite data | Works fine | Stack overflow / hang |
+| Memory | Can have space leaks | Predictable |
+| Side effects | Deferred (surprising!) | Immediate |
+| Debugging | Non-obvious order | Sequential |
+| Performance | Thunk overhead | Direct computation |
+
+---
+
+## Lazy → Eager Conversion
+
+### Infinite Structures → Generators
+
+```haskell
+-- Haskell: Infinite list (lazy by default)
+fibs :: [Integer]
+fibs = 0 : 1 : zipWith (+) fibs (tail fibs)
+
+take 10 fibs  -- Only computes first 10
+```
+
+```python
+# Python: Must explicitly use generators
+def fibs():
+    a, b = 0, 1
+    while True:
+        yield a
+        a, b = b, a + b
+
+from itertools import islice
+list(islice(fibs(), 10))  # Take first 10
+```
+
+```rust
+// Rust: Iterators are lazy, collections are eager
+fn fibs() -> impl Iterator<Item = u64> {
+    let mut state = (0, 1);
+    std::iter::from_fn(move || {
+        let next = state.0;
+        state = (state.1, state.0 + state.1);
+        Some(next)
+    })
+}
+
+fibs().take(10).collect::<Vec<_>>()
+```
+
+```elixir
+# Elixir: Stream for laziness
+fibs = Stream.unfold({0, 1}, fn {a, b} -> {a, {b, a + b}} end)
+
+Enum.take(fibs, 10)
+```
+
+```erlang
+%% Erlang: Manual thunks for laziness
+fib_stream() ->
+    fib_stream(0, 1).
+
+fib_stream(A, B) ->
+    fun() -> {A, fib_stream(B, A + B)} end.
+
+take(0, _Stream) -> [];
+take(N, Stream) ->
+    {Value, Next} = Stream(),
+    [Value | take(N - 1, Next)].
+```
+
+---
+
+## Eager → Lazy Conversion
+
+### Avoiding Unnecessary Computation
+
+```python
+# Python: Eager - computes all before filtering
+def process(items):
+    result = []
+    for item in items:
+        transformed = expensive_transform(item)  # Called for ALL items
+        if is_valid(transformed):
+            result.append(transformed)
+    return result[:10]  # Only needed first 10!
+```
+
+```haskell
+-- Haskell: Lazy - only transforms what's needed
+process :: [Item] -> [Item]
+process items =
+    take 10 $ filter isValid $ map expensiveTransform items
+-- Only transforms until 10 valid items found
+```
+
+### Adding Laziness to Eager Languages
+
+```python
+# Python: Use generators for laziness
+def process(items):
+    for item in items:
+        transformed = expensive_transform(item)
+        if is_valid(transformed):
+            yield transformed
+
+list(islice(process(items), 10))  # Only compute first 10
+```
+
+```elixir
+# Elixir: Use Stream instead of Enum
+items
+|> Stream.map(&expensive_transform/1)
+|> Stream.filter(&is_valid/1)
+|> Enum.take(10)
+```
+
+---
+
+## Side Effects with Laziness
+
+### The Problem
+
+```haskell
+-- Haskell: Side effects are deferred!
+let xs = map (\x -> trace ("processing " ++ show x) x) [1..10]
+-- Nothing printed yet!
+
+head xs  -- "processing 1" printed now
+```
+
+### The Solution
+
+```haskell
+-- Haskell: Use IO for controlled effects
+processWithLogging :: [Int] -> IO [Int]
+processWithLogging xs = forM xs $ \x -> do
+    putStrLn $ "processing " ++ show x
+    return x
+
+-- Or use strict evaluation
+import Control.DeepSeq
+let !xs = force $ map process items  -- Evaluate now
+```
+
+---
+
+## Space Leaks
+
+### The Problem
+
+```haskell
+-- Haskell: Space leak - holds reference to entire list
+mean :: [Double] -> Double
+mean xs = sum xs / fromIntegral (length xs)
+-- Traverses list twice, holding it in memory
+```
+
+### The Solution
+
+```haskell
+-- Haskell: Fold once, strict accumulator
+mean :: [Double] -> Double
+mean xs = s / fromIntegral n
+  where
+    (s, n) = foldl' (\(!s, !n) x -> (s + x, n + 1)) (0, 0) xs
+```
+
+---
+
+## Iterator Patterns (Lazy in Eager Languages)
+
+### Rust Iterators
+
+```rust
+// Lazy operations
+let iter = vec![1, 2, 3, 4, 5]
+    .into_iter()
+    .map(|x| x * 2)      // Not computed yet
+    .filter(|x| x > 4);  // Still not computed
+
+// Only computed when consumed
+let result: Vec<_> = iter.collect();
+```
+
+### Python Generators
+
+```python
+# Generator expression (lazy)
+squares = (x * x for x in range(1000000))
+
+# List comprehension (eager)
+squares = [x * x for x in range(1000000)]
+```
+
+### Elixir Stream vs Enum
+
+```elixir
+# Enum: Eager - creates intermediate lists
+1..1_000_000
+|> Enum.map(&(&1 * 2))     # Creates full list
+|> Enum.filter(&(&1 > 10)) # Creates another list
+|> Enum.take(10)
+
+# Stream: Lazy - processes one at a time
+1..1_000_000
+|> Stream.map(&(&1 * 2))     # No computation
+|> Stream.filter(&(&1 > 10)) # Still no computation
+|> Enum.take(10)             # Computes just what's needed
+```
+
+---
+
+## Conversion Guidelines
+
+### Lazy → Eager
+
+1. Replace infinite structures with generators/iterators
+2. Ensure side effects are in IO/effect monads
+3. Watch for space leaks becoming eager memory usage
+4. Add explicit limits (`take`, `limit`) before consuming
+5. Consider strictness annotations for performance
+
+### Eager → Lazy
+
+1. Remove explicit iteration limits (laziness handles it)
+2. Be careful with side effects - they'll be deferred
+3. Use `seq`/strict annotations for performance-critical paths
+4. Consider space leaks with retained references
+5. Test that work isn't duplicated on multiple traversals
+
+---
+
+## Quick Reference
+
+| Pattern | Lazy Language | Eager Language |
+|---------|---------------|----------------|
+| Infinite list | `[1..]` | Generator/Stream |
+| Transform | `map f xs` | `iter().map()` |
+| Filter | `filter p xs` | `iter().filter()` |
+| Take n | `take n xs` | `.take(n)` |
+| Force eval | `seq`, `!` | Default |
+| Defer eval | Default | `lazy`, generator |

--- a/components/skills/meta-convert-guide/reference/gotchas/by-family.md
+++ b/components/skills/meta-convert-guide/reference/gotchas/by-family.md
@@ -1,0 +1,297 @@
+# Gotchas by Language Family
+
+Common pitfalls when converting between language paradigms and memory models.
+
+---
+
+## OOP → Functional
+
+### Inheritance → Composition
+
+| OOP Pattern | FP Pitfall | Solution |
+|-------------|------------|----------|
+| Deep class hierarchies | Trying to replicate with traits | Use composition + traits |
+| Protected members | No equivalent | Redesign with modules |
+| Abstract classes | Partial implementation | Trait + default methods |
+
+```rust
+// ❌ Trying to replicate inheritance
+trait Animal {
+    fn speak(&self);
+}
+trait Dog: Animal {}  // This isn't inheritance!
+
+// ✓ Composition
+struct Dog {
+    name: String,
+}
+impl Animal for Dog {
+    fn speak(&self) { println!("Woof!"); }
+}
+```
+
+### Mutable State → Immutability
+
+| OOP Pattern | FP Pitfall | Solution |
+|-------------|------------|----------|
+| Object mutation | Excessive cloning | Use builders, functional updates |
+| Setters | Clone on every set | Batch updates, builder pattern |
+| Global state | Arc<Mutex> everywhere | Pass state explicitly |
+
+### Method Chaining
+
+```typescript
+// OOP: Returns this for chaining
+class Builder {
+  setValue(v: string): this { this.value = v; return this; }
+}
+```
+
+```rust
+// Rust: Consumes self, returns new Self
+impl Builder {
+    fn set_value(mut self, v: String) -> Self {
+        self.value = v;
+        self
+    }
+}
+```
+
+---
+
+## Dynamic → Static Typing
+
+### Runtime Type Checks
+
+| Dynamic Pattern | Static Pitfall | Solution |
+|-----------------|----------------|----------|
+| `isinstance()` | Match on wrong enum variant | Use exhaustive matching |
+| Duck typing | Overly complex trait bounds | Accept simpler interfaces |
+| `hasattr()` | Option everywhere | Design with known structure |
+
+### Optional Fields
+
+```python
+# Python: Fields can be None anytime
+user.email  # Might be None
+
+# Easy but wrong pattern in Rust
+struct User {
+    email: Option<String>,  // Now you check everywhere
+}
+```
+
+```rust
+// ✓ Better: Separate types for different states
+struct UnverifiedUser { /* no email */ }
+struct VerifiedUser { email: String }  // Always has email
+```
+
+### Type Narrowing
+
+```typescript
+// TypeScript: Type narrowing with guards
+if (typeof x === "string") {
+  x.toUpperCase();  // x is string here
+}
+```
+
+```rust
+// Rust: Pattern matching
+match x {
+    Value::String(s) => s.to_uppercase(),
+    _ => /* handle other cases */
+}
+```
+
+---
+
+## GC → Ownership
+
+### Reference Cycles
+
+| GC Pattern | Ownership Pitfall | Solution |
+|------------|-------------------|----------|
+| Parent ↔ Child refs | `Rc<RefCell>` cycles | Weak references |
+| Observer pattern | Leaked Rc | Use indices or callbacks |
+| Graph structures | Arc everywhere | Arena allocators |
+
+```rust
+// ❌ Creates cycle, memory leak
+struct Node {
+    parent: Option<Rc<RefCell<Node>>>,
+    children: Vec<Rc<RefCell<Node>>>,
+}
+
+// ✓ Break cycle with Weak
+struct Node {
+    parent: Option<Weak<RefCell<Node>>>,  // Weak!
+    children: Vec<Rc<RefCell<Node>>>,
+}
+```
+
+### Shared Mutable State
+
+```python
+# Python: Easy shared mutation
+shared_list = []
+def add(x): shared_list.append(x)  # Just works
+```
+
+```rust
+// Rust: Must be explicit
+let shared_list = Arc::new(Mutex::new(Vec::new()));
+shared_list.lock().unwrap().push(x);
+```
+
+### Lifetimes in Structs
+
+```rust
+// ❌ Common mistake: storing references
+struct Cache<'a> {
+    data: &'a str,  // Lifetime pain begins
+}
+
+// ✓ Usually better: own the data
+struct Cache {
+    data: String,  // Simple, no lifetime
+}
+```
+
+---
+
+## Interpreted → Compiled
+
+### Runtime Reflection
+
+| Interpreted | Compiled Pitfall | Solution |
+|-------------|------------------|----------|
+| `eval()` | No equivalent | Code generation, DSL |
+| `getattr()` | Complex macros | Enum dispatch |
+| Monkey patching | Can't modify at runtime | Trait objects, strategy pattern |
+
+### Dynamic Dispatch
+
+```python
+# Python: Call any method by name
+getattr(obj, method_name)()
+```
+
+```rust
+// Rust: Must plan dispatch upfront
+enum Command { Start, Stop, Restart }
+match cmd {
+    Command::Start => obj.start(),
+    Command::Stop => obj.stop(),
+    Command::Restart => obj.restart(),
+}
+```
+
+### Hot Reload
+
+| Interpreted | Compiled Alternative |
+|-------------|----------------------|
+| Module reload | Recompile (fast with incremental) |
+| REPL modifications | `cargo watch`, test-driven |
+| Runtime patches | Feature flags, config |
+
+---
+
+## Exception → Result
+
+### Error Propagation
+
+| Exception Pattern | Result Pitfall | Solution |
+|-------------------|----------------|----------|
+| Catch at top level | `.unwrap()` everywhere | Use `?` operator |
+| Rethrow with context | Lost error chain | `anyhow`, `thiserror` |
+| Finally blocks | Forgotten cleanup | `Drop` trait, RAII |
+
+```python
+# Python: Try/except/finally
+try:
+    resource = acquire()
+    work(resource)
+finally:
+    resource.release()
+```
+
+```rust
+// Rust: RAII handles cleanup
+let resource = Resource::acquire()?;
+work(&resource)?;
+// Drop automatically calls release
+```
+
+### Multiple Error Types
+
+```rust
+// ❌ Fighting the type system
+fn process() -> Result<(), Box<dyn Error>> {
+    // Works but loses type info
+}
+
+// ✓ Use error enums or anyhow
+#[derive(thiserror::Error)]
+enum AppError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Parse error: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+```
+
+---
+
+## Lazy → Eager Evaluation
+
+### Infinite Sequences
+
+| Lazy Pattern | Eager Pitfall | Solution |
+|--------------|---------------|----------|
+| Infinite lists | Immediate OOM | Iterators |
+| Take from stream | Collect everything | `.take(n)` |
+| Lazy IO | Buffer entire file | Streaming readers |
+
+```haskell
+-- Haskell: Infinite list, no problem
+take 10 [1..]  -- [1,2,3,4,5,6,7,8,9,10]
+```
+
+```rust
+// Rust: Use iterators, not Vec
+(1..).take(10).collect::<Vec<_>>()  // Works
+
+// ❌ Don't try to collect infinite
+let v: Vec<_> = (1..).collect();  // Hangs forever
+```
+
+### Memoization
+
+```haskell
+-- Haskell: Automatic memoization
+fib = 0 : 1 : zipWith (+) fib (tail fib)
+```
+
+```rust
+// Rust: Manual caching
+fn fib_memo(n: u64, cache: &mut HashMap<u64, u64>) -> u64 {
+    if let Some(&v) = cache.get(&n) { return v; }
+    let result = fib_memo(n-1, cache) + fib_memo(n-2, cache);
+    cache.insert(n, result);
+    result
+}
+```
+
+---
+
+## Quick Reference: Family Transitions
+
+| From → To | Primary Challenge | Key Strategy |
+|-----------|-------------------|--------------|
+| OOP → FP | Inheritance mindset | Composition + traits |
+| Dynamic → Static | Runtime flexibility | Enums + pattern matching |
+| GC → Ownership | Shared references | Clone, Rc, or redesign |
+| Interpreted → Compiled | Reflection/eval | Code generation, macros |
+| Exception → Result | Error propagation | `?` operator, error enums |
+| Lazy → Eager | Infinite structures | Iterators, streaming |

--- a/components/skills/meta-convert-guide/reference/gotchas/by-language.md
+++ b/components/skills/meta-convert-guide/reference/gotchas/by-language.md
@@ -1,0 +1,484 @@
+# Gotchas by Language Pair
+
+Specific pitfalls when converting between common language pairs.
+
+---
+
+## Python → Rust
+
+### None Handling
+
+```python
+# Python: None is everywhere
+def find(items, key):
+    for item in items:
+        if item.key == key:
+            return item
+    return None  # Implicit possibility
+```
+
+```rust
+// Rust: Must be explicit
+fn find(items: &[Item], key: &str) -> Option<&Item> {
+    items.iter().find(|i| i.key == key)
+}
+// Caller MUST handle None case
+```
+
+### List Comprehensions
+
+```python
+# Python: Compact
+squares = [x**2 for x in range(10) if x % 2 == 0]
+```
+
+```rust
+// Rust: Iterator chain
+let squares: Vec<_> = (0..10)
+    .filter(|x| x % 2 == 0)
+    .map(|x| x * x)
+    .collect();
+```
+
+### Dynamic Attributes
+
+```python
+# Python: Add attributes anytime
+obj.new_field = "value"
+```
+
+```rust
+// Rust: Use HashMap for dynamic fields
+struct Dynamic {
+    known: String,
+    extra: HashMap<String, Value>,
+}
+```
+
+### Default Arguments
+
+```python
+# Python
+def greet(name, greeting="Hello"):
+    print(f"{greeting}, {name}!")
+```
+
+```rust
+// Rust: Builder pattern or Option
+fn greet(name: &str, greeting: Option<&str>) {
+    let greeting = greeting.unwrap_or("Hello");
+    println!("{}, {}!", greeting, name);
+}
+
+// Or builder
+Greeting::new(name).greeting("Hi").send();
+```
+
+---
+
+## TypeScript → Rust
+
+### Null Coalescing
+
+```typescript
+// TypeScript
+const value = input ?? defaultValue;
+const nested = obj?.prop?.deep ?? "default";
+```
+
+```rust
+// Rust
+let value = input.unwrap_or(default_value);
+let nested = obj
+    .and_then(|o| o.prop.as_ref())
+    .and_then(|p| p.deep.as_ref())
+    .unwrap_or(&"default".to_string());
+
+// Or with if-let chains (nightly/future)
+```
+
+### Object Spread
+
+```typescript
+// TypeScript
+const updated = { ...original, name: "new" };
+```
+
+```rust
+// Rust: Struct update syntax
+let updated = User { name: "new".into(), ..original };
+// Note: moves non-Copy fields from original!
+```
+
+### Union Types
+
+```typescript
+// TypeScript
+type Result = string | number | null;
+```
+
+```rust
+// Rust: Enum
+enum Result {
+    Text(String),
+    Number(i64),
+    None,
+}
+```
+
+### Async/Await Differences
+
+```typescript
+// TypeScript: Promises auto-start
+const promise = fetchData();  // Already running!
+await promise;
+```
+
+```rust
+// Rust: Futures are lazy
+let future = fetch_data();  // Nothing happens yet
+future.await;  // Now it runs
+```
+
+---
+
+## Go → Rust
+
+### Error Returns
+
+```go
+// Go: Multiple returns
+func process() (Result, error) {
+    if err != nil {
+        return Result{}, err
+    }
+    return result, nil
+}
+```
+
+```rust
+// Rust: Result type
+fn process() -> Result<ProcessResult, Error> {
+    // Use ? for propagation
+    let data = get_data()?;
+    Ok(ProcessResult::from(data))
+}
+```
+
+### Goroutines → Tokio
+
+```go
+// Go: Simple goroutine
+go func() {
+    doWork()
+}()
+```
+
+```rust
+// Rust: Spawn task
+tokio::spawn(async {
+    do_work().await
+});
+```
+
+### Interface Satisfaction
+
+```go
+// Go: Implicit interface satisfaction
+type Reader interface { Read([]byte) (int, error) }
+// Any type with Read method satisfies Reader
+```
+
+```rust
+// Rust: Explicit impl
+trait Reader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+}
+impl Reader for MyType {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> { ... }
+}
+```
+
+### Zero Values
+
+```go
+// Go: Zero values for everything
+var s string  // ""
+var n int     // 0
+var b bool    // false
+```
+
+```rust
+// Rust: Must initialize or use Default
+let s: String = String::new();  // or Default::default()
+let n: i32 = 0;
+let b: bool = false;
+// Or derive Default for structs
+```
+
+---
+
+## JavaScript → Rust
+
+### Truthy/Falsy
+
+```javascript
+// JavaScript: Truthy coercion
+if (value) { /* value is truthy */ }
+if (!array.length) { /* empty */ }
+```
+
+```rust
+// Rust: Explicit checks
+if value.is_some() { ... }
+if array.is_empty() { ... }
+if !string.is_empty() { ... }
+```
+
+### Array Methods
+
+| JavaScript | Rust Equivalent |
+|------------|-----------------|
+| `.map()` | `.iter().map()` |
+| `.filter()` | `.iter().filter()` |
+| `.reduce()` | `.iter().fold()` |
+| `.find()` | `.iter().find()` |
+| `.some()` | `.iter().any()` |
+| `.every()` | `.iter().all()` |
+| `.includes()` | `.contains()` |
+| `.flat()` | `.flatten()` |
+
+### Object Destructuring
+
+```javascript
+// JavaScript
+const { name, age = 0 } = user;
+```
+
+```rust
+// Rust: Pattern matching
+let User { name, age } = user;
+// For defaults, use Option fields
+let age = user.age.unwrap_or(0);
+```
+
+### Prototypes → Traits
+
+```javascript
+// JavaScript: Prototype extension
+Array.prototype.first = function() {
+    return this[0];
+};
+```
+
+```rust
+// Rust: Extension trait
+trait First<T> {
+    fn first(&self) -> Option<&T>;
+}
+impl<T> First<T> for Vec<T> {
+    fn first(&self) -> Option<&T> {
+        self.get(0)
+    }
+}
+```
+
+---
+
+## Java → Rust
+
+### Null Safety
+
+```java
+// Java: Nullable everywhere
+String name = user.getName();  // Could be null
+if (name != null) { ... }
+```
+
+```rust
+// Rust: Option is explicit
+let name: Option<String> = user.name();
+if let Some(name) = name { ... }
+// Or
+let name = user.name().unwrap_or_default();
+```
+
+### Checked Exceptions
+
+```java
+// Java: Checked exceptions
+public void read() throws IOException {
+    // ...
+}
+```
+
+```rust
+// Rust: Result types
+fn read() -> io::Result<()> {
+    // Use ? to propagate
+}
+```
+
+### Inheritance Hierarchies
+
+```java
+// Java: Deep inheritance
+class Dog extends Animal implements Pet, Trainable { }
+```
+
+```rust
+// Rust: Composition + traits
+struct Dog {
+    animal: AnimalData,
+}
+impl Pet for Dog { ... }
+impl Trainable for Dog { ... }
+```
+
+### Generics Differences
+
+```java
+// Java: Type erasure
+List<String> list = new ArrayList<>();
+// At runtime, just List
+```
+
+```rust
+// Rust: Monomorphization
+Vec<String>  // Distinct compiled type
+Vec<i32>     // Different compiled type
+```
+
+---
+
+## Haskell/Scala → Rust
+
+### Higher-Kinded Types
+
+```haskell
+-- Haskell: Abstract over container
+class Functor f where
+  fmap :: (a -> b) -> f a -> f b
+```
+
+```rust
+// Rust: No HKTs, use concrete implementations
+// Each container has its own map
+vec.iter().map(f).collect()
+option.map(f)
+result.map(f)
+```
+
+### Type Classes → Traits
+
+```scala
+// Scala: Type class with implicit
+implicit val intShow: Show[Int] = _.toString
+def print[A: Show](a: A) = println(implicitly[Show[A]].show(a))
+```
+
+```rust
+// Rust: Traits
+impl Display for MyType {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result { ... }
+}
+fn print<T: Display>(a: T) { println!("{}", a); }
+```
+
+### Monadic Composition
+
+```haskell
+-- Haskell: Do notation
+do
+  x <- getLine
+  y <- getLine
+  return (x ++ y)
+```
+
+```rust
+// Rust: ? operator for Result/Option
+fn concat_lines() -> io::Result<String> {
+    let x = read_line()?;
+    let y = read_line()?;
+    Ok(format!("{}{}", x, y))
+}
+```
+
+---
+
+## Elixir → Rust
+
+### Pattern Matching in Functions
+
+```elixir
+# Elixir: Pattern match in function head
+def process({:ok, value}), do: handle_value(value)
+def process({:error, msg}), do: handle_error(msg)
+```
+
+```rust
+// Rust: Match in function body
+fn process(result: Result<Value, Error>) {
+    match result {
+        Ok(value) => handle_value(value),
+        Err(msg) => handle_error(msg),
+    }
+}
+```
+
+### Pipe Operator
+
+```elixir
+# Elixir: Pipe
+data
+|> parse()
+|> validate()
+|> transform()
+```
+
+```rust
+// Rust: Method chains or intermediate bindings
+let result = transform(validate(parse(data)?)?)?;
+
+// Or with methods
+data.parse()?.validate()?.transform()
+```
+
+### Processes → Tasks
+
+```elixir
+# Elixir: Spawn process
+spawn(fn -> do_work() end)
+```
+
+```rust
+// Rust: Spawn task
+tokio::spawn(async { do_work().await });
+```
+
+### Hot Code Reload
+
+```elixir
+# Elixir: Hot reload in production
+# Just works with releases
+```
+
+```rust
+// Rust: No equivalent
+// Recompile and redeploy
+// Use feature flags for runtime behavior changes
+```
+
+---
+
+## Quick Reference: Common Traps
+
+| From | To | Trap | Solution |
+|------|-----|------|----------|
+| Python | Rust | Implicit None | Always return Option |
+| TypeScript | Rust | Object spread moves | Clone if needed |
+| Go | Rust | Zero values | Default trait |
+| JavaScript | Rust | Truthy checks | Explicit bool methods |
+| Java | Rust | null everywhere | Option<T> |
+| Haskell | Rust | HKTs | Per-type implementations |
+| Elixir | Rust | Pipes | Method chains |

--- a/components/skills/meta-convert-guide/reference/hkt-type-classes.md
+++ b/components/skills/meta-convert-guide/reference/hkt-type-classes.md
@@ -1,0 +1,338 @@
+# Higher-Kinded Types & Type Classes Reference
+
+Advanced type system features and their translation across languages.
+
+---
+
+## Higher-Kinded Types (HKTs)
+
+### What Are HKTs?
+
+HKTs are types that take other type constructors as parameters.
+
+```haskell
+-- Haskell: f is a type constructor (like [], Maybe, IO)
+class Functor f where
+  fmap :: (a -> b) -> f a -> f b
+
+-- f is higher-kinded: it takes a type and produces a type
+-- [] :: * -> *
+-- Maybe :: * -> *
+```
+
+### Language Support
+
+| Language   | HKT Support                | Alternative            |
+|------------|----------------------------|------------------------|
+| Haskell    | Full (`Functor`, `Monad`)  | N/A                    |
+| Scala      | Full (with kind-projector) | N/A                    |
+| Rust       | No (use GATs or traits)    | Associated types, GATs |
+| TypeScript | No                         | Mapped types, generics |
+| Go         | No                         | Code generation        |
+
+---
+
+## Functor Pattern
+
+### Haskell (Native)
+
+```haskell
+class Functor f where
+  fmap :: (a -> b) -> f a -> f b
+
+instance Functor [] where
+  fmap = map
+
+instance Functor Maybe where
+  fmap _ Nothing = Nothing
+  fmap f (Just x) = Just (f x)
+```
+
+### Rust (Trait per Container)
+
+```rust
+// Can't abstract over container, so define per-type
+trait Mappable {
+    type Item;
+    type Output<U>;
+
+    fn map<U, F: FnMut(Self::Item) -> U>(self, f: F) -> Self::Output<U>;
+}
+
+impl<T> Mappable for Vec<T> {
+    type Item = T;
+    type Output<U> = Vec<U>;
+
+    fn map<U, F: FnMut(T) -> U>(self, f: F) -> Vec<U> {
+        self.into_iter().map(f).collect()
+    }
+}
+
+impl<T> Mappable for Option<T> {
+    type Item = T;
+    type Output<U> = Option<U>;
+
+    fn map<U, F: FnMut(T) -> U>(self, f: F) -> Option<U> {
+        self.map(f)
+    }
+}
+```
+
+### TypeScript (Per-Type Methods)
+
+```typescript
+// No abstraction - each type has its own map
+const arr = [1, 2, 3].map((x) => x * 2);
+const opt = someOption.map((x) => x * 2);  // If using Option library
+```
+
+---
+
+## Monad Pattern
+
+### Haskell (Native)
+
+```haskell
+class Monad m where
+  return :: a -> m a
+  (>>=) :: m a -> (a -> m b) -> m b
+
+-- Do notation is sugar for >>=
+result <- computation
+-- desugars to:
+computation >>= \result -> ...
+```
+
+### Rust (? Operator)
+
+```rust
+// The ? operator is like monadic bind for Result/Option
+fn process() -> Result<Output, Error> {
+    let a = step_a()?;  // Like: step_a >>= \a ->
+    let b = step_b(a)?;
+    Ok(b)
+}
+
+// For Option
+fn find_user_email(id: &str) -> Option<String> {
+    let user = users.get(id)?;
+    let profile = user.profile.as_ref()?;
+    Some(profile.email.clone())
+}
+```
+
+### Go (Error Returns)
+
+```go
+// Manual chaining
+func process() (Output, error) {
+    a, err := stepA()
+    if err != nil {
+        return Output{}, err
+    }
+
+    b, err := stepB(a)
+    if err != nil {
+        return Output{}, err
+    }
+
+    return b, nil
+}
+```
+
+---
+
+## Type Classes
+
+### Common Type Classes
+
+| Haskell | Scala | Rust | Purpose |
+|---------|-------|------|---------|
+| `Eq` | - | `PartialEq`, `Eq` | Equality |
+| `Ord` | `Ordered` | `PartialOrd`, `Ord` | Ordering |
+| `Show` | - | `Display`, `Debug` | String representation |
+| `Functor` | `Functor` | Per-type `.map()` | Mappable |
+| `Applicative` | `Applicative` | - | Apply functions in context |
+| `Monad` | `Monad` | `?` operator | Sequential computation |
+| `Monoid` | `Monoid` | - | Combine with identity |
+| `Foldable` | `Foldable` | `.fold()` | Reduce to single value |
+
+### Scala Type Class Pattern
+
+```scala
+// Scala: Type class pattern
+trait Show[A] {
+  def show(a: A): String
+}
+
+object Show {
+  implicit val intShow: Show[Int] = (a: Int) => a.toString
+
+  def apply[A](implicit sh: Show[A]): Show[A] = sh
+}
+
+def print[A: Show](a: A): Unit =
+  println(implicitly[Show[A]].show(a))
+```
+
+### Rust Trait (Similar to Type Class)
+
+```rust
+trait Show {
+    fn show(&self) -> String;
+}
+
+impl Show for i32 {
+    fn show(&self) -> String { self.to_string() }
+}
+
+fn print<T: Show>(a: &T) {
+    println!("{}", a.show());
+}
+```
+
+---
+
+## Applicative Pattern
+
+### Haskell
+
+```haskell
+class Functor f => Applicative f where
+  pure :: a -> f a
+  (<*>) :: f (a -> b) -> f a -> f b
+
+-- Example: Apply function to multiple Options
+liftA2 :: Applicative f => (a -> b -> c) -> f a -> f b -> f c
+liftA2 f a b = f <$> a <*> b
+
+-- Usage
+liftA2 (+) (Just 1) (Just 2)  -- Just 3
+liftA2 (+) Nothing (Just 2)   -- Nothing
+```
+
+### Rust (Manual)
+
+```rust
+// Rust: Manual implementation
+fn lift_a2<A, B, C, F>(f: F, a: Option<A>, b: Option<B>) -> Option<C>
+where
+    F: FnOnce(A, B) -> C,
+{
+    Some(f(a?, b?))
+}
+
+// Usage
+lift_a2(|x, y| x + y, Some(1), Some(2))  // Some(3)
+lift_a2(|x, y| x + y, None, Some(2))     // None
+```
+
+---
+
+## Monoid Pattern
+
+### Haskell
+
+```haskell
+class Monoid m where
+  mempty :: m              -- Identity element
+  mappend :: m -> m -> m   -- Combine (also <>)
+
+instance Monoid [a] where
+  mempty = []
+  mappend = (++)
+
+-- Fold a list of monoids
+mconcat :: Monoid m => [m] -> m
+mconcat = foldr mappend mempty
+```
+
+### Rust (Default + Add)
+
+```rust
+// Rust: Use Default + std::ops::Add or custom trait
+trait Monoid: Default {
+    fn combine(self, other: Self) -> Self;
+}
+
+impl Monoid for String {
+    fn combine(self, other: Self) -> Self {
+        self + &other
+    }
+}
+
+fn mconcat<T: Monoid>(items: impl IntoIterator<Item = T>) -> T {
+    items.into_iter().fold(T::default(), |acc, x| acc.combine(x))
+}
+```
+
+---
+
+## Translating HKT Code
+
+### When Converting FROM Haskell/Scala
+
+1. **Identify which HKT abstractions are used**
+   - Functor → `.map()` methods
+   - Monad → `?` operator (Rust), explicit chaining (Go)
+   - Applicative → Manual lifting functions
+
+2. **Accept loss of abstraction**
+   - Code will be less generic
+   - May need to duplicate logic per container type
+
+3. **Use traits/interfaces for specific behaviors**
+   - Can still share behavior, just not container-abstractly
+
+### Example: Generic Validation
+
+```haskell
+-- Haskell: Applicative validation
+validateUser :: String -> String -> Validation [Error] User
+validateUser name email =
+  User <$> validateName name <*> validateEmail email
+```
+
+```rust
+// Rust: Explicit handling (no HKT abstraction)
+fn validate_user(name: &str, email: &str) -> Result<User, Vec<Error>> {
+    let name_result = validate_name(name);
+    let email_result = validate_email(email);
+
+    match (name_result, email_result) {
+        (Ok(name), Ok(email)) => Ok(User { name, email }),
+        _ => {
+            let mut errors = Vec::new();
+            if let Err(e) = name_result { errors.extend(e); }
+            if let Err(e) = email_result { errors.extend(e); }
+            Err(errors)
+        }
+    }
+}
+```
+
+---
+
+## GATs (Generic Associated Types) in Rust
+
+Rust's GATs provide some HKT-like capabilities:
+
+```rust
+trait Container {
+    type Item;
+    type Mapped<U>;  // GAT: associated type with generic
+
+    fn map<U, F: FnMut(Self::Item) -> U>(self, f: F) -> Self::Mapped<U>;
+}
+
+impl<T> Container for Vec<T> {
+    type Item = T;
+    type Mapped<U> = Vec<U>;
+
+    fn map<U, F: FnMut(T) -> U>(self, f: F) -> Vec<U> {
+        self.into_iter().map(f).collect()
+    }
+}
+```
+
+This allows more abstraction than pre-GAT Rust, but still not full HKT.

--- a/components/skills/meta-convert-guide/reference/memory-ownership.md
+++ b/components/skills/meta-convert-guide/reference/memory-ownership.md
@@ -1,0 +1,317 @@
+# Memory & Ownership Reference
+
+Comprehensive reference for memory model translation, especially GC → Ownership.
+
+---
+
+## Memory Model Comparison
+
+| Language   | Memory Model              | Cleanup              | Ownership          |
+|------------|---------------------------|----------------------|--------------------|
+| TypeScript | GC (V8)                   | Automatic            | Shared references  |
+| Python     | GC (ref counting + cycle) | Automatic            | Shared references  |
+| Go         | GC (concurrent)           | Automatic            | Shared references  |
+| Rust       | Ownership + Borrowing     | Deterministic (RAII) | Explicit ownership |
+| C++        | Manual / RAII             | Deterministic        | Explicit           |
+| Swift      | ARC                       | Deterministic        | Explicit           |
+
+---
+
+## GC → Ownership Translation
+
+### Key Differences
+
+| GC Languages | Ownership Languages |
+|--------------|---------------------|
+| Allocate freely | Consider ownership at creation |
+| Share references anywhere | One owner, many borrows |
+| Cleanup "sometime later" | Cleanup when owner goes out of scope |
+| Circular refs OK (with cycle detection) | Circular refs need Rc/Arc |
+| Simple mental model | More planning required |
+
+### Ownership Decision Tree
+
+```
+START: Is this data shared across components?
+│
+├─ YES: Is it mutated by multiple parts?
+│   │
+│   ├─ YES: Multi-threaded access?
+│   │   ├─ YES → Arc<Mutex<T>> or channels
+│   │   └─ NO  → Rc<RefCell<T>>
+│   │
+│   └─ NO: → Arc<T> or Rc<T> (shared, immutable)
+│
+└─ NO: Single owner
+    │
+    ├─ Does data outlive its creator?
+    │   ├─ YES → Return owned value (move)
+    │   └─ NO  → Return borrowed reference (&T)
+    │
+    └─ Is mutation needed?
+        ├─ YES → &mut T (exclusive borrow)
+        └─ NO  → &T (shared borrow)
+```
+
+---
+
+## Borrowing Pattern Reference
+
+| Source Pattern      | Rust Pattern              | When to Use                                       |
+|---------------------|---------------------------|---------------------------------------------------|
+| Pass by reference   | `&T`                      | Read-only access, no mutation needed              |
+| Mutable reference   | `&mut T`                  | Single mutator, temporary access                  |
+| Shared ownership    | `Rc<T>` / `Arc<T>`        | Multiple owners, single-threaded / multi-threaded |
+| Interior mutability | `RefCell<T>` / `Mutex<T>` | Shared + mutable, single / multi-threaded         |
+| Optional ownership  | `Option<Box<T>>`          | Nullable owned values                             |
+
+---
+
+## Lifetime Patterns
+
+### Borrowing from Owner
+
+```rust
+// Struct that borrows from external data
+struct Parser<'a> {
+    source: &'a str,  // Borrows source, doesn't own it
+}
+
+impl<'a> Parser<'a> {
+    fn new(source: &'a str) -> Self {
+        Self { source }
+    }
+
+    fn parse(&self) -> Vec<Token<'a>> {
+        // Tokens can reference source
+    }
+}
+```
+
+### Avoiding Self-Referential Structs
+
+```rust
+// DON'T: Self-referential (won't compile)
+struct Bad {
+    data: String,
+    slice: &str,  // Can't reference data
+}
+
+// DO: Use indices instead
+struct Good {
+    source: String,
+    tokens: Vec<(usize, usize)>,  // (start, end) indices
+}
+
+impl Good {
+    fn get_token(&self, i: usize) -> &str {
+        let (start, end) = self.tokens[i];
+        &self.source[start..end]
+    }
+}
+```
+
+---
+
+## Clone vs Borrow Decision
+
+```
+START: Is the data expensive to clone?
+│
+├─ YES: Use borrowing with lifetimes
+│   │
+│   ├─ Single owner? → &T / &mut T
+│   └─ Multiple owners? → Arc<T>
+│
+└─ NO: Clone freely
+    │
+    ├─ Small data (< ~64 bytes)?
+    │   └─ Implement Copy if possible
+    │
+    └─ Larger data?
+        ├─ Clone explicitly
+        └─ Consider Cow<T> for optional cloning
+```
+
+### When to Clone
+
+| Situation | Clone? | Alternative |
+|-----------|--------|-------------|
+| Storing in collection | Often yes | Arc for large data |
+| Passing to thread | Yes (or Arc) | - |
+| Returning to caller | Usually yes | Return reference with lifetime |
+| Internal computation | Usually no | Borrow |
+| Small Copy types | Implicit | - |
+
+---
+
+## Shared State Patterns
+
+### GC Language (TypeScript)
+
+```typescript
+// Freely share references
+class Cache {
+  private data: Map<string, User> = new Map();
+
+  get(id: string): User | undefined {
+    return this.data.get(id);  // Returns reference
+  }
+
+  set(id: string, user: User): void {
+    this.data.set(id, user);  // Stores reference
+  }
+}
+```
+
+### Ownership Language (Rust)
+
+```rust
+struct Cache {
+    data: HashMap<String, User>,
+}
+
+impl Cache {
+    // Return borrowed reference (doesn't transfer ownership)
+    fn get(&self, id: &str) -> Option<&User> {
+        self.data.get(id)
+    }
+
+    // Take ownership of user (caller gives up ownership)
+    fn set(&mut self, id: String, user: User) {
+        self.data.insert(id, user);
+    }
+
+    // Alternative: clone if shared ownership needed
+    fn get_owned(&self, id: &str) -> Option<User> {
+        self.data.get(id).cloned()
+    }
+}
+```
+
+---
+
+## Smart Pointers
+
+| Pointer | Thread-Safe | Use Case |
+|---------|-------------|----------|
+| `Box<T>` | N/A (single owner) | Heap allocation, recursive types |
+| `Rc<T>` | No | Multiple owners, single thread |
+| `Arc<T>` | Yes | Multiple owners, multi-thread |
+| `RefCell<T>` | No | Interior mutability, single thread |
+| `Mutex<T>` | Yes | Interior mutability, multi-thread |
+| `RwLock<T>` | Yes | Read-heavy interior mutability |
+
+### Common Combinations
+
+```rust
+// Single-threaded shared mutable
+type SharedState = Rc<RefCell<State>>;
+
+// Multi-threaded shared mutable
+type ThreadSafeState = Arc<Mutex<State>>;
+
+// Multi-threaded read-heavy
+type ReadHeavyState = Arc<RwLock<State>>;
+```
+
+---
+
+## RAII Pattern
+
+Resources are tied to object lifetime.
+
+### GC Language Cleanup
+
+```typescript
+// Need explicit cleanup
+async function withFile(path: string, fn: (file: File) => void) {
+  const file = await fs.open(path);
+  try {
+    await fn(file);
+  } finally {
+    await file.close();  // Must remember to close
+  }
+}
+```
+
+### Rust RAII
+
+```rust
+// Automatic cleanup via Drop
+fn with_file(path: &Path) -> io::Result<()> {
+    let file = File::open(path)?;
+    // file automatically closed when it goes out of scope
+    process(&file)
+}
+
+// Custom Drop implementation
+struct Connection {
+    handle: Handle,
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        self.handle.disconnect();  // Always called
+    }
+}
+```
+
+---
+
+## Common Ownership Mistakes
+
+### Mistake 1: Fighting the Borrow Checker
+
+```rust
+// DON'T: Clone everything to avoid borrowing
+fn process(items: Vec<Item>) {
+    for item in items.clone() {  // Unnecessary clone
+        handle(&item);
+    }
+}
+
+// DO: Borrow instead
+fn process(items: &[Item]) {
+    for item in items {
+        handle(item);
+    }
+}
+```
+
+### Mistake 2: Unnecessary Indirection
+
+```rust
+// DON'T: Box when not needed
+struct Config {
+    name: Box<String>,  // Unnecessary
+}
+
+// DO: Direct ownership
+struct Config {
+    name: String,
+}
+```
+
+### Mistake 3: Mutex When Not Needed
+
+```rust
+// DON'T: Mutex for read-only shared data
+let data = Arc::new(Mutex::new(config));
+
+// DO: Arc for immutable sharing
+let data = Arc::new(config);
+```
+
+---
+
+## Performance Implications
+
+| Pattern | Cost | When to Use |
+|---------|------|-------------|
+| Move | Free | Default for owned values |
+| Borrow (&T) | Free | Read access |
+| Mutable borrow (&mut T) | Free | Exclusive write access |
+| Clone | O(n) | When you need independent copy |
+| Rc/Arc clone | O(1) | Shared ownership |
+| Mutex lock | Synchronization cost | Shared mutable access |

--- a/components/skills/meta-convert-guide/reference/metaprogramming.md
+++ b/components/skills/meta-convert-guide/reference/metaprogramming.md
@@ -1,0 +1,306 @@
+# Metaprogramming Reference
+
+Comprehensive reference for metaprogramming capabilities across languages.
+
+---
+
+## Capability Comparison
+
+| Language   | Decorators                  | Macros                       | Reflection            | Code Gen              |
+|------------|-----------------------------|------------------------------|-----------------------|-----------------------|
+| Python     | `@decorator`                | No                           | `inspect`, `__dict__` | `ast`                 |
+| TypeScript | `@decorator` (experimental) | No                           | Limited runtime       | Via build             |
+| Rust       | `#[attr]`                   | `macro_rules!`, proc macros  | No                    | Proc macros           |
+| Go         | No                          | No                           | `reflect` package     | `go generate`         |
+| Elixir     | No                          | `defmacro` (hygienic)        | Runtime introspection | Macros                |
+| Clojure    | No                          | `defmacro` (reader macros)   | Full (JVM)            | Macros                |
+| Haskell    | No                          | Template Haskell             | Limited               | TH, generics          |
+| Java       | `@annotation`               | No                           | Full runtime          | Annotation processors |
+| Scala      | `@annotation`               | `macro` (deprecated), inline | Full (JVM)            | Macros                |
+
+---
+
+## Decorator / Attribute Translation
+
+### Basic Translation
+
+| Python/TS Pattern | Rust Pattern | Go Pattern |
+|-------------------|--------------|------------|
+| `@decorator` | `#[attribute]` | Struct tags + codegen |
+| `@decorator(args)` | `#[attribute(args)]` | Struct tags |
+| Class decorator | Derive macro | Type definition |
+| Method decorator | Proc macro | Manual wrapper |
+
+### Route Decorator Example
+
+```typescript
+// TypeScript (NestJS style)
+@Controller("/users")
+class UserController {
+  @Get("/:id")
+  @Authenticate
+  async getUser(@Param("id") id: string): Promise<User> {
+    return this.userService.find(id);
+  }
+}
+```
+
+```rust
+// Rust (axum style)
+#[derive(Clone)]
+struct UserController { /* ... */ }
+
+impl UserController {
+    async fn get_user(
+        State(ctrl): State<Self>,
+        Path(id): Path<String>,
+        _auth: AuthenticatedUser,  // Extractor handles auth
+    ) -> Result<Json<User>, AppError> {
+        let user = ctrl.user_service.find(&id).await?;
+        Ok(Json(user))
+    }
+}
+
+// Router
+let app = Router::new()
+    .route("/users/:id", get(UserController::get_user))
+    .with_state(controller);
+```
+
+```go
+// Go (gin style)
+type UserController struct { /* ... */ }
+
+func (c *UserController) GetUser(ctx *gin.Context) {
+    id := ctx.Param("id")
+    user, err := c.userService.Find(id)
+    if err != nil {
+        ctx.JSON(500, gin.H{"error": err.Error()})
+        return
+    }
+    ctx.JSON(200, user)
+}
+
+// Router
+r.GET("/users/:id", authMiddleware(), ctrl.GetUser)
+```
+
+---
+
+## Macro Systems
+
+### Macro Type Comparison
+
+| Type | Language | Capabilities |
+|------|----------|--------------|
+| Text substitution | C | Simple replacement |
+| Declarative | Rust `macro_rules!` | Pattern matching |
+| Procedural | Rust proc macros | AST manipulation |
+| Hygienic | Elixir, Rust | No accidental capture |
+| Reader | Clojure | Syntax extension |
+| Template | Haskell TH | Compile-time codegen |
+
+### Declarative Macro Example
+
+```clojure
+;; Clojure
+(defmacro unless [pred & body]
+  `(if (not ~pred)
+     (do ~@body)))
+```
+
+```rust
+// Rust
+macro_rules! unless {
+    ($pred:expr, $body:block) => {
+        if !$pred $body
+    };
+}
+```
+
+```elixir
+# Elixir
+defmacro unless(pred, do: body) do
+  quote do
+    if !unquote(pred), do: unquote(body)
+  end
+end
+```
+
+---
+
+## Reflection Capabilities
+
+| Capability       | Python                    | TypeScript          | Rust         | Go                        |
+|------------------|---------------------------|---------------------|--------------|---------------------------|
+| Get field names  | `dir()`, `__dict__`       | `Object.keys()`     | Derive macro | `reflect.TypeOf()`        |
+| Get field values | `getattr()`               | Direct access       | No           | `reflect.ValueOf()`       |
+| Set field values | `setattr()`               | Direct access       | No           | `reflect.Set()` (limited) |
+| Call by name     | `getattr(obj, name)()`    | `obj[name]()`       | No           | `reflect.Method()`        |
+| Create instance  | `type(name, bases, dict)` | `new Constructor()` | No           | `reflect.New()`           |
+
+### Translation Strategies
+
+| Reflection Use Case | Static Language Alternative |
+|---------------------|----------------------------|
+| Serialization | Derive macros, codegen |
+| Dependency injection | Constructor injection |
+| ORM mapping | Compile-time macros |
+| Dynamic dispatch | Trait objects, enums |
+| Configuration | Builder pattern |
+
+---
+
+## Dependency Injection Patterns
+
+| Language    | DI Approach                   | Example                               |
+|-------------|-------------------------------|---------------------------------------|
+| TypeScript  | Class decorators + reflection | `@Injectable()`, Angular/NestJS       |
+| Python      | Decorators + containers       | `@inject`, dependency-injector        |
+| Rust        | Trait objects + constructors  | Manual DI, no runtime reflection      |
+| Go          | Interface + constructors      | Wire (codegen), manual DI             |
+| Java/Kotlin | Annotations + reflection      | Spring `@Autowired`, Dagger           |
+| Elixir      | Module behaviours + config    | No DI framework (functional approach) |
+
+### From Decorator DI to Manual DI
+
+```typescript
+// TypeScript: Decorator-based DI
+@Injectable()
+class UserService {
+  constructor(
+    @Inject("DATABASE") private db: Database,
+    private logger: Logger,
+  ) {}
+}
+```
+
+```rust
+// Rust: Constructor injection
+struct UserService {
+    db: Arc<dyn Database>,
+    logger: Arc<dyn Logger>,
+}
+
+impl UserService {
+    fn new(db: Arc<dyn Database>, logger: Arc<dyn Logger>) -> Self {
+        Self { db, logger }
+    }
+}
+
+// Composition root
+fn create_services() -> UserService {
+    let db: Arc<dyn Database> = Arc::new(PostgresDatabase::new());
+    let logger: Arc<dyn Logger> = Arc::new(ConsoleLogger::new());
+    UserService::new(db, logger)
+}
+```
+
+---
+
+## Code Generation
+
+### Build-Time vs Runtime
+
+| Approach | Languages | When |
+|----------|-----------|------|
+| Compile-time macros | Rust, Elixir, Clojure | Compilation |
+| Annotation processors | Java, Kotlin | Compilation |
+| go generate | Go | Before compilation |
+| Runtime reflection | Python, JS, Java | Runtime |
+
+### Go Generate Pattern
+
+```go
+//go:generate stringer -type=Color
+
+type Color int
+
+const (
+    Red Color = iota
+    Green
+    Blue
+)
+```
+
+### Rust Derive Macro
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct User {
+    name: String,
+    age: u32,
+}
+// Generates impl blocks at compile time
+```
+
+---
+
+## Mixin / Trait Composition
+
+| Language | Pattern | Example |
+|----------|---------|---------|
+| Python | Multiple inheritance | `class C(A, B)` |
+| Ruby | Module include | `include ModuleName` |
+| TypeScript | Mixin function | `class extends Mixin(Base)` |
+| Rust | Multiple impl | `impl TraitA for T`, `impl TraitB for T` |
+| Go | Embedding | `type C struct { A; B }` |
+| Scala | Trait mixing | `class C extends A with B` |
+
+### Translation Example
+
+```typescript
+// TypeScript: Mixin
+function Timestamped<T extends Constructor>(Base: T) {
+  return class extends Base {
+    createdAt = new Date();
+  };
+}
+
+class User extends Timestamped(BaseModel) {}
+```
+
+```rust
+// Rust: Trait + derive (or manual impl)
+trait Timestamped {
+    fn created_at(&self) -> DateTime<Utc>;
+}
+
+// Via derive macro or manual impl
+impl Timestamped for User {
+    fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+}
+```
+
+---
+
+## Converting FROM Reflection-Heavy Code
+
+1. **Identify what reflection achieves**
+   - Serialization → Use serde/codegen
+   - DI → Use constructor injection
+   - ORM → Use compile-time macros
+
+2. **Use compile-time alternatives**
+   - Macros for boilerplate
+   - Generics for type flexibility
+   - Traits for polymorphism
+
+3. **Accept limitations**
+   - Some dynamic patterns can't translate
+   - May need architecture changes
+
+---
+
+## Converting TO Reflection-Capable
+
+1. **Consider if reflection is idiomatic**
+   - Often there are better patterns
+   - Reflection can be slow
+
+2. **Prefer static approaches**
+   - Better type safety
+   - Faster execution
+   - Easier to reason about

--- a/components/skills/meta-convert-guide/reference/paradigm-translation.md
+++ b/components/skills/meta-convert-guide/reference/paradigm-translation.md
@@ -1,0 +1,330 @@
+# Paradigm Translation Reference
+
+Guide for converting between programming paradigms (OOP → FP, FP → FP, etc.).
+
+---
+
+## OOP → Functional Translation
+
+### Core Concept Mapping
+
+| OOP Concept           | Functional Approach                       | Key Insight                                      |
+|-----------------------|-------------------------------------------|--------------------------------------------------|
+| Class with fields     | Record/struct + module functions          | Data and behavior separated                      |
+| Inheritance hierarchy | Composition / Type classes / Protocols    | Favor capabilities over hierarchies              |
+| Mutable object state  | Immutable data + transformation functions | New version instead of mutation                  |
+| Method chaining       | Function pipelines                        | `obj.a().b()` → `b(a(obj))` or `obj \|> a \|> b` |
+| Interface             | Protocol / Type class / Trait             | Behavior contract                                |
+| Private methods       | Module-private functions                  | Visibility at module level                       |
+
+### Class → Data + Functions
+
+```typescript
+// OOP: Class with methods
+class User {
+  private name: string;
+  private email: string;
+
+  constructor(name: string, email: string) {
+    this.name = name;
+    this.email = email;
+  }
+
+  greet(): string {
+    return `Hello, ${this.name}!`;
+  }
+
+  updateEmail(email: string): void {
+    this.email = email;
+  }
+}
+```
+
+```elixir
+# Functional: Data + functions
+defmodule User do
+  defstruct [:name, :email]
+
+  def new(name, email) do
+    %User{name: name, email: email}
+  end
+
+  def greet(%User{name: name}) do
+    "Hello, #{name}!"
+  end
+
+  def update_email(%User{} = user, email) do
+    %{user | email: email}  # Returns new user, doesn't mutate
+  end
+end
+```
+
+### Inheritance → Composition
+
+```typescript
+// OOP: Inheritance hierarchy
+abstract class Shape {
+  abstract area(): number;
+}
+
+class Circle extends Shape {
+  constructor(private radius: number) {
+    super();
+  }
+  area(): number {
+    return Math.PI * this.radius ** 2;
+  }
+}
+
+class Rectangle extends Shape {
+  constructor(
+    private width: number,
+    private height: number,
+  ) {
+    super();
+  }
+  area(): number {
+    return this.width * this.height;
+  }
+}
+```
+
+```rust
+// Functional: Enum + pattern matching
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+}
+
+impl Shape {
+    fn area(&self) -> f64 {
+        match self {
+            Shape::Circle { radius } => std::f64::consts::PI * radius.powi(2),
+            Shape::Rectangle { width, height } => width * height,
+        }
+    }
+}
+```
+
+---
+
+## Immutability Patterns
+
+### Mutable → Immutable
+
+| Mutable Pattern       | Immutable Pattern                  | Example Languages       |
+|-----------------------|------------------------------------|-------------------------|
+| `obj.field = value`   | `{...obj, field: value}`           | JS, Clojure, Elixir     |
+| `list.push(x)`        | `[x \| list]` or `cons(x, list)`   | Erlang, Elixir, Haskell |
+| `dict[key] = value`   | `Map.put(dict, key, value)`        | Elixir, Clojure         |
+| Accumulator variables | `fold`/`reduce` with initial value | All functional          |
+| In-place sort         | Return sorted copy                 | All functional          |
+
+### Example: Mutable to Immutable
+
+```python
+# Mutable (imperative)
+def process_users(users):
+    result = []
+    for user in users:
+        if user.active:
+            user.score += 10  # Mutation!
+            result.append(user)
+    return result
+```
+
+```elixir
+# Immutable (functional)
+def process_users(users) do
+  users
+  |> Enum.filter(& &1.active)
+  |> Enum.map(& %{&1 | score: &1.score + 10})  # New map, not mutation
+end
+```
+
+---
+
+## State Management
+
+| OOP Approach     | Functional Equivalent                |
+|------------------|--------------------------------------|
+| Singleton        | Module with state (GenServer, Agent) |
+| Observer pattern | Event streams, pub/sub               |
+| Factory pattern  | Constructor functions, protocols     |
+| Repository       | Pure functions + effect boundary     |
+| State machine    | Enum + transition functions          |
+
+### Stateful Service Translation
+
+```typescript
+// OOP: Stateful service
+class Counter {
+  private count = 0;
+
+  increment(): void {
+    this.count++;
+  }
+
+  get(): number {
+    return this.count;
+  }
+}
+```
+
+```elixir
+# Functional: GenServer for state
+defmodule Counter do
+  use GenServer
+
+  def start_link(_), do: GenServer.start_link(__MODULE__, 0, name: __MODULE__)
+  def increment, do: GenServer.cast(__MODULE__, :increment)
+  def get, do: GenServer.call(__MODULE__, :get)
+
+  @impl true
+  def init(_), do: {:ok, 0}
+
+  @impl true
+  def handle_cast(:increment, count), do: {:noreply, count + 1}
+
+  @impl true
+  def handle_call(:get, _from, count), do: {:reply, count, count}
+end
+```
+
+---
+
+## Functional → Functional Translation
+
+Different functional languages have different idioms.
+
+### Key Differences
+
+| Aspect            | Clojure          | Elixir        | Haskell          | Scala           |
+|-------------------|------------------|---------------|------------------|-----------------|
+| **Typing**        | Dynamic          | Dynamic       | Static (HM)      | Static (hybrid) |
+| **Laziness**      | Lazy seqs        | Strict        | Lazy default     | Strict          |
+| **Purity**        | Practical        | Practical     | Pure (IO)        | Hybrid          |
+| **Macros**        | Yes              | Yes           | Template Haskell | Limited         |
+| **Concurrency**   | STM + core.async | Actors (BEAM) | STM, async       | Akka            |
+| **Pattern match** | Limited          | Full          | Full             | Full            |
+
+### Laziness Translation
+
+```haskell
+-- Haskell: Lazy by default
+naturals = [0..]  -- Infinite list, evaluated on demand
+take 5 naturals   -- [0,1,2,3,4]
+```
+
+```clojure
+;; Clojure: Explicit lazy sequences
+(def naturals (range))  ; Lazy sequence
+(take 5 naturals)  ; (0 1 2 3 4)
+```
+
+```elixir
+# Elixir: Strict, use Stream for laziness
+naturals = Stream.iterate(0, &(&1 + 1))
+Enum.take(naturals, 5)  # [0, 1, 2, 3, 4]
+```
+
+### Purity Translation
+
+```haskell
+-- Haskell: Effects in IO monad
+readConfig :: FilePath -> IO Config
+readConfig path = do
+  content <- readFile path
+  pure (parseConfig content)
+```
+
+```clojure
+;; Clojure: Effects are implicit
+(defn read-config [path]
+  (-> path slurp parse-config))
+```
+
+```elixir
+# Elixir: Effects are implicit
+def read_config(path) do
+  path |> File.read!() |> parse_config()
+end
+```
+
+---
+
+## Concurrency Model Translation (FP)
+
+| From               | To                 | Translation Strategy                         |
+|--------------------|--------------------|----------------------------------------------|
+| Clojure STM        | Elixir Agent       | `ref` → `Agent`, `alter` → `Agent.update`    |
+| Clojure core.async | Elixir GenServer   | Channels → GenServer calls, go blocks → Task |
+| Haskell STM        | Clojure STM        | Similar concepts, different syntax           |
+| Elixir GenServer   | Clojure component  | GenServer → Stuart Sierra's component        |
+| Erlang processes   | Clojure core.async | Mailbox → channel, receive → alts!           |
+
+### Example: Clojure STM → Elixir Agent
+
+```clojure
+;; Clojure: STM
+(def account (ref {:balance 100}))
+
+(dosync
+  (alter account update :balance + 50))
+```
+
+```elixir
+# Elixir: Agent
+{:ok, account} = Agent.start_link(fn -> %{balance: 100} end)
+
+Agent.update(account, fn state ->
+  %{state | balance: state.balance + 50}
+end)
+```
+
+---
+
+## Pipeline Styles
+
+| Language | Pipeline Syntax | Direction |
+|----------|-----------------|-----------|
+| Elixir | `\|>` | Left to right |
+| F# | `\|>` | Left to right |
+| Haskell | `&` (lens) | Left to right |
+| Haskell | `.` (compose) | Right to left |
+| Clojure | `->` / `->>` | Left to right |
+| OCaml | `\|>` | Left to right |
+
+### Pipeline Example
+
+```elixir
+# Elixir
+users
+|> Enum.filter(&(&1.active))
+|> Enum.map(&(&1.name))
+|> Enum.sort()
+```
+
+```clojure
+;; Clojure
+(->> users
+     (filter :active)
+     (map :name)
+     (sort))
+```
+
+```haskell
+-- Haskell (with &)
+users
+  & filter active
+  & map name
+  & sort
+```
+
+```fsharp
+// F#
+users
+|> List.filter (fun u -> u.Active)
+|> List.map (fun u -> u.Name)
+|> List.sort
+```

--- a/components/skills/meta-convert-guide/reference/performance.md
+++ b/components/skills/meta-convert-guide/reference/performance.md
@@ -1,0 +1,279 @@
+# Performance Reference
+
+Performance considerations when converting between languages.
+
+---
+
+## Performance Impact Matrix
+
+| Conversion              | Performance Impact | Why                               |
+| ----------------------- | ------------------ | --------------------------------- |
+| GC → Ownership          | Usually faster     | No GC pauses, predictable cleanup |
+| Dynamic → Static typing | Usually faster     | No runtime type checks            |
+| Interpreted → Compiled  | Much faster        | Direct machine code               |
+| Async → Sync            | Context-dependent  | May lose concurrency benefits     |
+| Class hierarchy → Enums | Often faster       | Better cache locality             |
+
+---
+
+## Common Performance Pitfalls
+
+### 1. Unnecessary Cloning
+
+```rust
+// ❌ Cloning when borrowing would work
+fn process(items: Vec<Item>) {
+    for item in items.clone() {  // Unnecessary clone
+        handle(&item);
+    }
+}
+
+// ✓ Borrow instead
+fn process(items: &[Item]) {
+    for item in items {
+        handle(item);
+    }
+}
+```
+
+### 2. String Allocation Overhead
+
+```rust
+// ❌ Many small allocations
+fn build_message(parts: &[&str]) -> String {
+    let mut result = String::new();
+    for part in parts {
+        result = result + part;  // Reallocates each time
+    }
+    result
+}
+
+// ✓ Pre-allocate or use join
+fn build_message(parts: &[&str]) -> String {
+    parts.join("")  // Single allocation
+}
+
+// ✓ Or with capacity
+fn build_message(parts: &[&str]) -> String {
+    let total_len: usize = parts.iter().map(|s| s.len()).sum();
+    let mut result = String::with_capacity(total_len);
+    for part in parts {
+        result.push_str(part);
+    }
+    result
+}
+```
+
+### 3. Dynamic Dispatch Overhead
+
+```rust
+// ❌ Trait objects when static dispatch possible
+fn process(handler: &dyn Handler) {
+    handler.handle();  // Virtual call
+}
+
+// ✓ Generics for static dispatch (when possible)
+fn process<H: Handler>(handler: &H) {
+    handler.handle();  // Inlined, no virtual call
+}
+```
+
+### 4. Inefficient Collection Choice
+
+| Need               | Wrong Choice           | Right Choice        |
+| ------------------ | ---------------------- | ------------------- |
+| Fast lookup by key | `Vec` + linear search  | `HashMap`           |
+| Ordered iteration  | `HashMap`              | `BTreeMap` or `Vec` |
+| Unique values      | `Vec` + contains check | `HashSet`           |
+| Stack behavior     | `VecDeque`             | `Vec` (push/pop)    |
+| Queue behavior     | `Vec`                  | `VecDeque`          |
+
+### 5. Boxing When Not Needed
+
+```rust
+// ❌ Unnecessary heap allocation
+struct Config {
+    name: Box<String>,  // Box is unnecessary here
+}
+
+// ✓ Direct ownership
+struct Config {
+    name: String,  // Already heap-allocated internally
+}
+```
+
+---
+
+## Memory Efficiency
+
+### Stack vs Heap
+
+| Allocation | Cost            | When to Use                    |
+| ---------- | --------------- | ------------------------------ |
+| Stack      | Free            | Small, known-size data         |
+| Heap       | Allocation cost | Large, dynamic, or shared data |
+
+```rust
+// Stack (fast)
+let arr = [0u8; 1024];  // 1KB on stack
+
+// Heap (necessary for large)
+let vec = vec![0u8; 1_000_000];  // 1MB on heap
+```
+
+### Reducing Allocations
+
+```rust
+// ❌ Creates new Vec each call
+fn get_filtered(items: &[Item]) -> Vec<&Item> {
+    items.iter().filter(|i| i.active).collect()
+}
+
+// ✓ Return iterator, let caller decide
+fn get_filtered(items: &[Item]) -> impl Iterator<Item = &Item> {
+    items.iter().filter(|i| i.active)
+}
+```
+
+---
+
+## Cache Efficiency
+
+### Data Layout
+
+```rust
+// ❌ Poor cache locality (AoS)
+struct Particles {
+    particles: Vec<Particle>,  // Each particle has x, y, z, mass, ...
+}
+
+// ✓ Better cache locality for position updates (SoA)
+struct Particles {
+    x: Vec<f32>,
+    y: Vec<f32>,
+    z: Vec<f32>,
+    mass: Vec<f32>,
+}
+```
+
+### Contiguous Memory
+
+```rust
+// ❌ Pointer chasing
+struct Node {
+    value: i32,
+    children: Vec<Box<Node>>,  // Each child is a heap allocation
+}
+
+// ✓ Flat structure with indices
+struct Tree {
+    nodes: Vec<NodeData>,
+}
+struct NodeData {
+    value: i32,
+    children: Vec<usize>,  // Indices into nodes
+}
+```
+
+---
+
+## Async Performance
+
+### Avoid Blocking in Async
+
+```rust
+// ❌ Blocks the executor
+async fn bad_read_file(path: &str) -> String {
+    std::fs::read_to_string(path).unwrap()  // Blocking!
+}
+
+// ✓ Use async I/O or spawn_blocking
+async fn good_read_file(path: &str) -> String {
+    tokio::fs::read_to_string(path).await.unwrap()
+}
+
+// ✓ For CPU-intensive work
+async fn cpu_work(data: Vec<u8>) -> Result {
+    tokio::task::spawn_blocking(move || {
+        expensive_computation(&data)
+    }).await?
+}
+```
+
+### Buffer Sizes
+
+```rust
+// Tune buffer sizes for throughput
+let (tx, rx) = tokio::sync::mpsc::channel(1000);  // Buffer 1000 items
+
+// For streams
+stream
+    .buffer_unordered(10)  // 10 concurrent operations
+    .collect()
+```
+
+---
+
+## Benchmarking
+
+### Rust: Criterion
+
+```rust
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn benchmark_function(c: &mut Criterion) {
+    c.bench_function("my_function", |b| {
+        b.iter(|| my_function(black_box(input)))
+    });
+}
+
+criterion_group!(benches, benchmark_function);
+criterion_main!(benches);
+```
+
+### Go: Built-in
+
+```go
+func BenchmarkMyFunction(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        myFunction(input)
+    }
+}
+```
+
+### Python: timeit
+
+```python
+import timeit
+
+result = timeit.timeit(
+    lambda: my_function(input),
+    number=1000
+)
+print(f"Average: {result / 1000:.6f}s")
+```
+
+---
+
+## Profiling Tools
+
+| Language   | CPU Profiler     | Memory Profiler | Flamegraph       |
+| ---------- | ---------------- | --------------- | ---------------- |
+| Rust       | perf, samply     | heaptrack, dhat | cargo-flamegraph |
+| Go         | pprof            | pprof           | go tool pprof    |
+| Python     | cProfile, py-spy | memory_profiler | py-spy           |
+| TypeScript | Node --prof      | heapdump        | 0x               |
+
+---
+
+## Quick Wins
+
+| Pattern                          | Impact     | Effort   |
+| -------------------------------- | ---------- | -------- |
+| Use references instead of clones | High       | Low      |
+| Pre-allocate collections         | Medium     | Low      |
+| Choose right collection type     | High       | Low      |
+| Use iterators over loops         | Low-Medium | Low      |
+| Avoid allocations in hot paths   | High       | Medium   |
+| Use static dispatch              | Medium     | Low      |
+| Profile before optimizing        | N/A        | Required |

--- a/components/skills/meta-convert-guide/reference/serialization.md
+++ b/components/skills/meta-convert-guide/reference/serialization.md
@@ -1,0 +1,277 @@
+# Serialization Reference
+
+Comprehensive reference for serialization patterns across languages.
+
+---
+
+## Library Mapping
+
+| Language   | JSON                          | Validation            | Schema Gen            | Binary                 |
+| ---------- | ----------------------------- | --------------------- | --------------------- | ---------------------- |
+| TypeScript | built-in, `class-transformer` | Zod, Joi, Yup         | TypeBox, Zod          | protobuf, msgpack      |
+| Python     | `json` stdlib, Pydantic       | Pydantic, marshmallow | Pydantic, dataclasses | protobuf, msgpack      |
+| Rust       | serde_json                    | validator crate       | schemars              | serde + bincode, rmp   |
+| Go         | `encoding/json`               | validator, ozzo       | go-jsonschema         | protobuf, gob          |
+| Elixir     | Jason, Poison                 | Ecto changesets       | -                     | :erlang.term_to_binary |
+| Clojure    | cheshire, jsonista            | spec, malli           | spec                  | nippy, transit         |
+| Haskell    | aeson                         | -                     | -                     | binary, cereal         |
+
+---
+
+## Attribute / Annotation Mapping
+
+### Field Renaming
+
+| Language   | Pattern                    | Example                          |
+| ---------- | -------------------------- | -------------------------------- |
+| TypeScript | `@Expose({ name: "..." })` | `@Expose({ name: "full_name" })` |
+| Python     | `Field(alias="...")`       | `Field(alias="fullName")`        |
+| Rust       | `#[serde(rename = "...")]` | `#[serde(rename = "full_name")]` |
+| Go         | Struct tag                 | `` `json:"full_name"` ``         |
+
+### Field Exclusion
+
+| Language   | Pattern               | Example                               |
+| ---------- | --------------------- | ------------------------------------- |
+| TypeScript | `@Exclude()`          | `@Exclude() password: string`         |
+| Python     | `Field(exclude=True)` | `password: str = Field(exclude=True)` |
+| Rust       | `#[serde(skip)]`      | `#[serde(skip)] password: String`     |
+| Go         | Tag with `-`          | `` `json:"-"` ``                      |
+
+### Default Values
+
+| Language   | Pattern                    | Example                              |
+| ---------- | -------------------------- | ------------------------------------ |
+| TypeScript | Default in class           | `port: number = 8080`                |
+| Python     | `Field(default=...)`       | `port: int = Field(default=8080)`    |
+| Rust       | `#[serde(default = "fn")]` | `#[serde(default = "default_port")]` |
+| Go         | Constructor                | Initialize in `NewConfig()`          |
+
+---
+
+## Validation Patterns
+
+### Schema Definition Comparison
+
+```typescript
+// TypeScript: Zod
+const UserSchema = z.object({
+  email: z.string().email(),
+  age: z.number().min(0).max(150),
+  role: z.enum(["admin", "user", "guest"]),
+});
+```
+
+```rust
+// Rust: validator crate
+#[derive(Validate, Deserialize)]
+struct User {
+    #[validate(email)]
+    email: String,
+
+    #[validate(range(min = 0, max = 150))]
+    age: u8,
+
+    role: Role,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Role { Admin, User, Guest }
+```
+
+```python
+# Python: Pydantic
+from pydantic import BaseModel, EmailStr, Field
+from enum import Enum
+
+class Role(str, Enum):
+    admin = "admin"
+    user = "user"
+    guest = "guest"
+
+class User(BaseModel):
+    email: EmailStr
+    age: int = Field(ge=0, le=150)
+    role: Role
+```
+
+```go
+// Go: validator
+type User struct {
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"gte=0,lte=150"`
+    Role  string `json:"role" validate:"oneof=admin user guest"`
+}
+```
+
+---
+
+## Polymorphic / Tagged Union
+
+### Discriminated Union Pattern
+
+```typescript
+// TypeScript
+type Shape =
+  | { type: "circle"; radius: number }
+  | { type: "rectangle"; width: number; height: number };
+```
+
+```rust
+// Rust: serde tag
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Shape {
+    Circle { radius: f64 },
+    Rectangle { width: f64, height: f64 },
+}
+```
+
+```python
+# Python: Pydantic discriminated union
+from typing import Literal, Union, Annotated
+from pydantic import BaseModel, Discriminator
+
+class Circle(BaseModel):
+    type: Literal["circle"] = "circle"
+    radius: float
+
+class Rectangle(BaseModel):
+    type: Literal["rectangle"] = "rectangle"
+    width: float
+    height: float
+
+Shape = Annotated[Union[Circle, Rectangle], Discriminator("type")]
+```
+
+---
+
+## Custom Serializers
+
+### Date/Time Handling
+
+```typescript
+// TypeScript: class-transformer
+class Event {
+  @Transform(({ value }) => new Date(value), { toClassOnly: true })
+  @Transform(({ value }) => value.toISOString(), { toPlainOnly: true })
+  timestamp: Date;
+}
+```
+
+```rust
+// Rust: serde custom module
+mod iso_date {
+    use chrono::{DateTime, Utc};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(date: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        s.serialize_str(&date.to_rfc3339())
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+    where D: Deserializer<'de> {
+        let s = String::deserialize(d)?;
+        DateTime::parse_from_rfc3339(&s)
+            .map(|dt| dt.with_timezone(&Utc))
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct Event {
+    #[serde(with = "iso_date")]
+    timestamp: DateTime<Utc>,
+}
+```
+
+---
+
+## Nested Objects
+
+### Flat vs Nested
+
+```rust
+// Rust: Flatten nested fields
+#[derive(Serialize, Deserialize)]
+struct Config {
+    name: String,
+    #[serde(flatten)]
+    settings: Settings,  // Fields merged into parent
+}
+
+#[derive(Serialize, Deserialize)]
+struct Settings {
+    timeout: u32,
+    retries: u32,
+}
+
+// JSON: {"name": "test", "timeout": 30, "retries": 3}
+```
+
+### Optional Nested
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct User {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    address: Option<Address>,  // Omitted if None
+}
+```
+
+---
+
+## Schema Versioning
+
+### Migration Pattern
+
+```rust
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "version")]
+enum UserRecord {
+    #[serde(rename = "1")]
+    V1(UserV1),
+    #[serde(rename = "2")]
+    V2(UserV2),
+}
+
+impl UserRecord {
+    fn to_latest(self) -> UserV2 {
+        match self {
+            UserRecord::V1(v1) => v1.migrate(),
+            UserRecord::V2(v2) => v2,
+        }
+    }
+}
+```
+
+### Migration Strategies
+
+| Strategy           | When to Use                          | Risk Level |
+| ------------------ | ------------------------------------ | ---------- |
+| Dual-write         | New field added, old readers exist   | Low        |
+| Schema versioning  | Breaking changes needed              | Medium     |
+| Envelope pattern   | Mixed versions in same system        | Medium     |
+| Big-bang migration | All readers/writers updated together | High       |
+
+---
+
+## Performance Considerations
+
+| Format           | Speed     | Size       | Human Readable |
+| ---------------- | --------- | ---------- | -------------- |
+| JSON             | Medium    | Large      | Yes            |
+| MessagePack      | Fast      | Small      | No             |
+| CBOR             | Fast      | Small      | No             |
+| Protocol Buffers | Very Fast | Very Small | No             |
+| Bincode (Rust)   | Very Fast | Small      | No             |
+
+### Choosing a Format
+
+- **JSON**: Default for APIs, debugging, configs
+- **MessagePack/CBOR**: JSON-like but smaller/faster
+- **Protocol Buffers**: Cross-language, schema-first
+- **Bincode**: Rust-only, maximum speed

--- a/components/skills/meta-convert-guide/reference/type-system-mapping.md
+++ b/components/skills/meta-convert-guide/reference/type-system-mapping.md
@@ -1,0 +1,252 @@
+# Type System Mapping Strategies
+
+Comprehensive strategies for mapping types between languages.
+
+---
+
+## Primitive Type Mappings
+
+Create a complete primitive mapping table for each language pair.
+
+### Example: TypeScript → Rust
+
+| TypeScript  | Rust     | Notes                          |
+|-------------|----------|--------------------------------|
+| `string`    | `String` | Owned, heap-allocated          |
+| `string`    | `&str`   | Borrowed, for parameters       |
+| `number`    | `i32`    | Default integer                |
+| `number`    | `i64`    | Large integers                 |
+| `number`    | `f64`    | Floating point                 |
+| `boolean`   | `bool`   | Direct mapping                 |
+| `null`      | -        | Use Option<T>                  |
+| `undefined` | -        | Use Option<T>                  |
+| `any`       | -        | Avoid; use generics or enums   |
+| `unknown`   | -        | Use generics with trait bounds |
+| `never`     | `!`      | Never type (unstable)          |
+| `void`      | `()`     | Unit type                      |
+
+### Example: Python → Rust
+
+| Python      | Rust            | Notes                    |
+|-------------|-----------------|--------------------------|
+| `str`       | `String`        | Owned string             |
+| `str`       | `&str`          | Borrowed string          |
+| `int`       | `i64`           | Python ints are unbounded|
+| `int`       | `BigInt`        | For truly large ints     |
+| `float`     | `f64`           | 64-bit float             |
+| `bool`      | `bool`          | Direct mapping           |
+| `None`      | `Option::None`  | Explicit optionality     |
+| `Any`       | -               | Use generics             |
+| `bytes`     | `Vec<u8>`       | Byte vector              |
+| `bytes`     | `&[u8]`         | Borrowed bytes           |
+
+### Example: Go → Rust
+
+| Go          | Rust            | Notes                    |
+|-------------|-----------------|--------------------------|
+| `string`    | `String`        | Owned                    |
+| `string`    | `&str`          | Borrowed                 |
+| `int`       | `isize`         | Platform-dependent       |
+| `int32`     | `i32`           | Direct mapping           |
+| `int64`     | `i64`           | Direct mapping           |
+| `float64`   | `f64`           | Direct mapping           |
+| `bool`      | `bool`          | Direct mapping           |
+| `nil`       | `Option::None`  | Explicit optionality     |
+| `[]byte`    | `Vec<u8>`       | Byte vector              |
+| `error`     | `Result<T, E>`  | Error as return value    |
+
+---
+
+## Composite Type Mappings
+
+### Collections
+
+| TypeScript     | Rust                    | Python           | Go               |
+|----------------|-------------------------|------------------|------------------|
+| `T[]`          | `Vec<T>`                | `list[T]`        | `[]T`            |
+| `readonly T[]` | `&[T]`                  | `tuple[T, ...]`  | -                |
+| `[T, U]`       | `(T, U)`                | `tuple[T, U]`    | struct           |
+| `Record<K, V>` | `HashMap<K, V>`         | `dict[K, V]`     | `map[K]V`        |
+| `Map<K, V>`    | `HashMap<K, V>`         | `dict[K, V]`     | `map[K]V`        |
+| `Set<T>`       | `HashSet<T>`            | `set[T]`         | `map[T]struct{}` |
+
+### Union Types
+
+| TypeScript     | Rust                    | Python           | Go               |
+|----------------|-------------------------|------------------|------------------|
+| `T \| U`       | `enum { A(T), B(U) }`   | `Union[T, U]`    | interface        |
+| `T \| null`    | `Option<T>`             | `Optional[T]`    | `*T` (pointer)   |
+| `T & U`        | `struct { ...T, ...U }` | Multiple inherit | Embedding        |
+
+---
+
+## Interface/Class to Struct/Trait
+
+### Structural Mappings
+
+| TypeScript Pattern            | Rust Pattern                        | When to Use             |
+|-------------------------------|-------------------------------------|-------------------------|
+| `interface X { ... }`         | `struct X { ... }`                  | Data-only types         |
+| `interface X { method(): T }` | `trait X { fn method(&self) -> T }` | Behavior contracts      |
+| `class X implements Y`        | `struct X` + `impl Y for X`         | Implementation          |
+| `class X extends Y`           | Composition over inheritance        | Rust avoids inheritance |
+| `abstract class X`            | `trait X`                           | Abstract contracts      |
+
+### Data Types
+
+```typescript
+// TypeScript: Data interface
+interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+```
+
+```rust
+// Rust: Struct
+struct User {
+    id: String,
+    name: String,
+    email: String,
+}
+```
+
+### Behavior Contracts
+
+```typescript
+// TypeScript: Interface with methods
+interface Repository<T> {
+  find(id: string): Promise<T | null>;
+  save(item: T): Promise<void>;
+}
+```
+
+```rust
+// Rust: Trait
+trait Repository<T> {
+    async fn find(&self, id: &str) -> Option<T>;
+    async fn save(&self, item: &T) -> Result<(), Error>;
+}
+```
+
+---
+
+## Generic Type Mappings
+
+| TypeScript            | Rust            | Notes                 |
+|-----------------------|-----------------|-----------------------|
+| `<T>`                 | `<T>`           | Unconstrained generic |
+| `<T extends U>`       | `<T: U>`        | Trait bound           |
+| `<T extends A & B>`   | `<T: A + B>`    | Multiple bounds       |
+| `<T = Default>`       | `<T = Default>` | Default type          |
+| `<T extends keyof U>` | Custom trait    | No direct equivalent  |
+
+### Generic Functions
+
+```typescript
+// TypeScript: Generic function
+function identity<T>(value: T): T {
+  return value;
+}
+```
+
+```rust
+// Rust: Generic function
+fn identity<T>(value: T) -> T {
+    value
+}
+```
+
+### Bounded Generics
+
+```typescript
+// TypeScript: Bounded generic
+function process<T extends Serializable>(item: T): string {
+  return item.serialize();
+}
+```
+
+```rust
+// Rust: Trait bound
+fn process<T: Serialize>(item: &T) -> String {
+    serde_json::to_string(item).unwrap()
+}
+```
+
+---
+
+## Nullable / Optional Handling
+
+### Mapping Strategies
+
+| Source              | Target (Rust)   | Target (Go)     | Target (Python)   |
+|---------------------|-----------------|-----------------|-------------------|
+| `T \| null`         | `Option<T>`     | `*T`            | `Optional[T]`     |
+| `T \| undefined`    | `Option<T>`     | zero value      | `Optional[T]`     |
+| `T?` (optional)     | `Option<T>`     | `*T`            | `Optional[T]`     |
+| `Required<T>`       | `T` (all fields)| `T` (all fields)| Required fields   |
+| `Partial<T>`        | All `Option<>`  | All pointers    | All Optional      |
+
+### Null Propagation
+
+```typescript
+// TypeScript: Optional chaining
+const name = user?.profile?.name ?? "Unknown";
+```
+
+```rust
+// Rust: Option combinators
+let name = user
+    .as_ref()
+    .and_then(|u| u.profile.as_ref())
+    .map(|p| p.name.as_str())
+    .unwrap_or("Unknown");
+```
+
+```go
+// Go: Explicit checks
+var name string
+if user != nil && user.Profile != nil {
+    name = user.Profile.Name
+} else {
+    name = "Unknown"
+}
+```
+
+---
+
+## Type Alias Strategies
+
+| Source Pattern       | Rust             | Go               | Python           |
+|----------------------|------------------|------------------|------------------|
+| Simple alias         | `type X = Y`     | `type X = Y`     | `X = Y`          |
+| Newtype (branded)    | `struct X(Y)`    | `type X Y`       | `NewType('X', Y)`|
+| Generic alias        | `type X<T> = Y<T>`| Not supported   | `X = Y[T]`       |
+
+### Newtype Pattern (Type Safety)
+
+```typescript
+// TypeScript: Branded type
+type UserId = string & { readonly __brand: unique symbol };
+type OrderId = string & { readonly __brand: unique symbol };
+```
+
+```rust
+// Rust: Newtype wrapper
+struct UserId(String);
+struct OrderId(String);
+
+// Can't mix them up!
+fn get_user(id: UserId) -> User { ... }
+fn get_order(id: OrderId) -> Order { ... }
+```
+
+```go
+// Go: Type definition
+type UserId string
+type OrderId string
+
+func getUser(id UserId) *User { ... }
+func getOrder(id OrderId) *Order { ... }
+```

--- a/components/skills/meta-convert-guide/reference/type-system-translation.md
+++ b/components/skills/meta-convert-guide/reference/type-system-translation.md
@@ -1,0 +1,329 @@
+# Type System Translation Reference
+
+Guide for converting between static/dynamic and strong/weak type systems.
+
+---
+
+## Type System Classification
+
+| Language   | Static/Dynamic | Strong/Weak | Inference Level |
+| ---------- | -------------- | ----------- | --------------- |
+| Haskell    | Static         | Strong      | Very strong     |
+| Rust       | Static         | Strong      | Strong          |
+| TypeScript | Static\*       | Strong      | Moderate        |
+| Go         | Static         | Strong      | Minimal         |
+| Python     | Dynamic        | Strong      | None (runtime)  |
+| JavaScript | Dynamic        | Weak        | None            |
+| Clojure    | Dynamic        | Strong      | None            |
+| Elixir     | Dynamic        | Strong      | None            |
+
+\*TypeScript is optionally typed and compiles to JavaScript
+
+---
+
+## Static → Dynamic Translation
+
+### What Changes
+
+| Static Pattern                  | Dynamic Approach  | Mitigation for Safety          |
+| ------------------------------- | ----------------- | ------------------------------ |
+| Compile-time type errors        | Runtime errors    | Add runtime validation         |
+| Type annotations                | Optional/ignored  | Use type hints (Python), JSDoc |
+| Generic constraints             | Duck typing       | Document expected interface    |
+| Pattern matching exhaustiveness | Runtime failures  | Add catch-all cases            |
+| Nullability tracking            | All refs nullable | Defensive null checks          |
+
+### Translation Example
+
+```typescript
+// TypeScript: Static types
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+function processUser(user: User): string {
+  return `${user.name} <${user.email}>`;
+}
+
+// Compile error: Argument of type 'string' is not assignable
+// processUser("not a user")
+```
+
+```python
+# Python: Runtime typing with optional hints
+from dataclasses import dataclass
+
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+
+def process_user(user: User) -> str:
+    # Type hints help but don't prevent runtime errors
+    return f"{user.name} <{user.email}>"
+
+# No compile error - fails at runtime
+# process_user("not a user")  # AttributeError
+
+# Add runtime validation for safety
+def process_user_safe(user: User) -> str:
+    if not isinstance(user, User):
+        raise TypeError(f"Expected User, got {type(user)}")
+    return f"{user.name} <{user.email}>"
+```
+
+---
+
+## Dynamic → Static Translation
+
+### Challenges
+
+| Dynamic Pattern        | Static Challenge       | Solution                |
+| ---------------------- | ---------------------- | ----------------------- |
+| Dict with mixed types  | Need concrete type     | Define struct/interface |
+| Duck typing            | Must declare interface | Create trait/interface  |
+| Runtime type switching | Need sum type          | Use enum/union          |
+| Optional fields        | All fields required    | Use Option<T>/Maybe     |
+| Any/unknown data       | No escape hatch        | Use generics or enums   |
+
+### Translation Example
+
+```python
+# Python: Dynamic, flexible structure
+def process_event(event):
+    event_type = event.get("type")
+    if event_type == "click":
+        return f"Clicked at {event['x']}, {event['y']}"
+    elif event_type == "keypress":
+        return f"Pressed key {event['key']}"
+    else:
+        return f"Unknown event: {event}"
+```
+
+```rust
+// Rust: Must define all variants explicitly
+#[derive(Debug)]
+enum Event {
+    Click { x: i32, y: i32 },
+    Keypress { key: char },
+    Unknown { raw: String },
+}
+
+fn process_event(event: Event) -> String {
+    match event {
+        Event::Click { x, y } => format!("Clicked at {}, {}", x, y),
+        Event::Keypress { key } => format!("Pressed key {}", key),
+        Event::Unknown { raw } => format!("Unknown event: {}", raw),
+    }
+}
+```
+
+---
+
+## Type Inference Comparison
+
+| Language   | Inference Level | Annotation Requirement                  |
+| ---------- | --------------- | --------------------------------------- |
+| Haskell    | Very strong     | Rarely needed (signatures recommended)  |
+| Rust       | Strong          | Type annotations at function boundaries |
+| TypeScript | Moderate        | Recommended at boundaries               |
+| Go         | Minimal         | Required at function signatures         |
+| Python     | None (runtime)  | Optional (mypy uses them)               |
+
+### Inference Examples
+
+```haskell
+-- Haskell: Compiler infers everything
+map f [] = []
+map f (x:xs) = f x : map f xs
+-- Inferred: map :: (a -> b) -> [a] -> [b]
+```
+
+```rust
+// Rust: Local inference, explicit at boundaries
+fn transform(items: Vec<i32>) -> Vec<i32> {
+    items.iter()           // Inferred: Iter<&i32>
+         .map(|x| x * 2)   // Inferred: Map<..., closure>
+         .collect()        // Needs turbofish OR return type
+}
+```
+
+```go
+// Go: Minimal inference, mostly explicit
+func transform(items []int) []int {
+    result := make([]int, len(items))  // := infers type
+    for i, v := range items {
+        result[i] = v * 2
+    }
+    return result
+}
+```
+
+---
+
+## Gradual Typing Strategies
+
+For languages with optional typing (Python, TypeScript):
+
+### Phased Migration
+
+```python
+# Phase 1: No types (original)
+def fetch_users(filters):
+    results = db.query(filters)
+    return [transform(r) for r in results]
+
+# Phase 2: Return type only
+def fetch_users(filters) -> list[User]:
+    results = db.query(filters)
+    return [transform(r) for r in results]
+
+# Phase 3: Full typing
+def fetch_users(filters: UserFilters) -> list[User]:
+    results: list[DbRow] = db.query(filters)
+    return [transform(r) for r in results]
+
+# Phase 4: Runtime validation (strict mode)
+from pydantic import BaseModel
+
+class UserFilters(BaseModel):
+    active: bool = True
+    role: str | None = None
+
+def fetch_users(filters: UserFilters) -> list[User]:
+    # Pydantic validates at runtime
+    ...
+```
+
+---
+
+## Handling Dynamic Features
+
+### `any` Type
+
+| Language   | `any` equivalent      | Static alternative   |
+| ---------- | --------------------- | -------------------- |
+| TypeScript | `any`, `unknown`      | Generics, unions     |
+| Python     | No enforcement        | Type hints           |
+| Rust       | None                  | Enums, trait objects |
+| Go         | `interface{}` / `any` | Generics (1.18+)     |
+
+### Translation
+
+```typescript
+// TypeScript: any escape hatch
+function process(data: any): any {
+  return data.transform();
+}
+```
+
+```rust
+// Rust: Must be explicit
+// Option 1: Trait object (runtime dispatch)
+fn process(data: &dyn Transformable) -> Box<dyn Output> {
+    data.transform()
+}
+
+// Option 2: Generic (compile-time dispatch)
+fn process<T: Transformable>(data: T) -> T::Output {
+    data.transform()
+}
+
+// Option 3: Enum (closed set of types)
+enum Data {
+    String(String),
+    Number(i64),
+    Object(HashMap<String, Data>),
+}
+```
+
+---
+
+## Null Safety
+
+| Language   | Null Representation | Static Safety                  |
+| ---------- | ------------------- | ------------------------------ |
+| TypeScript | `null`, `undefined` | Optional with strictNullChecks |
+| Rust       | `Option<T>`         | Required                       |
+| Go         | `nil`               | No (runtime check)             |
+| Python     | `None`              | Optional with type hints       |
+| Kotlin     | `T?`                | Required                       |
+| Swift      | `T?`                | Required                       |
+
+### Migration Pattern
+
+```typescript
+// TypeScript: Nullable
+function getUser(id: string): User | null {
+  return db.find(id);
+}
+
+const user = getUser("123");
+if (user) {
+  console.log(user.name); // TypeScript knows user is not null
+}
+```
+
+```rust
+// Rust: Option<T>
+fn get_user(id: &str) -> Option<User> {
+    db.find(id)
+}
+
+if let Some(user) = get_user("123") {
+    println!("{}", user.name);
+}
+
+// Or with combinators
+get_user("123")
+    .map(|u| println!("{}", u.name));
+```
+
+---
+
+## Pattern Matching Exhaustiveness
+
+### Static Languages
+
+```rust
+// Rust: Compiler enforces exhaustiveness
+enum Status {
+    Active,
+    Inactive,
+    Pending,
+}
+
+fn handle(status: Status) -> &'static str {
+    match status {
+        Status::Active => "active",
+        Status::Inactive => "inactive",
+        // Compile error if Pending not handled
+    }
+}
+```
+
+### Dynamic Languages
+
+```python
+# Python: Must add catch-all manually
+from enum import Enum
+
+class Status(Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    PENDING = "pending"
+
+def handle(status: Status) -> str:
+    match status:
+        case Status.ACTIVE:
+            return "active"
+        case Status.INACTIVE:
+            return "inactive"
+        case Status.PENDING:
+            return "pending"
+        case _:  # Must add for safety
+            raise ValueError(f"Unknown status: {status}")
+```

--- a/components/skills/meta-convert-guide/reference/typescript-patterns.md
+++ b/components/skills/meta-convert-guide/reference/typescript-patterns.md
@@ -1,0 +1,403 @@
+# TypeScript Advanced Patterns Reference
+
+TypeScript-specific patterns that require careful translation to other languages.
+
+---
+
+## Type Guards
+
+### User-Defined Type Guards
+
+```typescript
+// TypeScript: Type guard function
+interface Dog {
+  bark(): void;
+}
+interface Cat {
+  meow(): void;
+}
+type Pet = Dog | Cat;
+
+function isDog(pet: Pet): pet is Dog {
+  return "bark" in pet;
+}
+
+function speak(pet: Pet) {
+  if (isDog(pet)) {
+    pet.bark(); // TypeScript knows pet is Dog
+  } else {
+    pet.meow(); // TypeScript knows pet is Cat
+  }
+}
+```
+
+### Translation to Other Languages
+
+```rust
+// Rust: Enum with pattern matching
+enum Pet {
+    Dog(Dog),
+    Cat(Cat),
+}
+
+fn speak(pet: &Pet) {
+    match pet {
+        Pet::Dog(dog) => dog.bark(),
+        Pet::Cat(cat) => cat.meow(),
+    }
+}
+```
+
+```python
+# Python: isinstance checks (runtime)
+from typing import Union
+
+def speak(pet: Union[Dog, Cat]) -> None:
+    if isinstance(pet, Dog):
+        pet.bark()
+    else:
+        pet.meow()
+```
+
+```go
+// Go: Type switch
+func speak(pet interface{}) {
+    switch p := pet.(type) {
+    case Dog:
+        p.Bark()
+    case Cat:
+        p.Meow()
+    }
+}
+```
+
+---
+
+## Conditional Types
+
+```typescript
+// TypeScript: Conditional type
+type Flatten<T> = T extends Array<infer U> ? U : T;
+
+type A = Flatten<string[]>; // string
+type B = Flatten<number>; // number
+```
+
+### Translation Strategies
+
+```rust
+// Rust: Trait with associated type
+trait Flatten {
+    type Output;
+}
+
+impl<T> Flatten for Vec<T> {
+    type Output = T;
+}
+
+impl Flatten for i32 {
+    type Output = i32;
+}
+```
+
+```haskell
+-- Haskell: Type families
+type family Flatten a where
+  Flatten [a] = a
+  Flatten a = a
+```
+
+**Note:** Most languages don't have direct equivalents. Use:
+
+- Separate types/functions for each case
+- Traits with associated types
+- Code generation
+
+---
+
+## Mapped Types
+
+```typescript
+// TypeScript: Mapped types
+type Partial<T> = { [K in keyof T]?: T[K] };
+type Readonly<T> = { readonly [K in keyof T]: T[K] };
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+
+interface User {
+  name: string;
+  age: number;
+}
+
+type PartialUser = Partial<User>; // { name?: string; age?: number; }
+```
+
+### Translation
+
+```rust
+// Rust: No mapped types - use derive macros or manual
+#[derive(Default)]
+struct UserBuilder {
+    name: Option<String>,
+    age: Option<u32>,
+}
+
+// Readonly is default in Rust (use &mut for mutation)
+struct User {
+    name: String,
+    age: u32,
+}
+```
+
+```python
+# Python: TypedDict with total=False
+from typing import TypedDict
+
+class PartialUser(TypedDict, total=False):
+    name: str
+    age: int
+
+# Or dataclass with Optional
+@dataclass
+class PartialUser:
+    name: Optional[str] = None
+    age: Optional[int] = None
+```
+
+---
+
+## Template Literal Types
+
+```typescript
+// TypeScript: Template literal type
+type EventName = `on${Capitalize<string>}`;
+type ValidEvent = `on${"Click" | "Hover" | "Focus"}`;
+
+function on(event: ValidEvent, handler: () => void) {}
+on("onClick", () => {}); // OK
+// on("onClack", () => {});  // Error
+```
+
+### Translation
+
+Most languages don't have this. Use:
+
+```rust
+// Rust: Enum instead
+#[derive(Debug, Clone, Copy)]
+enum Event {
+    Click,
+    Hover,
+    Focus,
+}
+
+fn on(event: Event, handler: impl Fn()) {}
+```
+
+```go
+// Go: Const enum pattern
+type Event string
+
+const (
+    EventClick Event = "onClick"
+    EventHover Event = "onHover"
+    EventFocus Event = "onFocus"
+)
+
+func on(event Event, handler func()) {}
+```
+
+---
+
+## Branded / Opaque Types
+
+```typescript
+// TypeScript: Branded type for type safety
+type UserId = string & { readonly __brand: unique symbol };
+type OrderId = string & { readonly __brand: unique symbol };
+
+function createUserId(id: string): UserId {
+  return id as UserId;
+}
+
+function getUser(id: UserId) {} // Won't accept OrderId
+```
+
+### Translation
+
+```rust
+// Rust: Newtype pattern
+struct UserId(String);
+struct OrderId(String);
+
+impl UserId {
+    fn new(id: String) -> Self { Self(id) }
+    fn as_str(&self) -> &str { &self.0 }
+}
+
+fn get_user(id: &UserId) {}  // Won't accept OrderId
+```
+
+```python
+# Python: NewType (type-checker only)
+from typing import NewType
+
+UserId = NewType('UserId', str)
+OrderId = NewType('OrderId', str)
+
+def get_user(id: UserId) -> User: ...
+```
+
+```go
+// Go: Type definition
+type UserId string
+type OrderId string
+
+func getUser(id UserId) *User { ... }
+```
+
+---
+
+## Index Signatures
+
+```typescript
+// TypeScript: Index signature
+interface StringMap {
+  [key: string]: string;
+}
+
+interface NumberMap {
+  [key: string]: number;
+}
+
+// With known keys too
+interface Config {
+  name: string;
+  [key: string]: string | number; // Additional dynamic keys
+}
+```
+
+### Translation
+
+```rust
+// Rust: HashMap
+use std::collections::HashMap;
+
+type StringMap = HashMap<String, String>;
+type NumberMap = HashMap<String, i64>;
+
+// Mixed: Use struct + HashMap
+struct Config {
+    name: String,
+    extra: HashMap<String, serde_json::Value>,
+}
+```
+
+```python
+# Python: TypedDict or dict
+from typing import Dict
+
+StringMap = Dict[str, str]
+NumberMap = Dict[str, int]
+```
+
+---
+
+## Utility Types
+
+| TypeScript       | Rust             | Python                   | Go             |
+| ---------------- | ---------------- | ------------------------ | -------------- |
+| `Partial<T>`     | All `Option<>`   | `TypedDict(total=False)` | Pointer fields |
+| `Required<T>`    | No `Option<>`    | Required fields          | Non-pointer    |
+| `Readonly<T>`    | Default          | `frozen=True`            | -              |
+| `Pick<T, K>`     | New struct       | New TypedDict            | New struct     |
+| `Omit<T, K>`     | New struct       | New TypedDict            | New struct     |
+| `Record<K, V>`   | `HashMap<K, V>`  | `Dict[K, V]`             | `map[K]V`      |
+| `NonNullable<T>` | `T` (not Option) | Remove None              | Non-nil        |
+| `ReturnType<T>`  | Associated type  | -                        | -              |
+| `Parameters<T>`  | -                | -                        | -              |
+
+---
+
+## Discriminated Unions
+
+```typescript
+// TypeScript: Discriminated union
+type Result<T, E> = { success: true; value: T } | { success: false; error: E };
+
+function handle<T, E>(result: Result<T, E>) {
+  if (result.success) {
+    console.log(result.value); // TypeScript knows value exists
+  } else {
+    console.error(result.error); // TypeScript knows error exists
+  }
+}
+```
+
+### Translation
+
+```rust
+// Rust: Native enum
+enum Result<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+fn handle<T, E>(result: Result<T, E>) {
+    match result {
+        Ok(value) => println!("{:?}", value),
+        Err(error) => eprintln!("{:?}", error),
+    }
+}
+```
+
+```python
+# Python: Union with Literal discriminator
+from typing import Union, Literal
+from dataclasses import dataclass
+
+@dataclass
+class Success[T]:
+    success: Literal[True]
+    value: T
+
+@dataclass
+class Failure[E]:
+    success: Literal[False]
+    error: E
+
+Result = Union[Success[T], Failure[E]]
+```
+
+---
+
+## Generics with Defaults
+
+```typescript
+// TypeScript: Generic with default
+interface Container<T = string> {
+  value: T;
+}
+
+const stringContainer: Container = { value: "hello" };
+const numberContainer: Container<number> = { value: 42 };
+```
+
+### Translation
+
+```rust
+// Rust: Default generic
+struct Container<T = String> {
+    value: T,
+}
+
+let string_container: Container = Container { value: "hello".into() };
+let number_container: Container<i32> = Container { value: 42 };
+```
+
+```go
+// Go: No default generics (1.18+)
+// Must always specify type parameter
+type Container[T any] struct {
+    Value T
+}
+```

--- a/components/skills/meta-convert-guide/tables/quick-reference.md
+++ b/components/skills/meta-convert-guide/tables/quick-reference.md
@@ -1,0 +1,212 @@
+# Quick Reference Tables
+
+Condensed lookup tables for common conversion patterns.
+
+---
+
+## Type Mapping Quick Reference
+
+### Primitives
+
+| Concept   | Python  | TypeScript       | Rust        | Go        | Elixir     |
+| --------- | ------- | ---------------- | ----------- | --------- | ---------- |
+| Integer   | `int`   | `number`         | `i32/i64`   | `int`     | `integer`  |
+| Float     | `float` | `number`         | `f64`       | `float64` | `float`    |
+| Boolean   | `bool`  | `boolean`        | `bool`      | `bool`    | `boolean`  |
+| String    | `str`   | `string`         | `String`    | `string`  | `String.t` |
+| Char      | -       | -                | `char`      | `rune`    | -          |
+| Byte      | `bytes` | `Uint8Array`     | `u8`        | `byte`    | `binary`   |
+| None/Null | `None`  | `null/undefined` | `Option<T>` | `nil`     | `nil`      |
+
+### Collections
+
+| Concept       | Python  | TypeScript | Rust           | Go               | Elixir   |
+| ------------- | ------- | ---------- | -------------- | ---------------- | -------- |
+| Dynamic array | `list`  | `Array<T>` | `Vec<T>`       | `[]T`            | `list`   |
+| Fixed array   | -       | `T[]`      | `[T; N]`       | `[N]T`           | `tuple`  |
+| Hash map      | `dict`  | `Map<K,V>` | `HashMap<K,V>` | `map[K]V`        | `%{}`    |
+| Set           | `set`   | `Set<T>`   | `HashSet<T>`   | `map[T]struct{}` | `MapSet` |
+| Tuple         | `tuple` | `[A, B]`   | `(A, B)`       | -                | `{a, b}` |
+| Queue         | `deque` | -          | `VecDeque<T>`  | -                | `:queue` |
+
+---
+
+## Error Handling Quick Reference
+
+| Pattern      | Python          | TypeScript      | Rust               | Go              |
+| ------------ | --------------- | --------------- | ------------------ | --------------- |
+| Throw/Raise  | `raise`         | `throw`         | `panic!`           | `panic`         |
+| Try/Catch    | `try/except`    | `try/catch`     | -                  | `recover`       |
+| Return error | -               | -               | `Result<T,E>`      | `error` return  |
+| Propagate    | `raise`         | `throw`         | `?`                | `if err != nil` |
+| Wrap context | -               | -               | `.context()`       | `fmt.Errorf`    |
+| Custom error | `class MyError` | `class MyError` | `#[derive(Error)]` | `errors.New`    |
+
+---
+
+## Async Quick Reference
+
+| Pattern      | TypeScript        | Python             | Rust        | Go           |
+| ------------ | ----------------- | ------------------ | ----------- | ------------ |
+| Define async | `async function`  | `async def`        | `async fn`  | `go func()`  |
+| Await        | `await`           | `await`            | `.await`    | channel recv |
+| Parallel     | `Promise.all()`   | `gather()`         | `join!`     | WaitGroup    |
+| Race         | `Promise.race()`  | `wait(..., FIRST)` | `select!`   | `select`     |
+| Channel      | -                 | `asyncio.Queue`    | `mpsc`      | `chan`       |
+| Timeout      | `AbortController` | `wait_for()`       | `timeout()` | `context`    |
+| Spawn        | -                 | `create_task()`    | `spawn()`   | `go`         |
+
+---
+
+## Memory/Ownership Quick Reference
+
+| Pattern             | GC Languages      | Rust                      |
+| ------------------- | ----------------- | ------------------------- |
+| Share read-only     | Just pass         | `&T`                      |
+| Share mutable       | Just mutate       | `&mut T`                  |
+| Transfer ownership  | Implicit copy     | `T` (move)                |
+| Keep copy           | Automatic         | `.clone()`                |
+| Reference count     | GC handles        | `Rc<T>` / `Arc<T>`        |
+| Interior mutability | N/A               | `RefCell<T>` / `Mutex<T>` |
+| Weak reference      | Usually automatic | `Weak<T>`                 |
+
+---
+
+## String Operations
+
+| Operation | Python            | JavaScript        | Rust                    |
+| --------- | ----------------- | ----------------- | ----------------------- |
+| Length    | `len(s)`          | `s.length`        | `s.len()`               |
+| Concat    | `a + b`           | `a + b`           | `format!("{}{}", a, b)` |
+| Split     | `s.split(",")`    | `s.split(",")`    | `s.split(",")`          |
+| Join      | `",".join(lst)`   | `arr.join(",")`   | `v.join(",")`           |
+| Trim      | `s.strip()`       | `s.trim()`        | `s.trim()`              |
+| Contains  | `x in s`          | `s.includes(x)`   | `s.contains(x)`         |
+| Replace   | `s.replace(a, b)` | `s.replace(a, b)` | `s.replace(a, b)`       |
+| Uppercase | `s.upper()`       | `s.toUpperCase()` | `s.to_uppercase()`      |
+| Slice     | `s[1:4]`          | `s.slice(1, 4)`   | `&s[1..4]`              |
+
+---
+
+## Iterator/Collection Methods
+
+| Operation | Python                | JavaScript     | Rust                    |
+| --------- | --------------------- | -------------- | ----------------------- |
+| Map       | `map(f, lst)`         | `.map(f)`      | `.iter().map(f)`        |
+| Filter    | `filter(f, lst)`      | `.filter(f)`   | `.iter().filter(f)`     |
+| Reduce    | `reduce(f, lst)`      | `.reduce(f)`   | `.iter().fold(init, f)` |
+| Find      | next(filter(...))     | `.find(f)`     | `.iter().find(f)`       |
+| Any       | `any(...)`            | `.some(f)`     | `.iter().any(f)`        |
+| All       | `all(...)`            | `.every(f)`    | `.iter().all(f)`        |
+| Count     | `len(list(...))`      | `.length`      | `.count()`              |
+| Take      | `islice(it, n)`       | `.slice(0, n)` | `.take(n)`              |
+| Skip      | `islice(it, n, None)` | `.slice(n)`    | `.skip(n)`              |
+| Enumerate | `enumerate(it)`       | `.entries()`   | `.enumerate()`          |
+| Zip       | `zip(a, b)`           | -              | `.zip(other)`           |
+| Flatten   | `chain.from_iterable` | `.flat()`      | `.flatten()`            |
+| Collect   | `list(it)`            | `[...it]`      | `.collect()`            |
+
+---
+
+## Pattern Matching
+
+| Pattern   | Python 3.10+           | Rust                    |
+| --------- | ---------------------- | ----------------------- |
+| Literal   | `case 1:`              | `1 =>`                  |
+| Variable  | `case x:`              | `x =>`                  |
+| Wildcard  | `case _:`              | `_ =>`                  |
+| OR        | `case 1 \| 2:`         | `1 \| 2 =>`             |
+| Guard     | `case x if x > 0:`     | `x if x > 0 =>`         |
+| Tuple     | `case (a, b):`         | `(a, b) =>`             |
+| Struct    | `case Point(x, y):`    | `Point { x, y } =>`     |
+| List head | `case [first, *rest]:` | `[first, rest @ ..] =>` |
+| Range     | -                      | `1..=10 =>`             |
+
+---
+
+## Testing Frameworks
+
+| Language   | Framework   | Assert              | Mock            |
+| ---------- | ----------- | ------------------- | --------------- |
+| Python     | pytest      | `assert x == y`     | `unittest.mock` |
+| TypeScript | Jest/Vitest | `expect(x).toBe(y)` | `jest.fn()`     |
+| Rust       | built-in    | `assert_eq!(x, y)`  | mockall         |
+| Go         | testing     | `if got != want`    | gomock          |
+| Elixir     | ExUnit      | `assert x == y`     | Mox             |
+
+---
+
+## Build/Package Commands
+
+| Task         | npm/yarn        | cargo          | go                | mix            |
+| ------------ | --------------- | -------------- | ----------------- | -------------- |
+| Init         | `npm init`      | `cargo new`    | `go mod init`     | `mix new`      |
+| Install deps | `npm install`   | `cargo build`  | `go mod download` | `mix deps.get` |
+| Add dep      | `npm install x` | `cargo add x`  | `go get x`        | add to mix.exs |
+| Build        | `npm run build` | `cargo build`  | `go build`        | `mix compile`  |
+| Test         | `npm test`      | `cargo test`   | `go test`         | `mix test`     |
+| Run          | `npm start`     | `cargo run`    | `go run .`        | `mix run`      |
+| Format       | `prettier`      | `cargo fmt`    | `gofmt`           | `mix format`   |
+| Lint         | `eslint`        | `cargo clippy` | `golint`          | `mix credo`    |
+
+---
+
+## Common Library Equivalents
+
+| Category    | Python         | TypeScript  | Rust        | Go            |
+| ----------- | -------------- | ----------- | ----------- | ------------- |
+| HTTP Client | requests       | axios/fetch | reqwest     | net/http      |
+| JSON        | json           | built-in    | serde_json  | encoding/json |
+| CLI         | argparse/click | commander   | clap        | cobra/flag    |
+| Logging     | logging        | winston     | tracing     | log/slog      |
+| Date/Time   | datetime       | date-fns    | chrono      | time          |
+| ORM         | sqlalchemy     | prisma      | diesel/sqlx | gorm          |
+| Validation  | pydantic       | zod         | validator   | validator     |
+| Async       | asyncio        | built-in    | tokio       | goroutines    |
+| Testing     | pytest         | jest        | built-in    | testing       |
+| Env vars    | dotenv         | dotenv      | dotenvy     | godotenv      |
+
+---
+
+## Null/None Handling Cheatsheet
+
+| Operation           | TypeScript       | Rust                                        |
+| ------------------- | ---------------- | ------------------------------------------- |
+| Check exists        | `x !== null`     | `x.is_some()`                               |
+| Default             | `x ?? default`   | `x.unwrap_or(default)`                      |
+| Default lazy        | `x ?? compute()` | `x.unwrap_or_else(\|\| compute())`          |
+| Map if exists       | `x?.method()`    | `x.map(\|v\| v.method())`                   |
+| Chain               | `a?.b?.c`        | `a.and_then(\|a\| a.b).and_then(\|b\| b.c)` |
+| Panic if none       | `x!`             | `x.unwrap()`                                |
+| Expect with msg     | -                | `x.expect("msg")`                           |
+| Convert null→Option | -                | `Option::from(nullable)`                    |
+| Option→null         | -                | `opt.unwrap_or(null)`                       |
+
+---
+
+## Lifetime Cheatsheet (Rust)
+
+| Annotation | Meaning           | Use When                         |
+| ---------- | ----------------- | -------------------------------- |
+| `'a`       | Generic lifetime  | Multiple refs with same lifetime |
+| `'static`  | Lives forever     | String literals, leaked data     |
+| `'_`       | Elided lifetime   | Compiler can infer               |
+| `&T`       | Shared reference  | Read-only access                 |
+| `&mut T`   | Mutable reference | Exclusive write access           |
+| `T`        | Owned             | Transfer ownership               |
+
+### Common Patterns
+
+```rust
+// Return reference from single input
+fn first(s: &str) -> &str
+
+// Return reference tied to self
+fn get(&self) -> &T
+
+// Return reference tied to specific input
+fn longer<'a>(a: &'a str, b: &'a str) -> &'a str
+
+// Struct holding reference
+struct Holder<'a> { data: &'a str }
+```


### PR DESCRIPTION
## Summary

- Add `meta-convert-guide` skill for language conversion guidance
- Split from `meta-convert-dev` to separate concerns (skill creation vs usage guidance)
- Implements progressive disclosure pattern with 8688 lines across 25 files
- Main SKILL.md is 408 lines (under 500 line token budget)

## Structure

```
meta-convert-guide/
├── SKILL.md              # Main guide (408 lines)
├── FORMS.md              # Templates, checklists
├── examples/             # Practical examples
│   ├── idiom-translation.md
│   ├── error-handling.md
│   ├── concurrency.md
│   ├── metaprogramming.md
│   └── serialization.md
├── reference/            # Deep-dive documentation
│   ├── type-system-mapping.md
│   ├── error-handling.md
│   ├── concurrency.md
│   ├── memory-ownership.md
│   ├── async-patterns.md
│   ├── metaprogramming.md
│   ├── paradigm-translation.md
│   ├── serialization.md
│   └── gotchas/
│       ├── by-language.md
│       └── by-family.md
└── tables/
    └── quick-reference.md
```

## Key Features

- **APTV Workflow**: Analyze → Plan → Transform → Validate
- **8 Pillars Framework**: Module, Error, Concurrency, Metaprogramming, Zero/Default, Serialization, Build, Testing
- **9th Pillar**: Dev Workflow for REPL-centric languages
- **Quick Reference Tables**: Type mapping, error handling, async, memory/ownership
- **Language Gotchas**: Organized by language pair and paradigm family

## Test Plan

- [ ] Skill triggers on language conversion queries
- [ ] Progressive disclosure links work correctly
- [ ] Token budget maintained (< 500 lines in SKILL.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)